### PR TITLE
Add trading journal and strategy tracker (P2)

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -63,4 +63,113 @@ One row per (habit, calendar day). Supports count > 1 for multi-rep tracking.
 
 ---
 
-_Future tables (P2+): trades, runs, transactions, books, projects_
+---
+
+### `prop_accounts`
+Tracks funded/prop trading accounts per firm.
+
+| Column           | Type        | Notes                                                          |
+|------------------|-------------|----------------------------------------------------------------|
+| id               | uuid (PK)   | `gen_random_uuid()`                                            |
+| user_id          | uuid        | FK → auth.users(id)                                           |
+| firm             | prop_firm   | ENUM: FundedNext, AlphaFutures, TakeProfitTrader, YRM         |
+| account_label    | text        | e.g. "100K Evaluation #1"                                      |
+| account_size     | numeric     | starting account size ($)                                      |
+| balance          | numeric     | current balance (optional, manual)                             |
+| daily_loss_limit | numeric     | max daily loss allowed ($)                                     |
+| max_drawdown     | numeric     | max trailing/static drawdown ($)                               |
+| profit_target    | numeric     | profit target to pass challenge ($)                            |
+| is_active        | boolean     | default true                                                   |
+| is_funded        | boolean     | evaluation vs funded; default false                            |
+| notes            | text        | optional                                                       |
+| created_at       | timestamptz |                                                                |
+| updated_at       | timestamptz | auto-updated via trigger                                       |
+
+**RLS**: users manage only their own rows.
+
+---
+
+### `strategies`
+Named trading strategies with rules, applicable instruments, and timeframes.
+
+| Column      | Type         | Notes                              |
+|-------------|--------------|------------------------------------|
+| id          | uuid (PK)    | `gen_random_uuid()`                |
+| user_id     | uuid         | FK → auth.users(id)               |
+| name        | text         | required                           |
+| description | text         | brief overview                     |
+| rules       | text         | markdown playbook                  |
+| instruments | instrument[] | ENUM array: NQ, Gold, CL, 6E      |
+| timeframes  | text[]       | e.g. ['5m','15m']                  |
+| tags        | text[]       | e.g. ['ICT','SMC']                |
+| is_active   | boolean      | default true                       |
+| created_at  | timestamptz  |                                    |
+| updated_at  | timestamptz  | auto-updated via trigger           |
+
+**RLS**: users manage only their own rows.
+
+---
+
+### `trades`
+Core trade log — one row per executed trade.
+
+| Column           | Type            | Notes                                                    |
+|------------------|-----------------|----------------------------------------------------------|
+| id               | uuid (PK)       | `gen_random_uuid()`                                      |
+| user_id          | uuid            | FK → auth.users(id)                                     |
+| prop_account_id  | uuid            | FK → prop_accounts(id) ON DELETE SET NULL               |
+| strategy_id      | uuid            | FK → strategies(id) ON DELETE SET NULL                  |
+| instrument       | instrument      | ENUM: NQ, Gold, CL, 6E                                  |
+| direction        | trade_direction | ENUM: long, short                                        |
+| entry_price      | numeric         | required                                                 |
+| exit_price       | numeric         | optional (open trades)                                   |
+| contracts        | numeric         | number of contracts, default 1                           |
+| entry_time       | timestamptz     | required                                                 |
+| exit_time        | timestamptz     | optional                                                 |
+| gross_pnl        | numeric         | P&L before fees                                          |
+| fees             | numeric         | commissions/fees, default 0                              |
+| net_pnl          | numeric         | GENERATED ALWAYS AS (gross_pnl - fees) STORED           |
+| outcome          | trade_outcome   | ENUM: win, loss, break_even, open                       |
+| session          | trading_session | ENUM: london, new_york_am, new_york_pm, overnight, asia |
+| setup_tags       | text[]          | e.g. ['OB','FVG','BOS']                                 |
+| confluence_notes | text            | what aligned for this trade                              |
+| entry_notes      | text            | why you entered                                          |
+| exit_notes       | text            | why you exited                                           |
+| lessons          | text            | post-trade review                                        |
+| screenshots      | text[]          | URLs to trade screenshots                                |
+| pre_emotion      | text            | emotional state before trade                             |
+| post_emotion     | text            | emotional state after trade                              |
+| followed_rules   | boolean         | did you follow strategy rules                            |
+| is_reviewed      | boolean         | default false                                            |
+| created_at       | timestamptz     |                                                          |
+| updated_at       | timestamptz     | auto-updated via trigger                                 |
+
+**RLS**: users manage only their own rows.
+**Indexes**: `(user_id, entry_time DESC)`, `(user_id, instrument)`, `(user_id, outcome)`
+
+---
+
+### `trading_sessions`
+Daily trading journal — one entry per user per day.
+
+| Column            | Type        | Notes                             |
+|-------------------|-------------|-----------------------------------|
+| id                | uuid (PK)   | `gen_random_uuid()`               |
+| user_id           | uuid        | FK → auth.users(id)              |
+| session_date      | date        | calendar day                      |
+| pre_market_notes  | text        | bias, key levels, news            |
+| mood_before       | mood_rating | ENUM: '1'–'5'                    |
+| plan              | text        | what you planned to trade         |
+| post_market_notes | text        | session recap                     |
+| mood_after        | mood_rating | ENUM: '1'–'5'                    |
+| lessons           | text        | daily lessons                     |
+| followed_plan     | boolean     | did you follow the plan           |
+| created_at        | timestamptz |                                   |
+| updated_at        | timestamptz | auto-updated via trigger          |
+
+**Constraint**: `UNIQUE (user_id, session_date)` — one journal entry per day.
+**RLS**: users manage only their own rows.
+
+---
+
+_Future tables (P3+): runs, transactions, books, projects_

--- a/src/app/(dashboard)/trading/page.tsx
+++ b/src/app/(dashboard)/trading/page.tsx
@@ -1,8 +1,51 @@
-export default function TradingPage() {
+import { createClient } from "@/lib/supabase/server";
+import { TradingView } from "@/components/trading/trading-view";
+import type { Trade, PropAccount, Strategy } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+async function fetchInitialData() {
+  const supabase = createClient();
+
+  const [tradesRes, accountsRes, strategiesRes] = await Promise.all([
+    supabase
+      .from("trades")
+      .select("*, prop_accounts(id, firm, account_label), strategies(id, name)")
+      .order("entry_time", { ascending: false })
+      .limit(500),
+    supabase
+      .from("prop_accounts")
+      .select("*")
+      .order("created_at", { ascending: false }),
+    supabase
+      .from("strategies")
+      .select("*")
+      .order("name"),
+  ]);
+
+  return {
+    trades: (tradesRes.data ?? []) as Trade[],
+    accounts: (accountsRes.data ?? []) as PropAccount[],
+    strategies: (strategiesRes.data ?? []) as Strategy[],
+  };
+}
+
+export default async function TradingPage() {
+  const { trades, accounts, strategies } = await fetchInitialData();
+
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-bold">Trading</h1>
-      <p className="text-muted-foreground">Track your trades and portfolio performance.</p>
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Trading Journal</h1>
+        <p className="text-muted-foreground text-sm mt-1">
+          Log trades, track prop accounts, manage strategies, and review your performance.
+        </p>
+      </div>
+      <TradingView
+        initialTrades={trades}
+        initialAccounts={accounts}
+        initialStrategies={strategies}
+      />
     </div>
   );
 }

--- a/src/components/trading/prop-account-form.tsx
+++ b/src/components/trading/prop-account-form.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { useState } from "react";
+import { X } from "lucide-react";
+import {
+  propAccountSchema,
+  type PropAccountFormValues,
+  PROP_FIRMS,
+  PROP_FIRM_LABELS,
+} from "@/lib/validations/trading";
+import { createPropAccount, updatePropAccount } from "@/lib/supabase/trading";
+import { cn } from "@/lib/utils";
+import type { PropAccount } from "@/lib/types";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSaved: (account: PropAccount) => void;
+  initial?: PropAccount;
+}
+
+type FormErrors = Partial<Record<keyof PropAccountFormValues, string>>;
+
+function emptyForm(): PropAccountFormValues {
+  return {
+    firm: "FundedNext",
+    account_label: "",
+    account_size: 0,
+    balance: null,
+    daily_loss_limit: null,
+    max_drawdown: null,
+    profit_target: null,
+    is_active: true,
+    is_funded: false,
+    notes: null,
+  };
+}
+
+function fromAccount(a: PropAccount): PropAccountFormValues {
+  return {
+    firm: a.firm,
+    account_label: a.account_label,
+    account_size: a.account_size,
+    balance: a.balance,
+    daily_loss_limit: a.daily_loss_limit,
+    max_drawdown: a.max_drawdown,
+    profit_target: a.profit_target,
+    is_active: a.is_active,
+    is_funded: a.is_funded,
+    notes: a.notes,
+  };
+}
+
+export function PropAccountForm({ open, onClose, onSaved, initial }: Props) {
+  const [form, setForm] = useState<PropAccountFormValues>(
+    initial ? fromAccount(initial) : emptyForm()
+  );
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [saving, setSaving] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  function handleOpen(val: boolean) {
+    if (val) {
+      setForm(initial ? fromAccount(initial) : emptyForm());
+      setErrors({});
+      setServerError(null);
+    }
+    if (!val) onClose();
+  }
+
+  function numOrNull(val: string): number | null {
+    const n = parseFloat(val);
+    return isNaN(n) ? null : n;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErrors({});
+    setServerError(null);
+
+    const result = propAccountSchema.safeParse(form);
+    if (!result.success) {
+      const fe: FormErrors = {};
+      for (const issue of result.error.issues) {
+        const key = issue.path[0] as keyof PropAccountFormValues;
+        fe[key] = issue.message;
+      }
+      setErrors(fe);
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const saved = initial
+        ? await updatePropAccount(initial.id, result.data)
+        : await createPropAccount(result.data);
+      onSaved(saved);
+      onClose();
+    } catch (err) {
+      setServerError(err instanceof Error ? err.message : "Failed to save account");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const inputCls = (err?: string) =>
+    cn(
+      "w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring",
+      err && "border-destructive"
+    );
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleOpen}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-lg max-h-[90vh] overflow-y-auto -translate-x-1/2 -translate-y-1/2 rounded-xl bg-card p-6 shadow-xl">
+          <div className="mb-5 flex items-center justify-between">
+            <Dialog.Title className="text-lg font-semibold">
+              {initial ? "Edit Account" : "Add Prop Account"}
+            </Dialog.Title>
+            <Dialog.Close className="rounded-md p-1 text-muted-foreground hover:bg-accent">
+              <X className="h-4 w-4" />
+            </Dialog.Close>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {/* Firm */}
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Prop Firm</label>
+              <select
+                value={form.firm}
+                onChange={(e) => setForm({ ...form, firm: e.target.value as PropAccountFormValues["firm"] })}
+                className={inputCls(errors.firm)}
+              >
+                {PROP_FIRMS.map((f) => (
+                  <option key={f} value={f}>{PROP_FIRM_LABELS[f]}</option>
+                ))}
+              </select>
+              {errors.firm && <p className="text-xs text-destructive">{errors.firm}</p>}
+            </div>
+
+            {/* Label */}
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Account Label</label>
+              <input
+                type="text"
+                value={form.account_label}
+                onChange={(e) => setForm({ ...form, account_label: e.target.value })}
+                placeholder="e.g. 100K Evaluation #1"
+                className={inputCls(errors.account_label)}
+              />
+              {errors.account_label && (
+                <p className="text-xs text-destructive">{errors.account_label}</p>
+              )}
+            </div>
+
+            {/* Size + Balance */}
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <label className="text-sm font-medium">Account Size ($)</label>
+                <input
+                  type="number"
+                  step="0.01"
+                  value={form.account_size || ""}
+                  onChange={(e) => setForm({ ...form, account_size: parseFloat(e.target.value) || 0 })}
+                  placeholder="100000"
+                  className={inputCls(errors.account_size)}
+                />
+                {errors.account_size && (
+                  <p className="text-xs text-destructive">{errors.account_size}</p>
+                )}
+              </div>
+              <div className="space-y-1">
+                <label className="text-sm font-medium">Current Balance ($)</label>
+                <input
+                  type="number"
+                  step="0.01"
+                  value={form.balance ?? ""}
+                  onChange={(e) => setForm({ ...form, balance: numOrNull(e.target.value) })}
+                  placeholder="Optional"
+                  className={inputCls()}
+                />
+              </div>
+            </div>
+
+            {/* Limits */}
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <label className="text-sm font-medium">Daily Loss Limit ($)</label>
+                <input
+                  type="number"
+                  step="0.01"
+                  value={form.daily_loss_limit ?? ""}
+                  onChange={(e) => setForm({ ...form, daily_loss_limit: numOrNull(e.target.value) })}
+                  placeholder="Optional"
+                  className={inputCls()}
+                />
+              </div>
+              <div className="space-y-1">
+                <label className="text-sm font-medium">Max Drawdown ($)</label>
+                <input
+                  type="number"
+                  step="0.01"
+                  value={form.max_drawdown ?? ""}
+                  onChange={(e) => setForm({ ...form, max_drawdown: numOrNull(e.target.value) })}
+                  placeholder="Optional"
+                  className={inputCls()}
+                />
+              </div>
+            </div>
+
+            {/* Profit Target */}
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Profit Target ($)</label>
+              <input
+                type="number"
+                step="0.01"
+                value={form.profit_target ?? ""}
+                onChange={(e) => setForm({ ...form, profit_target: numOrNull(e.target.value) })}
+                placeholder="Optional"
+                className={inputCls()}
+              />
+            </div>
+
+            {/* Toggles */}
+            <div className="flex gap-6">
+              <label className="flex items-center gap-2 cursor-pointer text-sm">
+                <input
+                  type="checkbox"
+                  checked={form.is_funded}
+                  onChange={(e) => setForm({ ...form, is_funded: e.target.checked })}
+                  className="h-4 w-4 rounded border-border accent-primary"
+                />
+                Funded Account
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer text-sm">
+                <input
+                  type="checkbox"
+                  checked={form.is_active}
+                  onChange={(e) => setForm({ ...form, is_active: e.target.checked })}
+                  className="h-4 w-4 rounded border-border accent-primary"
+                />
+                Active
+              </label>
+            </div>
+
+            {/* Notes */}
+            <div className="space-y-1">
+              <label className="text-sm font-medium">
+                Notes <span className="text-xs text-muted-foreground">(optional)</span>
+              </label>
+              <textarea
+                value={form.notes ?? ""}
+                onChange={(e) => setForm({ ...form, notes: e.target.value || null })}
+                rows={3}
+                className="w-full resize-none rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
+
+            {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  className="rounded-md px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-accent"
+                >
+                  Cancel
+                </button>
+              </Dialog.Close>
+              <button
+                type="submit"
+                disabled={saving}
+                className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              >
+                {saving ? "Saving…" : initial ? "Update" : "Create"}
+              </button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/trading/prop-accounts-view.tsx
+++ b/src/components/trading/prop-accounts-view.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useState } from "react";
+import { Plus, Pencil, Trash2, Building2 } from "lucide-react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { PropAccountForm } from "./prop-account-form";
+import { deletePropAccount } from "@/lib/supabase/trading";
+import { PROP_FIRM_LABELS } from "@/lib/validations/trading";
+import { cn } from "@/lib/utils";
+import type { PropAccount } from "@/lib/types";
+
+interface Props {
+  accounts: PropAccount[];
+  onAccountsChange: (accounts: PropAccount[]) => void;
+}
+
+function formatMoney(n: number | null | undefined) {
+  if (n == null) return "—";
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(n);
+}
+
+function progressPct(balance: number | null, size: number, target: number | null) {
+  if (balance == null || target == null) return null;
+  const gained = balance - size;
+  return Math.max(0, Math.min(100, (gained / target) * 100));
+}
+
+export function PropAccountsView({ accounts, onAccountsChange }: Props) {
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<PropAccount | undefined>();
+  const [deleting, setDeleting] = useState<string | null>(null);
+
+  function openCreate() {
+    setEditing(undefined);
+    setFormOpen(true);
+  }
+
+  function openEdit(account: PropAccount) {
+    setEditing(account);
+    setFormOpen(true);
+  }
+
+  function handleSaved(saved: PropAccount) {
+    if (editing) {
+      onAccountsChange(accounts.map((a) => (a.id === saved.id ? saved : a)));
+    } else {
+      onAccountsChange([saved, ...accounts]);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    setDeleting(id);
+    try {
+      await deletePropAccount(id);
+      onAccountsChange(accounts.filter((a) => a.id !== id));
+    } finally {
+      setDeleting(null);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-base font-semibold">Prop Accounts</h2>
+        <button
+          onClick={openCreate}
+          className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Add Account
+        </button>
+      </div>
+
+      {accounts.length === 0 ? (
+        <div className="rounded-xl border border-dashed p-8 text-center text-muted-foreground">
+          <Building2 className="mx-auto mb-2 h-8 w-8 opacity-40" />
+          <p className="text-sm">No prop accounts yet.</p>
+          <p className="text-xs mt-1">Add an account to track your funded challenges.</p>
+        </div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {accounts.map((account) => {
+            const pct = progressPct(account.balance, account.account_size, account.profit_target);
+            return (
+              <div
+                key={account.id}
+                className={cn(
+                  "rounded-xl border bg-card p-4 space-y-3",
+                  !account.is_active && "opacity-60"
+                )}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="text-xs font-medium text-muted-foreground">
+                      {PROP_FIRM_LABELS[account.firm]}
+                    </p>
+                    <p className="font-semibold truncate">{account.account_label}</p>
+                  </div>
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    {account.is_funded && (
+                      <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs font-medium text-emerald-600">
+                        Funded
+                      </span>
+                    )}
+                    {!account.is_active && (
+                      <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                        Inactive
+                      </span>
+                    )}
+                    <DropdownMenu.Root>
+                      <DropdownMenu.Trigger asChild>
+                        <button className="rounded-md p-1 text-muted-foreground hover:bg-accent">
+                          <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 16 16">
+                            <circle cx="4" cy="8" r="1.5" />
+                            <circle cx="8" cy="8" r="1.5" />
+                            <circle cx="12" cy="8" r="1.5" />
+                          </svg>
+                        </button>
+                      </DropdownMenu.Trigger>
+                      <DropdownMenu.Portal>
+                        <DropdownMenu.Content
+                          className="z-50 min-w-[130px] rounded-lg border bg-card p-1 shadow-lg"
+                          align="end"
+                          sideOffset={4}
+                        >
+                          <DropdownMenu.Item
+                            onClick={() => openEdit(account)}
+                            className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-1.5 text-sm hover:bg-accent outline-none"
+                          >
+                            <Pencil className="h-3.5 w-3.5" />
+                            Edit
+                          </DropdownMenu.Item>
+                          <DropdownMenu.Item
+                            onClick={() => handleDelete(account.id)}
+                            disabled={deleting === account.id}
+                            className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-1.5 text-sm text-destructive hover:bg-destructive/10 outline-none disabled:opacity-50"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                            {deleting === account.id ? "Deleting…" : "Delete"}
+                          </DropdownMenu.Item>
+                        </DropdownMenu.Content>
+                      </DropdownMenu.Portal>
+                    </DropdownMenu.Root>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-2 text-sm">
+                  <div>
+                    <p className="text-xs text-muted-foreground">Size</p>
+                    <p className="font-medium">{formatMoney(account.account_size)}</p>
+                  </div>
+                  {account.balance != null && (
+                    <div>
+                      <p className="text-xs text-muted-foreground">Balance</p>
+                      <p className="font-medium">{formatMoney(account.balance)}</p>
+                    </div>
+                  )}
+                  {account.daily_loss_limit != null && (
+                    <div>
+                      <p className="text-xs text-muted-foreground">Daily Limit</p>
+                      <p className="font-medium text-amber-600">{formatMoney(account.daily_loss_limit)}</p>
+                    </div>
+                  )}
+                  {account.profit_target != null && (
+                    <div>
+                      <p className="text-xs text-muted-foreground">Target</p>
+                      <p className="font-medium text-emerald-600">{formatMoney(account.profit_target)}</p>
+                    </div>
+                  )}
+                </div>
+
+                {pct != null && (
+                  <div className="space-y-1">
+                    <div className="flex items-center justify-between text-xs text-muted-foreground">
+                      <span>Progress to target</span>
+                      <span>{pct.toFixed(1)}%</span>
+                    </div>
+                    <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+                      <div
+                        className="h-full rounded-full bg-emerald-500 transition-all"
+                        style={{ width: `${pct}%` }}
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <PropAccountForm
+        open={formOpen}
+        onClose={() => setFormOpen(false)}
+        onSaved={handleSaved}
+        initial={editing}
+      />
+    </div>
+  );
+}

--- a/src/components/trading/session-journal.tsx
+++ b/src/components/trading/session-journal.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { ChevronLeft, ChevronRight, Save } from "lucide-react";
+import {
+  tradingSessionSchema,
+  type TradingSessionFormValues,
+  MOOD_RATINGS,
+} from "@/lib/validations/trading";
+import { getTradingSession, upsertTradingSession } from "@/lib/supabase/trading";
+import { cn } from "@/lib/utils";
+import type { TradingSessionJournal } from "@/lib/types";
+
+function todayISO() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function offsetDate(date: string, days: number): string {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+function formatDisplayDate(iso: string) {
+  return new Date(iso + "T12:00:00").toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+const MOOD_EMOJIS: Record<string, string> = {
+  "1": "😞",
+  "2": "😕",
+  "3": "😐",
+  "4": "🙂",
+  "5": "😄",
+};
+
+function emptyForm(date: string): TradingSessionFormValues {
+  return {
+    session_date: date,
+    pre_market_notes: null,
+    mood_before: null,
+    plan: null,
+    post_market_notes: null,
+    mood_after: null,
+    lessons: null,
+    followed_plan: null,
+  };
+}
+
+function fromSession(s: TradingSessionJournal): TradingSessionFormValues {
+  return {
+    session_date: s.session_date,
+    pre_market_notes: s.pre_market_notes,
+    mood_before: s.mood_before,
+    plan: s.plan,
+    post_market_notes: s.post_market_notes,
+    mood_after: s.mood_after,
+    lessons: s.lessons,
+    followed_plan: s.followed_plan,
+  };
+}
+
+export function SessionJournal() {
+  const [date, setDate] = useState(todayISO());
+  const [form, setForm] = useState<TradingSessionFormValues>(emptyForm(date));
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Load session for the selected date
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setSaved(false);
+
+    getTradingSession(date)
+      .then((session) => {
+        if (cancelled) return;
+        setForm(session ? fromSession(session) : emptyForm(date));
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to load session");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [date]);
+
+  function changeDate(days: number) {
+    setDate(offsetDate(date, days));
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    setSaved(false);
+    try {
+      await upsertTradingSession({ ...form, session_date: date });
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const textAreaCls = "w-full resize-none rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring";
+  const isToday = date === todayISO();
+
+  return (
+    <div className="space-y-4">
+      {/* Date navigator */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => changeDate(-1)}
+          className="rounded-md border p-1.5 hover:bg-accent text-muted-foreground"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+        <div className="flex-1 text-center">
+          <p className="text-sm font-semibold">{formatDisplayDate(date)}</p>
+          {isToday && (
+            <p className="text-xs text-muted-foreground">Today</p>
+          )}
+        </div>
+        <button
+          onClick={() => changeDate(1)}
+          disabled={isToday}
+          className="rounded-md border p-1.5 hover:bg-accent text-muted-foreground disabled:opacity-40"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          max={todayISO()}
+          className="rounded-md border bg-background px-2 py-1.5 text-sm outline-none focus:ring-2 focus:ring-ring"
+        />
+      </div>
+
+      {loading ? (
+        <div className="rounded-xl border p-8 text-center text-muted-foreground text-sm">
+          Loading…
+        </div>
+      ) : (
+        <form onSubmit={handleSave} className="space-y-5">
+          {/* Pre-market section */}
+          <div className="rounded-xl border bg-card p-5 space-y-4">
+            <h3 className="text-sm font-semibold border-b pb-2">Pre-Market</h3>
+
+            {/* Mood Before */}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">Mood Before Trading</label>
+              <div className="flex gap-2">
+                {MOOD_RATINGS.map((rating) => (
+                  <button
+                    key={rating}
+                    type="button"
+                    onClick={() => setForm({ ...form, mood_before: rating as TradingSessionFormValues["mood_before"] })}
+                    className={cn(
+                      "flex flex-col items-center gap-0.5 rounded-lg border px-3 py-2 text-center transition-colors",
+                      form.mood_before === rating
+                        ? "border-primary bg-primary/10"
+                        : "hover:border-primary/40 hover:bg-accent"
+                    )}
+                  >
+                    <span className="text-lg">{MOOD_EMOJIS[rating]}</span>
+                    <span className="text-xs text-muted-foreground">{rating}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Pre-market notes */}
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Market Bias & Key Levels</label>
+              <textarea
+                value={form.pre_market_notes ?? ""}
+                onChange={(e) => setForm({ ...form, pre_market_notes: e.target.value || null })}
+                rows={3}
+                placeholder="HTF bias, key support/resistance, upcoming news events…"
+                className={textAreaCls}
+              />
+            </div>
+
+            {/* Plan */}
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Trade Plan for Today</label>
+              <textarea
+                value={form.plan ?? ""}
+                onChange={(e) => setForm({ ...form, plan: e.target.value || null })}
+                rows={4}
+                placeholder="What setups are you looking for? What are your rules for today?"
+                className={textAreaCls}
+              />
+            </div>
+          </div>
+
+          {/* Post-market section */}
+          <div className="rounded-xl border bg-card p-5 space-y-4">
+            <h3 className="text-sm font-semibold border-b pb-2">Post-Market</h3>
+
+            {/* Mood After */}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">Mood After Trading</label>
+              <div className="flex gap-2">
+                {MOOD_RATINGS.map((rating) => (
+                  <button
+                    key={rating}
+                    type="button"
+                    onClick={() => setForm({ ...form, mood_after: rating as TradingSessionFormValues["mood_after"] })}
+                    className={cn(
+                      "flex flex-col items-center gap-0.5 rounded-lg border px-3 py-2 text-center transition-colors",
+                      form.mood_after === rating
+                        ? "border-primary bg-primary/10"
+                        : "hover:border-primary/40 hover:bg-accent"
+                    )}
+                  >
+                    <span className="text-lg">{MOOD_EMOJIS[rating]}</span>
+                    <span className="text-xs text-muted-foreground">{rating}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Post notes */}
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Session Recap</label>
+              <textarea
+                value={form.post_market_notes ?? ""}
+                onChange={(e) => setForm({ ...form, post_market_notes: e.target.value || null })}
+                rows={3}
+                placeholder="How did the session go? Key observations…"
+                className={textAreaCls}
+              />
+            </div>
+
+            {/* Lessons */}
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Lessons Learned Today</label>
+              <textarea
+                value={form.lessons ?? ""}
+                onChange={(e) => setForm({ ...form, lessons: e.target.value || null })}
+                rows={3}
+                placeholder="What did you learn? What will you do differently tomorrow?"
+                className={textAreaCls}
+              />
+            </div>
+
+            {/* Followed Plan */}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">Did you stick to your plan?</label>
+              <div className="flex gap-2">
+                {[
+                  { val: true, label: "✓ Yes" },
+                  { val: false, label: "✗ No" },
+                  { val: null, label: "— N/A" },
+                ].map(({ val, label }) => (
+                  <button
+                    key={String(val)}
+                    type="button"
+                    onClick={() => setForm({ ...form, followed_plan: val })}
+                    className={cn(
+                      "rounded-md border px-3 py-1.5 text-sm font-medium transition-colors",
+                      form.followed_plan === val
+                        ? val === true
+                          ? "bg-emerald-500 text-white border-emerald-500"
+                          : val === false
+                          ? "bg-red-500 text-white border-red-500"
+                          : "bg-muted border-border"
+                        : "hover:bg-accent border-border"
+                    )}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          <div className="flex items-center justify-end gap-3">
+            {saved && (
+              <p className="text-sm text-emerald-600 font-medium">Saved!</p>
+            )}
+            <button
+              type="submit"
+              disabled={saving}
+              className="flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              <Save className="h-3.5 w-3.5" />
+              {saving ? "Saving…" : "Save Journal"}
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/components/trading/strategies-view.tsx
+++ b/src/components/trading/strategies-view.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState } from "react";
+import { Plus, Pencil, Trash2, BookOpen, CheckCircle2 } from "lucide-react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { StrategyForm } from "./strategy-form";
+import { deleteStrategy } from "@/lib/supabase/trading";
+import { INSTRUMENT_LABELS } from "@/lib/validations/trading";
+import { cn } from "@/lib/utils";
+import type { Strategy } from "@/lib/types";
+
+interface Props {
+  strategies: Strategy[];
+  onStrategiesChange: (strategies: Strategy[]) => void;
+}
+
+export function StrategiesView({ strategies, onStrategiesChange }: Props) {
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<Strategy | undefined>();
+  const [deleting, setDeleting] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  function openCreate() {
+    setEditing(undefined);
+    setFormOpen(true);
+  }
+
+  function openEdit(s: Strategy) {
+    setEditing(s);
+    setFormOpen(true);
+  }
+
+  function handleSaved(saved: Strategy) {
+    if (editing) {
+      onStrategiesChange(strategies.map((s) => (s.id === saved.id ? saved : s)));
+    } else {
+      onStrategiesChange([saved, ...strategies]);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    setDeleting(id);
+    try {
+      await deleteStrategy(id);
+      onStrategiesChange(strategies.filter((s) => s.id !== id));
+    } finally {
+      setDeleting(null);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-base font-semibold">Strategies</h2>
+        <button
+          onClick={openCreate}
+          className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          New Strategy
+        </button>
+      </div>
+
+      {strategies.length === 0 ? (
+        <div className="rounded-xl border border-dashed p-8 text-center text-muted-foreground">
+          <BookOpen className="mx-auto mb-2 h-8 w-8 opacity-40" />
+          <p className="text-sm">No strategies yet.</p>
+          <p className="text-xs mt-1">Create a strategy to attach to your trades.</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {strategies.map((s) => (
+            <div
+              key={s.id}
+              className={cn(
+                "rounded-xl border bg-card overflow-hidden",
+                !s.is_active && "opacity-60"
+              )}
+            >
+              {/* Header row */}
+              <div className="flex items-center gap-3 px-4 py-3">
+                <button
+                  className="flex-1 min-w-0 text-left"
+                  onClick={() => setExpanded(expanded === s.id ? null : s.id)}
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium truncate">{s.name}</span>
+                    {s.is_active && (
+                      <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
+                    )}
+                  </div>
+                  {s.description && (
+                    <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">{s.description}</p>
+                  )}
+                </button>
+
+                <div className="flex items-center gap-2 shrink-0">
+                  {/* Instrument pills */}
+                  <div className="hidden sm:flex gap-1">
+                    {(s.instruments ?? []).map((inst) => (
+                      <span
+                        key={inst}
+                        className="rounded-full bg-accent px-2 py-0.5 text-xs"
+                      >
+                        {inst}
+                      </span>
+                    ))}
+                  </div>
+
+                  <DropdownMenu.Root>
+                    <DropdownMenu.Trigger asChild>
+                      <button className="rounded-md p-1 text-muted-foreground hover:bg-accent">
+                        <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 16 16">
+                          <circle cx="4" cy="8" r="1.5" />
+                          <circle cx="8" cy="8" r="1.5" />
+                          <circle cx="12" cy="8" r="1.5" />
+                        </svg>
+                      </button>
+                    </DropdownMenu.Trigger>
+                    <DropdownMenu.Portal>
+                      <DropdownMenu.Content
+                        className="z-50 min-w-[130px] rounded-lg border bg-card p-1 shadow-lg"
+                        align="end"
+                        sideOffset={4}
+                      >
+                        <DropdownMenu.Item
+                          onClick={() => openEdit(s)}
+                          className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-1.5 text-sm hover:bg-accent outline-none"
+                        >
+                          <Pencil className="h-3.5 w-3.5" />
+                          Edit
+                        </DropdownMenu.Item>
+                        <DropdownMenu.Item
+                          onClick={() => handleDelete(s.id)}
+                          disabled={deleting === s.id}
+                          className="flex cursor-pointer items-center gap-2 rounded-md px-3 py-1.5 text-sm text-destructive hover:bg-destructive/10 outline-none disabled:opacity-50"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                          {deleting === s.id ? "Deleting…" : "Delete"}
+                        </DropdownMenu.Item>
+                      </DropdownMenu.Content>
+                    </DropdownMenu.Portal>
+                  </DropdownMenu.Root>
+                </div>
+              </div>
+
+              {/* Expanded rules */}
+              {expanded === s.id && s.rules && (
+                <div className="border-t bg-muted/30 px-4 py-3">
+                  <pre className="whitespace-pre-wrap text-xs font-mono text-foreground/80 leading-relaxed">
+                    {s.rules}
+                  </pre>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <StrategyForm
+        open={formOpen}
+        onClose={() => setFormOpen(false)}
+        onSaved={handleSaved}
+        initial={editing}
+      />
+    </div>
+  );
+}

--- a/src/components/trading/strategy-form.tsx
+++ b/src/components/trading/strategy-form.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { useState } from "react";
+import { X } from "lucide-react";
+import {
+  strategySchema,
+  type StrategyFormValues,
+  INSTRUMENTS,
+  INSTRUMENT_LABELS,
+} from "@/lib/validations/trading";
+import { createStrategy, updateStrategy } from "@/lib/supabase/trading";
+import { cn } from "@/lib/utils";
+import type { Strategy } from "@/lib/types";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSaved: (strategy: Strategy) => void;
+  initial?: Strategy;
+}
+
+type FormErrors = Partial<Record<keyof StrategyFormValues, string>>;
+
+function emptyForm(): StrategyFormValues {
+  return {
+    name: "",
+    description: null,
+    rules: null,
+    instruments: [],
+    timeframes: [],
+    tags: [],
+    is_active: true,
+  };
+}
+
+function fromStrategy(s: Strategy): StrategyFormValues {
+  return {
+    name: s.name,
+    description: s.description,
+    rules: s.rules,
+    instruments: s.instruments ?? [],
+    timeframes: s.timeframes ?? [],
+    tags: s.tags ?? [],
+    is_active: s.is_active,
+  };
+}
+
+const TIMEFRAME_OPTIONS = ["1m", "2m", "3m", "5m", "10m", "15m", "30m", "1h", "4h", "1D"];
+
+export function StrategyForm({ open, onClose, onSaved, initial }: Props) {
+  const [form, setForm] = useState<StrategyFormValues>(
+    initial ? fromStrategy(initial) : emptyForm()
+  );
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [saving, setSaving] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [tagInput, setTagInput] = useState("");
+
+  function handleOpen(val: boolean) {
+    if (val) {
+      setForm(initial ? fromStrategy(initial) : emptyForm());
+      setErrors({});
+      setServerError(null);
+      setTagInput("");
+    }
+    if (!val) onClose();
+  }
+
+  function toggleInstrument(inst: string) {
+    const cur = form.instruments ?? [];
+    setForm({
+      ...form,
+      instruments: cur.includes(inst as StrategyFormValues["instruments"] extends (infer T)[] | null | undefined ? T : never)
+        ? cur.filter((i) => i !== inst)
+        : [...cur, inst as typeof cur[number]],
+    });
+  }
+
+  function toggleTimeframe(tf: string) {
+    const cur = form.timeframes ?? [];
+    setForm({
+      ...form,
+      timeframes: cur.includes(tf) ? cur.filter((t) => t !== tf) : [...cur, tf],
+    });
+  }
+
+  function addTag(e: React.KeyboardEvent) {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      const tag = tagInput.trim();
+      if (tag && !(form.tags ?? []).includes(tag)) {
+        setForm({ ...form, tags: [...(form.tags ?? []), tag] });
+      }
+      setTagInput("");
+    }
+  }
+
+  function removeTag(tag: string) {
+    setForm({ ...form, tags: (form.tags ?? []).filter((t) => t !== tag) });
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErrors({});
+    setServerError(null);
+
+    const result = strategySchema.safeParse(form);
+    if (!result.success) {
+      const fe: FormErrors = {};
+      for (const issue of result.error.issues) {
+        const key = issue.path[0] as keyof StrategyFormValues;
+        fe[key] = issue.message;
+      }
+      setErrors(fe);
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const saved = initial
+        ? await updateStrategy(initial.id, result.data)
+        : await createStrategy(result.data);
+      onSaved(saved);
+      onClose();
+    } catch (err) {
+      setServerError(err instanceof Error ? err.message : "Failed to save strategy");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const inputCls = (err?: string) =>
+    cn(
+      "w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring",
+      err && "border-destructive"
+    );
+
+  const instruments = form.instruments ?? [];
+  const timeframes = form.timeframes ?? [];
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleOpen}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-lg max-h-[90vh] overflow-y-auto -translate-x-1/2 -translate-y-1/2 rounded-xl bg-card p-6 shadow-xl">
+          <div className="mb-5 flex items-center justify-between">
+            <Dialog.Title className="text-lg font-semibold">
+              {initial ? "Edit Strategy" : "New Strategy"}
+            </Dialog.Title>
+            <Dialog.Close className="rounded-md p-1 text-muted-foreground hover:bg-accent">
+              <X className="h-4 w-4" />
+            </Dialog.Close>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {/* Name */}
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Strategy Name</label>
+              <input
+                type="text"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                placeholder="e.g. ICT Breaker Block"
+                className={inputCls(errors.name)}
+              />
+              {errors.name && <p className="text-xs text-destructive">{errors.name}</p>}
+            </div>
+
+            {/* Description */}
+            <div className="space-y-1">
+              <label className="text-sm font-medium">
+                Description <span className="text-xs text-muted-foreground">(optional)</span>
+              </label>
+              <textarea
+                value={form.description ?? ""}
+                onChange={(e) => setForm({ ...form, description: e.target.value || null })}
+                rows={2}
+                placeholder="Brief overview of the strategy…"
+                className="w-full resize-none rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
+
+            {/* Rules / Playbook */}
+            <div className="space-y-1">
+              <label className="text-sm font-medium">
+                Rules / Playbook <span className="text-xs text-muted-foreground">(optional, markdown)</span>
+              </label>
+              <textarea
+                value={form.rules ?? ""}
+                onChange={(e) => setForm({ ...form, rules: e.target.value || null })}
+                rows={5}
+                placeholder="1. Wait for market structure shift&#10;2. Identify order block&#10;3. Enter on retest…"
+                className="w-full resize-none rounded-md border bg-background px-3 py-2 text-sm font-mono outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
+
+            {/* Instruments */}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">Instruments</label>
+              <div className="flex flex-wrap gap-2">
+                {INSTRUMENTS.map((inst) => (
+                  <button
+                    key={inst}
+                    type="button"
+                    onClick={() => toggleInstrument(inst)}
+                    className={cn(
+                      "rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+                      instruments.includes(inst as typeof instruments[number])
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-border hover:border-primary/50"
+                    )}
+                  >
+                    {INSTRUMENT_LABELS[inst]}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Timeframes */}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">Timeframes</label>
+              <div className="flex flex-wrap gap-2">
+                {TIMEFRAME_OPTIONS.map((tf) => (
+                  <button
+                    key={tf}
+                    type="button"
+                    onClick={() => toggleTimeframe(tf)}
+                    className={cn(
+                      "rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+                      timeframes.includes(tf)
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-border hover:border-primary/50"
+                    )}
+                  >
+                    {tf}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Tags */}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium">
+                Tags <span className="text-xs text-muted-foreground">(press Enter or comma to add)</span>
+              </label>
+              <input
+                type="text"
+                value={tagInput}
+                onChange={(e) => setTagInput(e.target.value)}
+                onKeyDown={addTag}
+                placeholder="e.g. ICT, SMC, momentum…"
+                className={inputCls()}
+              />
+              {(form.tags ?? []).length > 0 && (
+                <div className="flex flex-wrap gap-1.5 mt-1">
+                  {(form.tags ?? []).map((tag) => (
+                    <span
+                      key={tag}
+                      className="inline-flex items-center gap-1 rounded-full bg-accent px-2.5 py-0.5 text-xs"
+                    >
+                      {tag}
+                      <button
+                        type="button"
+                        onClick={() => removeTag(tag)}
+                        className="text-muted-foreground hover:text-foreground"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Active */}
+            <label className="flex items-center gap-2 cursor-pointer text-sm">
+              <input
+                type="checkbox"
+                checked={form.is_active}
+                onChange={(e) => setForm({ ...form, is_active: e.target.checked })}
+                className="h-4 w-4 rounded border-border accent-primary"
+              />
+              Active
+            </label>
+
+            {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  className="rounded-md px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-accent"
+                >
+                  Cancel
+                </button>
+              </Dialog.Close>
+              <button
+                type="submit"
+                disabled={saving}
+                className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              >
+                {saving ? "Saving…" : initial ? "Update" : "Create"}
+              </button>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/trading/trade-detail.tsx
+++ b/src/components/trading/trade-detail.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useState } from "react";
+import { X, Pencil, Trash2, TrendingUp, TrendingDown, CheckCircle2 } from "lucide-react";
+import { TradeForm } from "./trade-form";
+import { deleteTrade } from "@/lib/supabase/trading";
+import { SESSION_LABELS, PROP_FIRM_LABELS } from "@/lib/validations/trading";
+import { cn } from "@/lib/utils";
+import type { Trade, PropAccount, Strategy } from "@/lib/types";
+
+interface Props {
+  trade: Trade | null;
+  propAccounts: PropAccount[];
+  strategies: Strategy[];
+  onClose: () => void;
+  onUpdated: (trade: Trade) => void;
+  onDeleted: (id: string) => void;
+}
+
+function formatMoney(n: number | null | undefined) {
+  if (n == null) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+  }).format(n);
+}
+
+function formatDateTime(iso: string | null | undefined) {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function Row({ label, value, className }: { label: string; value: React.ReactNode; className?: string }) {
+  return (
+    <div className="flex items-start gap-2 py-2 border-b last:border-0">
+      <span className="text-sm text-muted-foreground w-36 shrink-0">{label}</span>
+      <span className={cn("text-sm flex-1", className)}>{value}</span>
+    </div>
+  );
+}
+
+export function TradeDetail({ trade, propAccounts, strategies, onClose, onUpdated, onDeleted }: Props) {
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  if (!trade) return null;
+
+  async function handleDelete() {
+    if (!confirm("Delete this trade? This cannot be undone.")) return;
+    setDeleting(true);
+    try {
+      await deleteTrade(trade!.id);
+      onDeleted(trade!.id);
+    } finally {
+      setDeleting(false);
+    }
+  }
+
+  const outcomeColors: Record<string, string> = {
+    win: "text-emerald-600",
+    loss: "text-red-600",
+    break_even: "text-amber-600",
+    open: "text-blue-600",
+  };
+
+  const outcomeLabels: Record<string, string> = {
+    win: "Win", loss: "Loss", break_even: "Break Even", open: "Open",
+  };
+
+  return (
+    <>
+      {/* Slide-in sheet */}
+      <div className="fixed inset-0 z-40 flex justify-end">
+        {/* Backdrop */}
+        <button
+          className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+          onClick={onClose}
+          aria-label="Close"
+        />
+        {/* Panel */}
+        <div className="relative z-10 flex h-full w-full max-w-xl flex-col bg-card shadow-2xl overflow-y-auto">
+          {/* Header */}
+          <div className="flex items-center justify-between gap-2 border-b px-6 py-4 sticky top-0 bg-card z-10">
+            <div className="flex items-center gap-3">
+              <div className="flex items-center gap-1.5">
+                <span className="text-lg font-semibold">{trade.instrument}</span>
+                {trade.direction === "long" ? (
+                  <TrendingUp className="h-5 w-5 text-emerald-500" />
+                ) : (
+                  <TrendingDown className="h-5 w-5 text-red-500" />
+                )}
+              </div>
+              <span className={cn("text-sm font-medium", outcomeColors[trade.outcome])}>
+                {outcomeLabels[trade.outcome]}
+              </span>
+              {trade.is_reviewed && (
+                <CheckCircle2 className="h-4 w-4 text-emerald-500" title="Reviewed" />
+              )}
+            </div>
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => setEditOpen(true)}
+                className="rounded-md p-1.5 text-muted-foreground hover:bg-accent"
+                title="Edit trade"
+              >
+                <Pencil className="h-4 w-4" />
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={deleting}
+                className="rounded-md p-1.5 text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                title="Delete trade"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+              <button
+                onClick={onClose}
+                className="rounded-md p-1.5 text-muted-foreground hover:bg-accent"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+
+          <div className="px-6 py-5 space-y-6">
+            {/* P&L highlight */}
+            <div className={cn(
+              "rounded-xl p-4 text-center",
+              (trade.net_pnl ?? 0) > 0 ? "bg-emerald-500/10" :
+              (trade.net_pnl ?? 0) < 0 ? "bg-red-500/10" : "bg-muted"
+            )}>
+              <p className="text-xs text-muted-foreground uppercase tracking-wide mb-1">Net P&L</p>
+              <p className={cn(
+                "text-3xl font-bold tabular-nums",
+                (trade.net_pnl ?? 0) > 0 ? "text-emerald-600" :
+                (trade.net_pnl ?? 0) < 0 ? "text-red-600" : "text-foreground"
+              )}>
+                {formatMoney(trade.net_pnl)}
+              </p>
+              {trade.fees > 0 && (
+                <p className="text-xs text-muted-foreground mt-1">
+                  Gross: {formatMoney(trade.gross_pnl)} · Fees: {formatMoney(trade.fees)}
+                </p>
+              )}
+            </div>
+
+            {/* Execution details */}
+            <div>
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                Execution
+              </h3>
+              <div className="rounded-lg border bg-muted/20 px-4">
+                <Row label="Entry Time" value={formatDateTime(trade.entry_time)} />
+                <Row label="Exit Time" value={formatDateTime(trade.exit_time)} />
+                <Row label="Entry Price" value={<span className="font-mono">{trade.entry_price}</span>} />
+                <Row label="Exit Price" value={<span className="font-mono">{trade.exit_price ?? "—"}</span>} />
+                <Row label="Contracts" value={trade.contracts} />
+                {trade.session && (
+                  <Row label="Session" value={SESSION_LABELS[trade.session] ?? trade.session} />
+                )}
+                {trade.prop_accounts && (
+                  <Row
+                    label="Account"
+                    value={`${PROP_FIRM_LABELS[trade.prop_accounts.firm]} · ${trade.prop_accounts.account_label}`}
+                  />
+                )}
+                {trade.strategies && (
+                  <Row label="Strategy" value={trade.strategies.name} />
+                )}
+              </div>
+            </div>
+
+            {/* Setup Tags */}
+            {(trade.setup_tags ?? []).length > 0 && (
+              <div>
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                  Setup Tags
+                </h3>
+                <div className="flex flex-wrap gap-1.5">
+                  {(trade.setup_tags ?? []).map((tag) => (
+                    <span
+                      key={tag}
+                      className="rounded-full border border-border bg-accent px-3 py-0.5 text-xs font-medium"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Notes sections */}
+            {[
+              { label: "Confluence Notes", value: trade.confluence_notes },
+              { label: "Entry Notes", value: trade.entry_notes },
+              { label: "Exit Notes", value: trade.exit_notes },
+            ].map(({ label, value }) =>
+              value ? (
+                <div key={label}>
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                    {label}
+                  </h3>
+                  <p className="text-sm leading-relaxed text-foreground/80 rounded-lg border bg-muted/20 px-4 py-3 whitespace-pre-wrap">
+                    {value}
+                  </p>
+                </div>
+              ) : null
+            )}
+
+            {/* Psychology */}
+            {(trade.pre_emotion || trade.post_emotion) && (
+              <div>
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                  Psychology
+                </h3>
+                <div className="rounded-lg border bg-muted/20 px-4">
+                  {trade.pre_emotion && <Row label="Pre-Trade" value={trade.pre_emotion} />}
+                  {trade.post_emotion && <Row label="Post-Trade" value={trade.post_emotion} />}
+                  {trade.followed_rules != null && (
+                    <Row
+                      label="Followed Rules"
+                      value={
+                        <span className={trade.followed_rules ? "text-emerald-600" : "text-red-600"}>
+                          {trade.followed_rules ? "Yes" : "No"}
+                        </span>
+                      }
+                    />
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Lessons */}
+            {trade.lessons && (
+              <div>
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-2">
+                  Lessons Learned
+                </h3>
+                <p className="text-sm leading-relaxed text-foreground/80 rounded-lg border bg-muted/20 px-4 py-3 whitespace-pre-wrap">
+                  {trade.lessons}
+                </p>
+              </div>
+            )}
+
+            {/* Timestamps */}
+            <p className="text-xs text-muted-foreground text-right">
+              Logged {new Date(trade.created_at).toLocaleDateString()}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <TradeForm
+        open={editOpen}
+        onClose={() => setEditOpen(false)}
+        onSaved={onUpdated}
+        initial={trade}
+        propAccounts={propAccounts}
+        strategies={strategies}
+      />
+    </>
+  );
+}

--- a/src/components/trading/trade-form.tsx
+++ b/src/components/trading/trade-form.tsx
@@ -1,0 +1,661 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { useState } from "react";
+import { X } from "lucide-react";
+import {
+  tradeSchema,
+  type TradeFormValues,
+  INSTRUMENTS,
+  TRADE_DIRECTIONS,
+  TRADE_OUTCOMES,
+  TRADING_SESSIONS,
+  INSTRUMENT_LABELS,
+  SESSION_LABELS,
+} from "@/lib/validations/trading";
+import { createTrade, updateTrade } from "@/lib/supabase/trading";
+import { cn } from "@/lib/utils";
+import type { Trade, PropAccount, Strategy } from "@/lib/types";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSaved: (trade: Trade) => void;
+  initial?: Trade;
+  propAccounts: PropAccount[];
+  strategies: Strategy[];
+}
+
+type FormErrors = Partial<Record<keyof TradeFormValues | string, string>>;
+
+const SETUP_TAG_SUGGESTIONS = [
+  "OB", "FVG", "BOS", "CHOCH", "MSS", "PDH", "PDL", "EQH", "EQL",
+  "Breaker", "Mitigation", "Liquidity", "Imbalance", "SNR", "VWAP",
+];
+
+function toLocalDateTimeInput(iso: string | null | undefined): string {
+  if (!iso) return "";
+  // iso is e.g. "2024-01-15T14:30:00Z" → convert to local YYYY-MM-DDTHH:mm
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function localInputToISO(val: string): string | null {
+  if (!val) return null;
+  return new Date(val).toISOString();
+}
+
+function nowLocalInput(): string {
+  return toLocalDateTimeInput(new Date().toISOString());
+}
+
+function emptyForm(): TradeFormValues {
+  return {
+    instrument: "NQ",
+    direction: "long",
+    entry_price: 0,
+    exit_price: null,
+    contracts: 1,
+    entry_time: new Date().toISOString(),
+    exit_time: null,
+    gross_pnl: null,
+    fees: 0,
+    outcome: "open",
+    prop_account_id: null,
+    strategy_id: null,
+    session: null,
+    setup_tags: [],
+    confluence_notes: null,
+    entry_notes: null,
+    exit_notes: null,
+    lessons: null,
+    screenshots: null,
+    pre_emotion: null,
+    post_emotion: null,
+    followed_rules: null,
+    is_reviewed: false,
+  };
+}
+
+function fromTrade(t: Trade): TradeFormValues {
+  return {
+    instrument: t.instrument,
+    direction: t.direction,
+    entry_price: t.entry_price,
+    exit_price: t.exit_price,
+    contracts: t.contracts,
+    entry_time: t.entry_time,
+    exit_time: t.exit_time,
+    gross_pnl: t.gross_pnl,
+    fees: t.fees,
+    outcome: t.outcome,
+    prop_account_id: t.prop_account_id,
+    strategy_id: t.strategy_id,
+    session: t.session,
+    setup_tags: t.setup_tags ?? [],
+    confluence_notes: t.confluence_notes,
+    entry_notes: t.entry_notes,
+    exit_notes: t.exit_notes,
+    lessons: t.lessons,
+    screenshots: t.screenshots,
+    pre_emotion: t.pre_emotion,
+    post_emotion: t.post_emotion,
+    followed_rules: t.followed_rules,
+    is_reviewed: t.is_reviewed,
+  };
+}
+
+export function TradeForm({ open, onClose, onSaved, initial, propAccounts, strategies }: Props) {
+  const [form, setForm] = useState<TradeFormValues>(initial ? fromTrade(initial) : emptyForm());
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [saving, setSaving] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [tagInput, setTagInput] = useState("");
+  const [activeTab, setActiveTab] = useState<"execution" | "context" | "review">("execution");
+
+  function handleOpen(val: boolean) {
+    if (val) {
+      setForm(initial ? fromTrade(initial) : emptyForm());
+      setErrors({});
+      setServerError(null);
+      setTagInput("");
+      setActiveTab("execution");
+    }
+    if (!val) onClose();
+  }
+
+  function toggleSetupTag(tag: string) {
+    const cur = form.setup_tags ?? [];
+    setForm({
+      ...form,
+      setup_tags: cur.includes(tag) ? cur.filter((t) => t !== tag) : [...cur, tag],
+    });
+  }
+
+  function addCustomTag(e: React.KeyboardEvent) {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      const tag = tagInput.trim().toUpperCase();
+      if (tag && !(form.setup_tags ?? []).includes(tag)) {
+        setForm({ ...form, setup_tags: [...(form.setup_tags ?? []), tag] });
+      }
+      setTagInput("");
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErrors({});
+    setServerError(null);
+
+    const result = tradeSchema.safeParse(form);
+    if (!result.success) {
+      const fe: FormErrors = {};
+      for (const issue of result.error.issues) {
+        const key = issue.path[0] as string;
+        fe[key] = issue.message;
+      }
+      setErrors(fe);
+      // Switch to tab containing the first error
+      const executionFields = ["instrument", "direction", "entry_price", "exit_price", "contracts", "entry_time", "exit_time", "gross_pnl", "fees", "outcome"];
+      const hasExecError = Object.keys(fe).some((k) => executionFields.includes(k));
+      if (hasExecError) setActiveTab("execution");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const saved = initial
+        ? await updateTrade(initial.id, result.data)
+        : await createTrade(result.data);
+      onSaved(saved);
+      onClose();
+    } catch (err) {
+      setServerError(err instanceof Error ? err.message : "Failed to save trade");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const inputCls = (err?: string) =>
+    cn(
+      "w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring",
+      err && "border-destructive"
+    );
+
+  const tabs = [
+    { id: "execution" as const, label: "Execution" },
+    { id: "context" as const, label: "Context" },
+    { id: "review" as const, label: "Review" },
+  ];
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleOpen}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/50 backdrop-blur-sm" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-2xl max-h-[90vh] overflow-y-auto -translate-x-1/2 -translate-y-1/2 rounded-xl bg-card shadow-xl">
+          <div className="flex items-center justify-between px-6 pt-5 pb-4 border-b">
+            <Dialog.Title className="text-lg font-semibold">
+              {initial ? "Edit Trade" : "Log New Trade"}
+            </Dialog.Title>
+            <Dialog.Close className="rounded-md p-1 text-muted-foreground hover:bg-accent">
+              <X className="h-4 w-4" />
+            </Dialog.Close>
+          </div>
+
+          {/* Tabs */}
+          <div className="flex gap-0 border-b px-6">
+            {tabs.map((tab) => (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => setActiveTab(tab.id)}
+                className={cn(
+                  "px-4 py-2.5 text-sm font-medium border-b-2 transition-colors -mb-px",
+                  activeTab === tab.id
+                    ? "border-primary text-primary"
+                    : "border-transparent text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+
+          <form onSubmit={handleSubmit}>
+            <div className="px-6 py-5 space-y-4">
+              {/* ---- EXECUTION TAB ---- */}
+              {activeTab === "execution" && (
+                <>
+                  {/* Instrument + Direction */}
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1">
+                      <label className="text-sm font-medium">Instrument</label>
+                      <select
+                        value={form.instrument}
+                        onChange={(e) => setForm({ ...form, instrument: e.target.value as TradeFormValues["instrument"] })}
+                        className={inputCls(errors.instrument)}
+                      >
+                        {INSTRUMENTS.map((i) => (
+                          <option key={i} value={i}>{INSTRUMENT_LABELS[i]}</option>
+                        ))}
+                      </select>
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-sm font-medium">Direction</label>
+                      <div className="flex rounded-md overflow-hidden border">
+                        {TRADE_DIRECTIONS.map((d) => (
+                          <button
+                            key={d}
+                            type="button"
+                            onClick={() => setForm({ ...form, direction: d })}
+                            className={cn(
+                              "flex-1 py-2 text-sm font-medium transition-colors",
+                              form.direction === d
+                                ? d === "long"
+                                  ? "bg-emerald-500 text-white"
+                                  : "bg-red-500 text-white"
+                                : "hover:bg-accent"
+                            )}
+                          >
+                            {d === "long" ? "▲ Long" : "▼ Short"}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Entry + Exit prices */}
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1">
+                      <label className="text-sm font-medium">Entry Price</label>
+                      <input
+                        type="number"
+                        step="0.00001"
+                        value={form.entry_price || ""}
+                        onChange={(e) => setForm({ ...form, entry_price: parseFloat(e.target.value) || 0 })}
+                        placeholder="0.00"
+                        className={inputCls(errors.entry_price)}
+                      />
+                      {errors.entry_price && <p className="text-xs text-destructive">{errors.entry_price}</p>}
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-sm font-medium">Exit Price</label>
+                      <input
+                        type="number"
+                        step="0.00001"
+                        value={form.exit_price ?? ""}
+                        onChange={(e) => setForm({ ...form, exit_price: e.target.value ? parseFloat(e.target.value) : null })}
+                        placeholder="Optional"
+                        className={inputCls(errors.exit_price)}
+                      />
+                    </div>
+                  </div>
+
+                  {/* Contracts + Fees */}
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1">
+                      <label className="text-sm font-medium">Contracts</label>
+                      <input
+                        type="number"
+                        step="0.01"
+                        min="0.01"
+                        value={form.contracts || ""}
+                        onChange={(e) => setForm({ ...form, contracts: parseFloat(e.target.value) || 1 })}
+                        className={inputCls(errors.contracts)}
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-sm font-medium">Fees ($)</label>
+                      <input
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        value={form.fees || ""}
+                        onChange={(e) => setForm({ ...form, fees: parseFloat(e.target.value) || 0 })}
+                        placeholder="0.00"
+                        className={inputCls()}
+                      />
+                    </div>
+                  </div>
+
+                  {/* Entry + Exit times */}
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1">
+                      <label className="text-sm font-medium">Entry Time</label>
+                      <input
+                        type="datetime-local"
+                        defaultValue={toLocalDateTimeInput(form.entry_time)}
+                        onChange={(e) => setForm({ ...form, entry_time: localInputToISO(e.target.value) ?? new Date().toISOString() })}
+                        className={inputCls(errors.entry_time)}
+                      />
+                      {errors.entry_time && <p className="text-xs text-destructive">{errors.entry_time}</p>}
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-sm font-medium">Exit Time</label>
+                      <input
+                        type="datetime-local"
+                        defaultValue={toLocalDateTimeInput(form.exit_time)}
+                        onChange={(e) => setForm({ ...form, exit_time: localInputToISO(e.target.value) })}
+                        className={inputCls()}
+                      />
+                    </div>
+                  </div>
+
+                  {/* Gross P&L */}
+                  <div className="space-y-1">
+                    <label className="text-sm font-medium">
+                      Gross P&L ($) <span className="text-xs text-muted-foreground">(before fees)</span>
+                    </label>
+                    <input
+                      type="number"
+                      step="0.01"
+                      value={form.gross_pnl ?? ""}
+                      onChange={(e) => setForm({ ...form, gross_pnl: e.target.value ? parseFloat(e.target.value) : null })}
+                      placeholder="e.g. 250.00 or -125.00"
+                      className={inputCls()}
+                    />
+                    {form.gross_pnl != null && form.fees > 0 && (
+                      <p className="text-xs text-muted-foreground">
+                        Net P&L: {(form.gross_pnl - form.fees).toFixed(2)}
+                      </p>
+                    )}
+                  </div>
+
+                  {/* Outcome */}
+                  <div className="space-y-1.5">
+                    <label className="text-sm font-medium">Outcome</label>
+                    <div className="flex gap-2">
+                      {TRADE_OUTCOMES.map((o) => {
+                        const colors: Record<string, string> = {
+                          win: "bg-emerald-500 text-white",
+                          loss: "bg-red-500 text-white",
+                          break_even: "bg-amber-500 text-white",
+                          open: "bg-blue-500 text-white",
+                        };
+                        const labels: Record<string, string> = {
+                          win: "Win", loss: "Loss", break_even: "B/E", open: "Open",
+                        };
+                        return (
+                          <button
+                            key={o}
+                            type="button"
+                            onClick={() => setForm({ ...form, outcome: o })}
+                            className={cn(
+                              "rounded-md px-3 py-1.5 text-sm font-medium border transition-colors",
+                              form.outcome === o
+                                ? colors[o]
+                                : "hover:bg-accent border-border"
+                            )}
+                          >
+                            {labels[o]}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  {/* Session + Prop Account */}
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1">
+                      <label className="text-sm font-medium">Session</label>
+                      <select
+                        value={form.session ?? ""}
+                        onChange={(e) => setForm({ ...form, session: (e.target.value as TradeFormValues["session"]) || null })}
+                        className={inputCls()}
+                      >
+                        <option value="">— None —</option>
+                        {TRADING_SESSIONS.map((s) => (
+                          <option key={s} value={s}>{SESSION_LABELS[s]}</option>
+                        ))}
+                      </select>
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-sm font-medium">Prop Account</label>
+                      <select
+                        value={form.prop_account_id ?? ""}
+                        onChange={(e) => setForm({ ...form, prop_account_id: e.target.value || null })}
+                        className={inputCls()}
+                      >
+                        <option value="">— None —</option>
+                        {propAccounts.map((a) => (
+                          <option key={a.id} value={a.id}>{a.account_label}</option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+
+                  {/* Strategy */}
+                  <div className="space-y-1">
+                    <label className="text-sm font-medium">Strategy</label>
+                    <select
+                      value={form.strategy_id ?? ""}
+                      onChange={(e) => setForm({ ...form, strategy_id: e.target.value || null })}
+                      className={inputCls()}
+                    >
+                      <option value="">— None —</option>
+                      {strategies.map((s) => (
+                        <option key={s.id} value={s.id}>{s.name}</option>
+                      ))}
+                    </select>
+                  </div>
+                </>
+              )}
+
+              {/* ---- CONTEXT TAB ---- */}
+              {activeTab === "context" && (
+                <>
+                  {/* Setup Tags */}
+                  <div className="space-y-1.5">
+                    <label className="text-sm font-medium">Setup Tags</label>
+                    <div className="flex flex-wrap gap-1.5">
+                      {SETUP_TAG_SUGGESTIONS.map((tag) => (
+                        <button
+                          key={tag}
+                          type="button"
+                          onClick={() => toggleSetupTag(tag)}
+                          className={cn(
+                            "rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors",
+                            (form.setup_tags ?? []).includes(tag)
+                              ? "border-primary bg-primary text-primary-foreground"
+                              : "border-border hover:border-primary/50"
+                          )}
+                        >
+                          {tag}
+                        </button>
+                      ))}
+                    </div>
+                    <input
+                      type="text"
+                      value={tagInput}
+                      onChange={(e) => setTagInput(e.target.value)}
+                      onKeyDown={addCustomTag}
+                      placeholder="Custom tag (Enter to add)…"
+                      className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+                    />
+                    {(form.setup_tags ?? []).filter((t) => !SETUP_TAG_SUGGESTIONS.includes(t)).length > 0 && (
+                      <div className="flex flex-wrap gap-1.5">
+                        {(form.setup_tags ?? [])
+                          .filter((t) => !SETUP_TAG_SUGGESTIONS.includes(t))
+                          .map((tag) => (
+                            <span
+                              key={tag}
+                              className="inline-flex items-center gap-1 rounded-full bg-primary/15 px-2.5 py-0.5 text-xs font-medium"
+                            >
+                              {tag}
+                              <button
+                                type="button"
+                                onClick={() => toggleSetupTag(tag)}
+                                className="text-muted-foreground hover:text-foreground"
+                              >
+                                <X className="h-3 w-3" />
+                              </button>
+                            </span>
+                          ))}
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Confluence Notes */}
+                  <div className="space-y-1">
+                    <label className="text-sm font-medium">Confluence Notes</label>
+                    <textarea
+                      value={form.confluence_notes ?? ""}
+                      onChange={(e) => setForm({ ...form, confluence_notes: e.target.value || null })}
+                      rows={3}
+                      placeholder="What lined up for this trade? (HTF bias, key levels…)"
+                      className="w-full resize-none rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+                    />
+                  </div>
+
+                  {/* Entry Notes */}
+                  <div className="space-y-1">
+                    <label className="text-sm font-medium">Entry Notes</label>
+                    <textarea
+                      value={form.entry_notes ?? ""}
+                      onChange={(e) => setForm({ ...form, entry_notes: e.target.value || null })}
+                      rows={3}
+                      placeholder="Why did you enter here?"
+                      className="w-full resize-none rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+                    />
+                  </div>
+
+                  {/* Exit Notes */}
+                  <div className="space-y-1">
+                    <label className="text-sm font-medium">Exit Notes</label>
+                    <textarea
+                      value={form.exit_notes ?? ""}
+                      onChange={(e) => setForm({ ...form, exit_notes: e.target.value || null })}
+                      rows={3}
+                      placeholder="Why did you exit here? Target hit, SL hit, manual exit…"
+                      className="w-full resize-none rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+                    />
+                  </div>
+
+                  {/* Pre/Post Emotion */}
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="space-y-1">
+                      <label className="text-sm font-medium">Pre-Trade Emotion</label>
+                      <input
+                        type="text"
+                        value={form.pre_emotion ?? ""}
+                        onChange={(e) => setForm({ ...form, pre_emotion: e.target.value || null })}
+                        placeholder="e.g. Confident, Anxious…"
+                        className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <label className="text-sm font-medium">Post-Trade Emotion</label>
+                      <input
+                        type="text"
+                        value={form.post_emotion ?? ""}
+                        onChange={(e) => setForm({ ...form, post_emotion: e.target.value || null })}
+                        placeholder="e.g. Calm, Frustrated…"
+                        className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+                      />
+                    </div>
+                  </div>
+                </>
+              )}
+
+              {/* ---- REVIEW TAB ---- */}
+              {activeTab === "review" && (
+                <>
+                  {/* Lessons */}
+                  <div className="space-y-1">
+                    <label className="text-sm font-medium">Lessons Learned</label>
+                    <textarea
+                      value={form.lessons ?? ""}
+                      onChange={(e) => setForm({ ...form, lessons: e.target.value || null })}
+                      rows={5}
+                      placeholder="What did this trade teach you? What would you do differently?"
+                      className="w-full resize-none rounded-md border bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+                    />
+                  </div>
+
+                  {/* Followed Rules */}
+                  <div className="space-y-2">
+                    <label className="text-sm font-medium">Did you follow your strategy rules?</label>
+                    <div className="flex gap-2">
+                      {[
+                        { val: true, label: "✓ Yes" },
+                        { val: false, label: "✗ No" },
+                        { val: null, label: "— N/A" },
+                      ].map(({ val, label }) => (
+                        <button
+                          key={String(val)}
+                          type="button"
+                          onClick={() => setForm({ ...form, followed_rules: val })}
+                          className={cn(
+                            "rounded-md border px-3 py-1.5 text-sm font-medium transition-colors",
+                            form.followed_rules === val
+                              ? val === true
+                                ? "bg-emerald-500 text-white border-emerald-500"
+                                : val === false
+                                ? "bg-red-500 text-white border-red-500"
+                                : "bg-muted border-border"
+                              : "hover:bg-accent border-border"
+                          )}
+                        >
+                          {label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Reviewed flag */}
+                  <label className="flex items-center gap-2 cursor-pointer text-sm">
+                    <input
+                      type="checkbox"
+                      checked={form.is_reviewed}
+                      onChange={(e) => setForm({ ...form, is_reviewed: e.target.checked })}
+                      className="h-4 w-4 rounded border-border accent-primary"
+                    />
+                    Mark as reviewed
+                  </label>
+                </>
+              )}
+
+              {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+            </div>
+
+            {/* Footer */}
+            <div className="flex items-center justify-between gap-2 border-t px-6 py-4">
+              <div className="flex gap-2">
+                {tabs.map((tab, idx) => (
+                  <button
+                    key={tab.id}
+                    type="button"
+                    onClick={() => setActiveTab(tab.id)}
+                    className={cn(
+                      "h-1.5 w-6 rounded-full transition-colors",
+                      activeTab === tab.id ? "bg-primary" : "bg-muted"
+                    )}
+                  />
+                ))}
+              </div>
+              <div className="flex gap-2">
+                <Dialog.Close asChild>
+                  <button
+                    type="button"
+                    className="rounded-md px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-accent"
+                  >
+                    Cancel
+                  </button>
+                </Dialog.Close>
+                <button
+                  type="submit"
+                  disabled={saving}
+                  className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+                >
+                  {saving ? "Saving…" : initial ? "Update Trade" : "Log Trade"}
+                </button>
+              </div>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/trading/trades-list.tsx
+++ b/src/components/trading/trades-list.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { Plus, SlidersHorizontal, TrendingUp, TrendingDown, Minus } from "lucide-react";
+import { TradeForm } from "./trade-form";
+import { INSTRUMENT_LABELS, SESSION_LABELS, INSTRUMENTS, TRADE_OUTCOMES, TRADING_SESSIONS } from "@/lib/validations/trading";
+import { deleteTrade } from "@/lib/supabase/trading";
+import { cn } from "@/lib/utils";
+import type { Trade, PropAccount, Strategy, Instrument, TradeOutcome } from "@/lib/types";
+
+interface Props {
+  trades: Trade[];
+  propAccounts: PropAccount[];
+  strategies: Strategy[];
+  onTradesChange: (trades: Trade[]) => void;
+  onSelectTrade: (trade: Trade) => void;
+}
+
+interface Filters {
+  instrument: Instrument | "";
+  outcome: TradeOutcome | "";
+  prop_account_id: string;
+  strategy_id: string;
+  from: string;
+  to: string;
+  search: string;
+}
+
+function formatMoney(n: number | null | undefined) {
+  if (n == null) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+  }).format(n);
+}
+
+function formatDateTime(iso: string) {
+  return new Date(iso).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function OutcomeChip({ outcome }: { outcome: Trade["outcome"] }) {
+  const cfg: Record<string, { cls: string; label: string }> = {
+    win: { cls: "bg-emerald-500/15 text-emerald-600", label: "Win" },
+    loss: { cls: "bg-red-500/15 text-red-600", label: "Loss" },
+    break_even: { cls: "bg-amber-500/15 text-amber-600", label: "B/E" },
+    open: { cls: "bg-blue-500/15 text-blue-600", label: "Open" },
+  };
+  const { cls, label } = cfg[outcome] ?? cfg.open;
+  return (
+    <span className={cn("rounded-full px-2 py-0.5 text-xs font-medium", cls)}>{label}</span>
+  );
+}
+
+export function TradesList({ trades, propAccounts, strategies, onTradesChange, onSelectTrade }: Props) {
+  const [formOpen, setFormOpen] = useState(false);
+  const [showFilters, setShowFilters] = useState(false);
+  const [filters, setFilters] = useState<Filters>({
+    instrument: "",
+    outcome: "",
+    prop_account_id: "",
+    strategy_id: "",
+    from: "",
+    to: "",
+    search: "",
+  });
+
+  function handleSaved(saved: Trade) {
+    if (trades.find((t) => t.id === saved.id)) {
+      onTradesChange(trades.map((t) => (t.id === saved.id ? saved : t)));
+    } else {
+      onTradesChange([saved, ...trades]);
+    }
+  }
+
+  const filtered = useMemo(() => {
+    return trades.filter((t) => {
+      if (filters.instrument && t.instrument !== filters.instrument) return false;
+      if (filters.outcome && t.outcome !== filters.outcome) return false;
+      if (filters.prop_account_id && t.prop_account_id !== filters.prop_account_id) return false;
+      if (filters.strategy_id && t.strategy_id !== filters.strategy_id) return false;
+      if (filters.from && t.entry_time < filters.from) return false;
+      if (filters.to && t.entry_time > filters.to + "T23:59:59") return false;
+      if (filters.search) {
+        const q = filters.search.toLowerCase();
+        const hay = [
+          t.instrument,
+          t.direction,
+          ...(t.setup_tags ?? []),
+          t.entry_notes ?? "",
+          t.exit_notes ?? "",
+          t.strategies?.name ?? "",
+        ].join(" ").toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [trades, filters]);
+
+  const selectCls = "rounded-md border bg-background px-2.5 py-1.5 text-sm outline-none focus:ring-2 focus:ring-ring";
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <h2 className="text-base font-semibold">
+          Trade Log
+          <span className="ml-2 text-sm font-normal text-muted-foreground">
+            {filtered.length} / {trades.length}
+          </span>
+        </h2>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setShowFilters(!showFilters)}
+            className={cn(
+              "flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors",
+              showFilters ? "bg-accent" : "hover:bg-accent"
+            )}
+          >
+            <SlidersHorizontal className="h-3.5 w-3.5" />
+            Filters
+          </button>
+          <button
+            onClick={() => setFormOpen(true)}
+            className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Log Trade
+          </button>
+        </div>
+      </div>
+
+      {/* Filter row */}
+      {showFilters && (
+        <div className="rounded-xl border bg-card p-4 space-y-3">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2">
+            <select
+              value={filters.instrument}
+              onChange={(e) => setFilters({ ...filters, instrument: e.target.value as Instrument | "" })}
+              className={selectCls}
+            >
+              <option value="">All Instruments</option>
+              {INSTRUMENTS.map((i) => <option key={i} value={i}>{i}</option>)}
+            </select>
+
+            <select
+              value={filters.outcome}
+              onChange={(e) => setFilters({ ...filters, outcome: e.target.value as TradeOutcome | "" })}
+              className={selectCls}
+            >
+              <option value="">All Outcomes</option>
+              <option value="win">Win</option>
+              <option value="loss">Loss</option>
+              <option value="break_even">Break Even</option>
+              <option value="open">Open</option>
+            </select>
+
+            <select
+              value={filters.prop_account_id}
+              onChange={(e) => setFilters({ ...filters, prop_account_id: e.target.value })}
+              className={selectCls}
+            >
+              <option value="">All Accounts</option>
+              {propAccounts.map((a) => (
+                <option key={a.id} value={a.id}>{a.account_label}</option>
+              ))}
+            </select>
+
+            <select
+              value={filters.strategy_id}
+              onChange={(e) => setFilters({ ...filters, strategy_id: e.target.value })}
+              className={selectCls}
+            >
+              <option value="">All Strategies</option>
+              {strategies.map((s) => (
+                <option key={s.id} value={s.id}>{s.name}</option>
+              ))}
+            </select>
+
+            <input
+              type="date"
+              value={filters.from}
+              onChange={(e) => setFilters({ ...filters, from: e.target.value })}
+              className={selectCls}
+            />
+            <input
+              type="date"
+              value={filters.to}
+              onChange={(e) => setFilters({ ...filters, to: e.target.value })}
+              className={selectCls}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={filters.search}
+              onChange={(e) => setFilters({ ...filters, search: e.target.value })}
+              placeholder="Search notes, tags, strategies…"
+              className="flex-1 rounded-md border bg-background px-3 py-1.5 text-sm outline-none focus:ring-2 focus:ring-ring"
+            />
+            <button
+              onClick={() => setFilters({ instrument: "", outcome: "", prop_account_id: "", strategy_id: "", from: "", to: "", search: "" })}
+              className="text-xs text-muted-foreground hover:text-foreground underline"
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Table / list */}
+      {filtered.length === 0 ? (
+        <div className="rounded-xl border border-dashed p-8 text-center text-muted-foreground">
+          <p className="text-sm">{trades.length === 0 ? "No trades logged yet." : "No trades match your filters."}</p>
+          {trades.length === 0 && (
+            <p className="text-xs mt-1">Click "Log Trade" to record your first trade.</p>
+          )}
+        </div>
+      ) : (
+        <div className="rounded-xl border overflow-hidden">
+          {/* Desktop table */}
+          <div className="hidden lg:block overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/40">
+                  <th className="px-4 py-2.5 text-left font-medium text-muted-foreground">Date/Time</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-muted-foreground">Instrument</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-muted-foreground">Dir</th>
+                  <th className="px-4 py-2.5 text-right font-medium text-muted-foreground">Entry</th>
+                  <th className="px-4 py-2.5 text-right font-medium text-muted-foreground">Exit</th>
+                  <th className="px-4 py-2.5 text-right font-medium text-muted-foreground">Qty</th>
+                  <th className="px-4 py-2.5 text-right font-medium text-muted-foreground">Net P&L</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-muted-foreground">Outcome</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-muted-foreground">Strategy</th>
+                  <th className="px-4 py-2.5 text-left font-medium text-muted-foreground">Tags</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {filtered.map((trade) => (
+                  <tr
+                    key={trade.id}
+                    onClick={() => onSelectTrade(trade)}
+                    className="hover:bg-accent/50 cursor-pointer transition-colors"
+                  >
+                    <td className="px-4 py-3 text-muted-foreground whitespace-nowrap">
+                      {formatDateTime(trade.entry_time)}
+                    </td>
+                    <td className="px-4 py-3 font-medium">{trade.instrument}</td>
+                    <td className="px-4 py-3">
+                      {trade.direction === "long" ? (
+                        <TrendingUp className="h-4 w-4 text-emerald-500" />
+                      ) : (
+                        <TrendingDown className="h-4 w-4 text-red-500" />
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono text-xs">{trade.entry_price}</td>
+                    <td className="px-4 py-3 text-right font-mono text-xs">
+                      {trade.exit_price ?? "—"}
+                    </td>
+                    <td className="px-4 py-3 text-right">{trade.contracts}</td>
+                    <td className={cn(
+                      "px-4 py-3 text-right font-medium tabular-nums",
+                      (trade.net_pnl ?? 0) > 0 && "text-emerald-600",
+                      (trade.net_pnl ?? 0) < 0 && "text-red-600"
+                    )}>
+                      {formatMoney(trade.net_pnl)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <OutcomeChip outcome={trade.outcome} />
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground text-xs">
+                      {trade.strategies?.name ?? "—"}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex flex-wrap gap-1 max-w-[120px]">
+                        {(trade.setup_tags ?? []).slice(0, 3).map((tag) => (
+                          <span key={tag} className="rounded bg-accent px-1.5 py-0.5 text-xs">{tag}</span>
+                        ))}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Mobile cards */}
+          <div className="lg:hidden divide-y">
+            {filtered.map((trade) => (
+              <button
+                key={trade.id}
+                onClick={() => onSelectTrade(trade)}
+                className="w-full text-left p-4 hover:bg-accent/50 transition-colors"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold">{trade.instrument}</span>
+                      {trade.direction === "long" ? (
+                        <TrendingUp className="h-3.5 w-3.5 text-emerald-500" />
+                      ) : (
+                        <TrendingDown className="h-3.5 w-3.5 text-red-500" />
+                      )}
+                      <OutcomeChip outcome={trade.outcome} />
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      {formatDateTime(trade.entry_time)}
+                      {trade.strategies?.name && ` · ${trade.strategies.name}`}
+                    </p>
+                  </div>
+                  <p className={cn(
+                    "font-semibold tabular-nums shrink-0",
+                    (trade.net_pnl ?? 0) > 0 && "text-emerald-600",
+                    (trade.net_pnl ?? 0) < 0 && "text-red-600"
+                  )}>
+                    {formatMoney(trade.net_pnl)}
+                  </p>
+                </div>
+                {(trade.setup_tags ?? []).length > 0 && (
+                  <div className="flex flex-wrap gap-1 mt-1.5">
+                    {(trade.setup_tags ?? []).slice(0, 4).map((tag) => (
+                      <span key={tag} className="rounded bg-accent px-1.5 py-0.5 text-xs">{tag}</span>
+                    ))}
+                  </div>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <TradeForm
+        open={formOpen}
+        onClose={() => setFormOpen(false)}
+        onSaved={handleSaved}
+        propAccounts={propAccounts}
+        strategies={strategies}
+      />
+    </div>
+  );
+}

--- a/src/components/trading/trading-analytics.tsx
+++ b/src/components/trading/trading-analytics.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  AreaChart,
+  Area,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from "recharts";
+import { computeTradeStats, buildDailyPnl } from "@/lib/supabase/trading";
+import { cn } from "@/lib/utils";
+import type { Trade } from "@/lib/types";
+
+interface Props {
+  trades: Trade[];
+}
+
+function formatMoney(n: number) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(n);
+}
+
+function MetricCard({
+  label,
+  value,
+  sub,
+  color,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  color?: string;
+}) {
+  return (
+    <div className="rounded-xl border bg-card p-4 space-y-1">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className={cn("text-2xl font-bold tabular-nums", color)}>{value}</p>
+      {sub && <p className="text-xs text-muted-foreground">{sub}</p>}
+    </div>
+  );
+}
+
+function CustomTooltip({ active, payload, label }: any) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="rounded-lg border bg-card px-3 py-2 shadow-lg text-sm">
+      <p className="text-muted-foreground text-xs mb-1">{label}</p>
+      {payload.map((p: any) => (
+        <p key={p.name} style={{ color: p.color }} className="font-medium">
+          {p.name}: {formatMoney(p.value)}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+export function TradingAnalytics({ trades }: Props) {
+  const stats = useMemo(() => computeTradeStats(trades), [trades]);
+  const dailyPnl = useMemo(() => buildDailyPnl(trades), [trades]);
+
+  // Per-instrument stats
+  const byInstrument = useMemo(() => {
+    const map = new Map<string, { wins: number; losses: number; pnl: number; count: number }>();
+    for (const t of trades) {
+      if (t.outcome === "open") continue;
+      const cur = map.get(t.instrument) ?? { wins: 0, losses: 0, pnl: 0, count: 0 };
+      map.set(t.instrument, {
+        wins: cur.wins + (t.outcome === "win" ? 1 : 0),
+        losses: cur.losses + (t.outcome === "loss" ? 1 : 0),
+        pnl: cur.pnl + (t.net_pnl ?? 0),
+        count: cur.count + 1,
+      });
+    }
+    return Array.from(map.entries()).map(([inst, d]) => ({
+      instrument: inst,
+      ...d,
+      winRate: d.count > 0 ? Math.round((d.wins / d.count) * 100) : 0,
+    }));
+  }, [trades]);
+
+  if (trades.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed p-8 text-center text-muted-foreground">
+        <p className="text-sm">No trades yet — analytics will appear here once you log trades.</p>
+      </div>
+    );
+  }
+
+  const pnlColor = stats.totalNetPnl >= 0 ? "text-emerald-600" : "text-red-600";
+
+  return (
+    <div className="space-y-6">
+      {/* Summary metrics */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+        <MetricCard
+          label="Net P&L"
+          value={formatMoney(stats.totalNetPnl)}
+          sub={`Gross: ${formatMoney(stats.totalGrossPnl)}`}
+          color={pnlColor}
+        />
+        <MetricCard
+          label="Win Rate"
+          value={`${stats.winRate.toFixed(1)}%`}
+          sub={`${stats.wins}W / ${stats.losses}L / ${stats.breakEvens}BE`}
+          color={stats.winRate >= 50 ? "text-emerald-600" : "text-red-600"}
+        />
+        <MetricCard
+          label="Profit Factor"
+          value={isFinite(stats.profitFactor) ? stats.profitFactor.toFixed(2) : "∞"}
+          sub="Gross wins ÷ gross losses"
+          color={stats.profitFactor >= 1 ? "text-emerald-600" : "text-red-600"}
+        />
+        <MetricCard
+          label="Avg Win"
+          value={formatMoney(stats.avgWin)}
+          color="text-emerald-600"
+        />
+        <MetricCard
+          label="Avg Loss"
+          value={formatMoney(stats.avgLoss)}
+          color="text-red-600"
+        />
+        <MetricCard
+          label="Total Trades"
+          value={String(stats.totalTrades)}
+          sub={`Fees: ${formatMoney(stats.totalFees)}`}
+        />
+      </div>
+
+      {/* Equity curve */}
+      {dailyPnl.length > 0 && (
+        <div className="rounded-xl border bg-card p-4 space-y-3">
+          <h3 className="text-sm font-semibold">Equity Curve</h3>
+          <ResponsiveContainer width="100%" height={220}>
+            <AreaChart data={dailyPnl} margin={{ top: 4, right: 8, bottom: 0, left: 8 }}>
+              <defs>
+                <linearGradient id="pnlGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop
+                    offset="5%"
+                    stopColor={stats.totalNetPnl >= 0 ? "#10b981" : "#ef4444"}
+                    stopOpacity={0.3}
+                  />
+                  <stop
+                    offset="95%"
+                    stopColor={stats.totalNetPnl >= 0 ? "#10b981" : "#ef4444"}
+                    stopOpacity={0}
+                  />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+              <XAxis
+                dataKey="date"
+                tick={{ fontSize: 11 }}
+                tickFormatter={(v) => {
+                  const d = new Date(v);
+                  return `${d.getMonth() + 1}/${d.getDate()}`;
+                }}
+              />
+              <YAxis
+                tick={{ fontSize: 11 }}
+                tickFormatter={(v) => formatMoney(v)}
+                width={80}
+              />
+              <Tooltip content={<CustomTooltip />} />
+              <Area
+                type="monotone"
+                dataKey="cumulative_pnl"
+                name="Cumulative P&L"
+                stroke={stats.totalNetPnl >= 0 ? "#10b981" : "#ef4444"}
+                strokeWidth={2}
+                fill="url(#pnlGradient)"
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+
+      {/* Daily P&L bar chart */}
+      {dailyPnl.length > 0 && (
+        <div className="rounded-xl border bg-card p-4 space-y-3">
+          <h3 className="text-sm font-semibold">Daily P&L</h3>
+          <ResponsiveContainer width="100%" height={180}>
+            <BarChart data={dailyPnl} margin={{ top: 4, right: 8, bottom: 0, left: 8 }}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+              <XAxis
+                dataKey="date"
+                tick={{ fontSize: 11 }}
+                tickFormatter={(v) => {
+                  const d = new Date(v);
+                  return `${d.getMonth() + 1}/${d.getDate()}`;
+                }}
+              />
+              <YAxis
+                tick={{ fontSize: 11 }}
+                tickFormatter={(v) => formatMoney(v)}
+                width={80}
+              />
+              <Tooltip content={<CustomTooltip />} />
+              <Bar dataKey="net_pnl" name="Daily P&L" radius={[3, 3, 0, 0]}>
+                {dailyPnl.map((entry, index) => (
+                  <Cell
+                    key={index}
+                    fill={entry.net_pnl >= 0 ? "#10b981" : "#ef4444"}
+                    fillOpacity={0.8}
+                  />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+
+      {/* Per-instrument breakdown */}
+      {byInstrument.length > 0 && (
+        <div className="rounded-xl border bg-card p-4 space-y-3">
+          <h3 className="text-sm font-semibold">By Instrument</h3>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b">
+                  <th className="pb-2 text-left font-medium text-muted-foreground">Instrument</th>
+                  <th className="pb-2 text-right font-medium text-muted-foreground">Trades</th>
+                  <th className="pb-2 text-right font-medium text-muted-foreground">Win Rate</th>
+                  <th className="pb-2 text-right font-medium text-muted-foreground">Net P&L</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {byInstrument
+                  .sort((a, b) => b.pnl - a.pnl)
+                  .map((row) => (
+                    <tr key={row.instrument}>
+                      <td className="py-2 font-medium">{row.instrument}</td>
+                      <td className="py-2 text-right text-muted-foreground">{row.count}</td>
+                      <td className="py-2 text-right">
+                        <span className={row.winRate >= 50 ? "text-emerald-600" : "text-red-600"}>
+                          {row.winRate}%
+                        </span>
+                      </td>
+                      <td className={cn(
+                        "py-2 text-right font-medium tabular-nums",
+                        row.pnl >= 0 ? "text-emerald-600" : "text-red-600"
+                      )}>
+                        {formatMoney(row.pnl)}
+                      </td>
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Best / Worst trades */}
+      <div className="grid sm:grid-cols-2 gap-3">
+        <div className="rounded-xl border bg-card p-4">
+          <h3 className="text-sm font-semibold mb-2 text-emerald-600">Best Trade</h3>
+          <p className="text-2xl font-bold tabular-nums text-emerald-600">
+            {formatMoney(stats.largestWin)}
+          </p>
+        </div>
+        <div className="rounded-xl border bg-card p-4">
+          <h3 className="text-sm font-semibold mb-2 text-red-600">Worst Trade</h3>
+          <p className="text-2xl font-bold tabular-nums text-red-600">
+            {formatMoney(stats.largestLoss)}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/trading/trading-view.tsx
+++ b/src/components/trading/trading-view.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import { BarChart2, BookOpen, Building2, List, ScrollText } from "lucide-react";
+import { TradesList } from "./trades-list";
+import { TradeDetail } from "./trade-detail";
+import { TradingAnalytics } from "./trading-analytics";
+import { PropAccountsView } from "./prop-accounts-view";
+import { StrategiesView } from "./strategies-view";
+import { SessionJournal } from "./session-journal";
+import { cn } from "@/lib/utils";
+import type { Trade, PropAccount, Strategy } from "@/lib/types";
+
+type Tab = "trades" | "analytics" | "journal" | "accounts" | "strategies";
+
+interface Props {
+  initialTrades: Trade[];
+  initialAccounts: PropAccount[];
+  initialStrategies: Strategy[];
+}
+
+const TABS: { id: Tab; label: string; icon: React.ElementType }[] = [
+  { id: "trades", label: "Trades", icon: List },
+  { id: "analytics", label: "Analytics", icon: BarChart2 },
+  { id: "journal", label: "Journal", icon: ScrollText },
+  { id: "accounts", label: "Accounts", icon: Building2 },
+  { id: "strategies", label: "Strategies", icon: BookOpen },
+];
+
+export function TradingView({ initialTrades, initialAccounts, initialStrategies }: Props) {
+  const [activeTab, setActiveTab] = useState<Tab>("trades");
+  const [trades, setTrades] = useState<Trade[]>(initialTrades);
+  const [accounts, setAccounts] = useState<PropAccount[]>(initialAccounts);
+  const [strategies, setStrategies] = useState<Strategy[]>(initialStrategies);
+  const [selectedTrade, setSelectedTrade] = useState<Trade | null>(null);
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Tab bar */}
+      <div className="flex gap-1 overflow-x-auto rounded-xl border bg-card p-1 shrink-0">
+        {TABS.map(({ id, label, icon: Icon }) => (
+          <button
+            key={id}
+            onClick={() => setActiveTab(id)}
+            className={cn(
+              "flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium whitespace-nowrap transition-colors",
+              activeTab === id
+                ? "bg-primary text-primary-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground hover:bg-accent"
+            )}
+          >
+            <Icon className="h-3.5 w-3.5" />
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Content */}
+      <div>
+        {activeTab === "trades" && (
+          <TradesList
+            trades={trades}
+            propAccounts={accounts}
+            strategies={strategies}
+            onTradesChange={setTrades}
+            onSelectTrade={(t) => setSelectedTrade(t)}
+          />
+        )}
+        {activeTab === "analytics" && (
+          <TradingAnalytics trades={trades} />
+        )}
+        {activeTab === "journal" && (
+          <SessionJournal />
+        )}
+        {activeTab === "accounts" && (
+          <PropAccountsView
+            accounts={accounts}
+            onAccountsChange={setAccounts}
+          />
+        )}
+        {activeTab === "strategies" && (
+          <StrategiesView
+            strategies={strategies}
+            onStrategiesChange={setStrategies}
+          />
+        )}
+      </div>
+
+      {/* Trade detail sheet */}
+      {selectedTrade && (
+        <TradeDetail
+          trade={selectedTrade}
+          propAccounts={accounts}
+          strategies={strategies}
+          onClose={() => setSelectedTrade(null)}
+          onUpdated={(updated) => {
+            setTrades(trades.map((t) => (t.id === updated.id ? updated : t)));
+            setSelectedTrade(updated);
+          }}
+          onDeleted={(id) => {
+            setTrades(trades.filter((t) => t.id !== id));
+            setSelectedTrade(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/lib/supabase/trading.ts
+++ b/src/lib/supabase/trading.ts
@@ -1,0 +1,339 @@
+import { createClient } from "./client";
+import type {
+  Trade,
+  PropAccount,
+  Strategy,
+  TradingSessionJournal,
+  TradeStats,
+  DailyPnl,
+  Instrument,
+  TradeOutcome,
+} from "@/lib/types";
+
+// ============================================================
+// Prop Accounts
+// ============================================================
+
+export async function getPropAccounts(): Promise<PropAccount[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("prop_accounts")
+    .select("*")
+    .order("created_at", { ascending: false });
+
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function createPropAccount(
+  input: Omit<PropAccount, "id" | "user_id" | "created_at" | "updated_at">
+): Promise<PropAccount> {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+
+  const { data, error } = await supabase
+    .from("prop_accounts")
+    .insert({ ...input, user_id: user.id })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function updatePropAccount(
+  id: string,
+  input: Partial<Omit<PropAccount, "id" | "user_id" | "created_at" | "updated_at">>
+): Promise<PropAccount> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("prop_accounts")
+    .update(input)
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function deletePropAccount(id: string): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase.from("prop_accounts").delete().eq("id", id);
+  if (error) throw error;
+}
+
+// ============================================================
+// Strategies
+// ============================================================
+
+export async function getStrategies(): Promise<Strategy[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("strategies")
+    .select("*")
+    .order("name");
+
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function createStrategy(
+  input: Omit<Strategy, "id" | "user_id" | "created_at" | "updated_at">
+): Promise<Strategy> {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+
+  const { data, error } = await supabase
+    .from("strategies")
+    .insert({ ...input, user_id: user.id })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function updateStrategy(
+  id: string,
+  input: Partial<Omit<Strategy, "id" | "user_id" | "created_at" | "updated_at">>
+): Promise<Strategy> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("strategies")
+    .update(input)
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function deleteStrategy(id: string): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase.from("strategies").delete().eq("id", id);
+  if (error) throw error;
+}
+
+// ============================================================
+// Trades
+// ============================================================
+
+export interface TradeFilters {
+  instrument?: Instrument;
+  outcome?: TradeOutcome;
+  prop_account_id?: string;
+  strategy_id?: string;
+  from?: string; // ISO date
+  to?: string;   // ISO date
+  limit?: number;
+  offset?: number;
+}
+
+export async function getTrades(filters: TradeFilters = {}): Promise<Trade[]> {
+  const supabase = createClient();
+  let query = supabase
+    .from("trades")
+    .select(
+      `*,
+       prop_accounts(id, firm, account_label),
+       strategies(id, name)`
+    )
+    .order("entry_time", { ascending: false });
+
+  if (filters.instrument) query = query.eq("instrument", filters.instrument);
+  if (filters.outcome) query = query.eq("outcome", filters.outcome);
+  if (filters.prop_account_id) query = query.eq("prop_account_id", filters.prop_account_id);
+  if (filters.strategy_id) query = query.eq("strategy_id", filters.strategy_id);
+  if (filters.from) query = query.gte("entry_time", filters.from);
+  if (filters.to) query = query.lte("entry_time", filters.to + "T23:59:59");
+  if (filters.limit) query = query.limit(filters.limit);
+  if (filters.offset) query = query.range(filters.offset, filters.offset + (filters.limit ?? 50) - 1);
+
+  const { data, error } = await query;
+  if (error) throw error;
+  return (data ?? []) as Trade[];
+}
+
+export async function getTradeById(id: string): Promise<Trade | null> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("trades")
+    .select(
+      `*,
+       prop_accounts(id, firm, account_label),
+       strategies(id, name)`
+    )
+    .eq("id", id)
+    .single();
+
+  if (error) {
+    if (error.code === "PGRST116") return null;
+    throw error;
+  }
+  return data as Trade;
+}
+
+export async function createTrade(
+  input: Omit<Trade, "id" | "user_id" | "net_pnl" | "created_at" | "updated_at" | "prop_accounts" | "strategies">
+): Promise<Trade> {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+
+  const { data, error } = await supabase
+    .from("trades")
+    .insert({ ...input, user_id: user.id })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as Trade;
+}
+
+export async function updateTrade(
+  id: string,
+  input: Partial<Omit<Trade, "id" | "user_id" | "net_pnl" | "created_at" | "updated_at" | "prop_accounts" | "strategies">>
+): Promise<Trade> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("trades")
+    .update(input)
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as Trade;
+}
+
+export async function deleteTrade(id: string): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase.from("trades").delete().eq("id", id);
+  if (error) throw error;
+}
+
+// ============================================================
+// Trading Session Journal
+// ============================================================
+
+export async function getTradingSession(date: string): Promise<TradingSessionJournal | null> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("trading_sessions")
+    .select("*")
+    .eq("session_date", date)
+    .maybeSingle();
+
+  if (error) throw error;
+  return data;
+}
+
+export async function getTradingSessions(from?: string, to?: string): Promise<TradingSessionJournal[]> {
+  const supabase = createClient();
+  let query = supabase
+    .from("trading_sessions")
+    .select("*")
+    .order("session_date", { ascending: false });
+
+  if (from) query = query.gte("session_date", from);
+  if (to) query = query.lte("session_date", to);
+
+  const { data, error } = await query;
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function upsertTradingSession(
+  input: Omit<TradingSessionJournal, "id" | "user_id" | "created_at" | "updated_at">
+): Promise<TradingSessionJournal> {
+  const supabase = createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+
+  const { data, error } = await supabase
+    .from("trading_sessions")
+    .upsert(
+      { ...input, user_id: user.id },
+      { onConflict: "user_id,session_date" }
+    )
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data;
+}
+
+// ============================================================
+// Analytics helpers (client-side computed)
+// ============================================================
+
+export function computeTradeStats(trades: Trade[]): TradeStats {
+  const closed = trades.filter((t) => t.outcome !== "open");
+  const wins = closed.filter((t) => t.outcome === "win");
+  const losses = closed.filter((t) => t.outcome === "loss");
+  const breakEvens = closed.filter((t) => t.outcome === "break_even");
+
+  const totalNetPnl = closed.reduce((s, t) => s + (t.net_pnl ?? 0), 0);
+  const totalGrossPnl = closed.reduce((s, t) => s + (t.gross_pnl ?? 0), 0);
+  const totalFees = closed.reduce((s, t) => s + (t.fees ?? 0), 0);
+
+  const winPnl = wins.map((t) => t.net_pnl ?? 0);
+  const lossPnl = losses.map((t) => t.net_pnl ?? 0);
+
+  const avgWin = wins.length ? winPnl.reduce((s, v) => s + v, 0) / wins.length : 0;
+  const avgLoss = losses.length ? lossPnl.reduce((s, v) => s + v, 0) / losses.length : 0;
+
+  const grossWins = wins.reduce((s, t) => s + (t.gross_pnl ?? 0), 0);
+  const grossLosses = Math.abs(losses.reduce((s, t) => s + (t.gross_pnl ?? 0), 0));
+  const profitFactor = grossLosses > 0 ? grossWins / grossLosses : grossWins > 0 ? Infinity : 0;
+
+  return {
+    totalTrades: closed.length,
+    wins: wins.length,
+    losses: losses.length,
+    breakEvens: breakEvens.length,
+    winRate: closed.length > 0 ? (wins.length / closed.length) * 100 : 0,
+    totalNetPnl,
+    totalGrossPnl,
+    totalFees,
+    avgWin,
+    avgLoss,
+    profitFactor,
+    largestWin: wins.length ? Math.max(...winPnl) : 0,
+    largestLoss: losses.length ? Math.min(...lossPnl) : 0,
+    avgRR: null, // requires stop loss data — future enhancement
+  };
+}
+
+export function buildDailyPnl(trades: Trade[]): DailyPnl[] {
+  const closed = trades.filter((t) => t.outcome !== "open" && t.exit_time);
+
+  // Group by local date of exit_time
+  const byDate = new Map<string, { pnl: number; count: number }>();
+  for (const t of closed) {
+    const date = (t.exit_time ?? t.entry_time).slice(0, 10);
+    const existing = byDate.get(date) ?? { pnl: 0, count: 0 };
+    byDate.set(date, {
+      pnl: existing.pnl + (t.net_pnl ?? 0),
+      count: existing.count + 1,
+    });
+  }
+
+  // Sort ascending and compute cumulative
+  const sorted = Array.from(byDate.entries()).sort(([a], [b]) => a.localeCompare(b));
+  let cumulative = 0;
+
+  return sorted.map(([date, { pnl, count }]) => {
+    cumulative += pnl;
+    return {
+      date,
+      net_pnl: pnl,
+      cumulative_pnl: cumulative,
+      trade_count: count,
+    };
+  });
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -46,6 +46,121 @@ export interface HabitWithLogs extends Habit {
   logged_today: boolean;
 }
 
+// ---- Trading Journal (P2) ----
+
+export type Instrument = "NQ" | "Gold" | "CL" | "6E";
+export type TradeDirection = "long" | "short";
+export type TradeOutcome = "win" | "loss" | "break_even" | "open";
+export type PropFirm = "FundedNext" | "AlphaFutures" | "TakeProfitTrader" | "YRM";
+export type TradingSession = "london" | "new_york_am" | "new_york_pm" | "overnight" | "asia";
+export type MoodRating = "1" | "2" | "3" | "4" | "5";
+
+export interface PropAccount {
+  id: string;
+  user_id: string;
+  firm: PropFirm;
+  account_label: string;
+  account_size: number;
+  balance: number | null;
+  daily_loss_limit: number | null;
+  max_drawdown: number | null;
+  profit_target: number | null;
+  is_active: boolean;
+  is_funded: boolean;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Strategy {
+  id: string;
+  user_id: string;
+  name: string;
+  description: string | null;
+  rules: string | null;
+  instruments: Instrument[] | null;
+  timeframes: string[] | null;
+  tags: string[] | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Trade {
+  id: string;
+  user_id: string;
+  prop_account_id: string | null;
+  strategy_id: string | null;
+  instrument: Instrument;
+  direction: TradeDirection;
+  entry_price: number;
+  exit_price: number | null;
+  contracts: number;
+  entry_time: string;
+  exit_time: string | null;
+  gross_pnl: number | null;
+  fees: number;
+  net_pnl: number | null;           // generated column
+  outcome: TradeOutcome;
+  session: TradingSession | null;
+  setup_tags: string[] | null;
+  confluence_notes: string | null;
+  entry_notes: string | null;
+  exit_notes: string | null;
+  lessons: string | null;
+  screenshots: string[] | null;
+  pre_emotion: string | null;
+  post_emotion: string | null;
+  followed_rules: boolean | null;
+  is_reviewed: boolean;
+  created_at: string;
+  updated_at: string;
+  // joined relations (optional)
+  prop_accounts?: Pick<PropAccount, "id" | "firm" | "account_label"> | null;
+  strategies?: Pick<Strategy, "id" | "name"> | null;
+}
+
+export interface TradingSessionJournal {
+  id: string;
+  user_id: string;
+  session_date: string;             // ISO date YYYY-MM-DD
+  pre_market_notes: string | null;
+  mood_before: MoodRating | null;
+  plan: string | null;
+  post_market_notes: string | null;
+  mood_after: MoodRating | null;
+  lessons: string | null;
+  followed_plan: boolean | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// ---- Analytics helpers ----
+
+export interface TradeStats {
+  totalTrades: number;
+  wins: number;
+  losses: number;
+  breakEvens: number;
+  winRate: number;                  // 0-100
+  totalNetPnl: number;
+  totalGrossPnl: number;
+  totalFees: number;
+  avgWin: number;
+  avgLoss: number;
+  profitFactor: number;
+  largestWin: number;
+  largestLoss: number;
+  avgRR: number | null;
+}
+
+export interface DailyPnl {
+  date: string;                     // YYYY-MM-DD
+  net_pnl: number;
+  cumulative_pnl: number;
+  trade_count: number;
+}
+
 export interface Note {
   id: string;
   title: string;

--- a/src/lib/validations/trading.ts
+++ b/src/lib/validations/trading.ts
@@ -1,0 +1,106 @@
+import { z } from "zod";
+
+export const INSTRUMENTS = ["NQ", "Gold", "CL", "6E"] as const;
+export const PROP_FIRMS = ["FundedNext", "AlphaFutures", "TakeProfitTrader", "YRM"] as const;
+export const TRADE_DIRECTIONS = ["long", "short"] as const;
+export const TRADE_OUTCOMES = ["win", "loss", "break_even", "open"] as const;
+export const TRADING_SESSIONS = ["london", "new_york_am", "new_york_pm", "overnight", "asia"] as const;
+export const MOOD_RATINGS = ["1", "2", "3", "4", "5"] as const;
+
+export const INSTRUMENT_LABELS: Record<string, string> = {
+  NQ: "NQ (NASDAQ Futures)",
+  Gold: "Gold (GC)",
+  CL: "CL (Crude Oil)",
+  "6E": "6E (Euro/USD)",
+};
+
+export const PROP_FIRM_LABELS: Record<string, string> = {
+  FundedNext: "FundedNext",
+  AlphaFutures: "AlphaFutures",
+  TakeProfitTrader: "Take Profit Trader",
+  YRM: "YRM",
+};
+
+export const SESSION_LABELS: Record<string, string> = {
+  london: "London",
+  new_york_am: "New York AM",
+  new_york_pm: "New York PM",
+  overnight: "Overnight",
+  asia: "Asia",
+};
+
+// ---- Prop Account ----
+
+export const propAccountSchema = z.object({
+  firm: z.enum(PROP_FIRMS),
+  account_label: z.string().min(1, "Label is required").max(100),
+  account_size: z.number({ invalid_type_error: "Required" }).positive("Must be positive"),
+  balance: z.number().nullable().optional(),
+  daily_loss_limit: z.number().positive().nullable().optional(),
+  max_drawdown: z.number().positive().nullable().optional(),
+  profit_target: z.number().positive().nullable().optional(),
+  is_active: z.boolean().default(true),
+  is_funded: z.boolean().default(false),
+  notes: z.string().nullable().optional(),
+});
+
+export type PropAccountFormValues = z.infer<typeof propAccountSchema>;
+
+// ---- Strategy ----
+
+export const strategySchema = z.object({
+  name: z.string().min(1, "Name is required").max(100),
+  description: z.string().nullable().optional(),
+  rules: z.string().nullable().optional(),
+  instruments: z.array(z.enum(INSTRUMENTS)).nullable().optional(),
+  timeframes: z.array(z.string()).nullable().optional(),
+  tags: z.array(z.string()).nullable().optional(),
+  is_active: z.boolean().default(true),
+});
+
+export type StrategyFormValues = z.infer<typeof strategySchema>;
+
+// ---- Trade ----
+
+export const tradeSchema = z.object({
+  instrument: z.enum(INSTRUMENTS),
+  direction: z.enum(TRADE_DIRECTIONS),
+  entry_price: z.number({ invalid_type_error: "Required" }).positive(),
+  exit_price: z.number().positive().nullable().optional(),
+  contracts: z.number({ invalid_type_error: "Required" }).positive().default(1),
+  entry_time: z.string().min(1, "Entry time is required"),
+  exit_time: z.string().nullable().optional(),
+  gross_pnl: z.number().nullable().optional(),
+  fees: z.number().min(0).default(0),
+  outcome: z.enum(TRADE_OUTCOMES).default("open"),
+  prop_account_id: z.string().uuid().nullable().optional(),
+  strategy_id: z.string().uuid().nullable().optional(),
+  session: z.enum(TRADING_SESSIONS).nullable().optional(),
+  setup_tags: z.array(z.string()).nullable().optional(),
+  confluence_notes: z.string().nullable().optional(),
+  entry_notes: z.string().nullable().optional(),
+  exit_notes: z.string().nullable().optional(),
+  lessons: z.string().nullable().optional(),
+  screenshots: z.array(z.string().url()).nullable().optional(),
+  pre_emotion: z.string().nullable().optional(),
+  post_emotion: z.string().nullable().optional(),
+  followed_rules: z.boolean().nullable().optional(),
+  is_reviewed: z.boolean().default(false),
+});
+
+export type TradeFormValues = z.infer<typeof tradeSchema>;
+
+// ---- Trading Session Journal ----
+
+export const tradingSessionSchema = z.object({
+  session_date: z.string().min(1, "Date is required"),
+  pre_market_notes: z.string().nullable().optional(),
+  mood_before: z.enum(MOOD_RATINGS).nullable().optional(),
+  plan: z.string().nullable().optional(),
+  post_market_notes: z.string().nullable().optional(),
+  mood_after: z.enum(MOOD_RATINGS).nullable().optional(),
+  lessons: z.string().nullable().optional(),
+  followed_plan: z.boolean().nullable().optional(),
+});
+
+export type TradingSessionFormValues = z.infer<typeof tradingSessionSchema>;

--- a/supabase/migrations/20240103000000_trading_schema.sql
+++ b/supabase/migrations/20240103000000_trading_schema.sql
@@ -1,0 +1,211 @@
+-- ============================================================
+-- P2: Trading Journal + Strategy Tracker
+-- ============================================================
+-- Instruments supported: NQ, Gold, CL, 6E
+-- Prop firms supported: FundedNext, AlphaFutures, TakeProfitTrader, YRM
+-- ============================================================
+
+-- Ensure updated_at trigger function exists (created in habits migration)
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+-- ============================================================
+-- ENUM TYPES
+-- ============================================================
+
+CREATE TYPE instrument AS ENUM ('NQ', 'Gold', 'CL', '6E');
+
+CREATE TYPE trade_direction AS ENUM ('long', 'short');
+
+CREATE TYPE trade_outcome AS ENUM ('win', 'loss', 'break_even', 'open');
+
+CREATE TYPE prop_firm AS ENUM (
+  'FundedNext',
+  'AlphaFutures',
+  'TakeProfitTrader',
+  'YRM'
+);
+
+CREATE TYPE trading_session AS ENUM ('london', 'new_york_am', 'new_york_pm', 'overnight', 'asia');
+
+CREATE TYPE mood_rating AS ENUM ('1', '2', '3', '4', '5');
+
+-- ============================================================
+-- TABLE: prop_accounts
+-- Track funded/prop trading accounts per firm
+-- ============================================================
+
+CREATE TABLE prop_accounts (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  firm          prop_firm NOT NULL,
+  account_label text NOT NULL,                  -- e.g. "100K Evaluation #1"
+  account_size  numeric(14,2) NOT NULL,          -- e.g. 100000
+  balance       numeric(14,2),                   -- current balance (optional, manual update)
+  daily_loss_limit  numeric(14,2),
+  max_drawdown  numeric(14,2),                   -- max trailing or static drawdown
+  profit_target numeric(14,2),
+  is_active     boolean NOT NULL DEFAULT true,
+  is_funded     boolean NOT NULL DEFAULT false,  -- evaluation vs funded
+  notes         text,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE prop_accounts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own prop_accounts"
+  ON prop_accounts FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER prop_accounts_updated_at
+  BEFORE UPDATE ON prop_accounts
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- ============================================================
+-- TABLE: strategies
+-- Named trading strategies with rules and applicable instruments
+-- ============================================================
+
+CREATE TABLE strategies (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name        text NOT NULL,
+  description text,
+  rules       text,                              -- markdown rules / playbook
+  instruments instrument[],                      -- which instruments this applies to
+  timeframes  text[],                            -- e.g. ['1m','5m','15m']
+  tags        text[],
+  is_active   boolean NOT NULL DEFAULT true,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE strategies ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own strategies"
+  ON strategies FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER strategies_updated_at
+  BEFORE UPDATE ON strategies
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- ============================================================
+-- TABLE: trades
+-- Core trade log — one row per executed trade
+-- ============================================================
+
+CREATE TABLE trades (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id          uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  prop_account_id  uuid REFERENCES prop_accounts(id) ON DELETE SET NULL,
+  strategy_id      uuid REFERENCES strategies(id) ON DELETE SET NULL,
+
+  -- Instrument & direction
+  instrument       instrument NOT NULL,
+  direction        trade_direction NOT NULL,
+
+  -- Execution
+  entry_price      numeric(14,5) NOT NULL,
+  exit_price       numeric(14,5),
+  contracts        numeric(10,2) NOT NULL DEFAULT 1,
+  entry_time       timestamptz NOT NULL,
+  exit_time        timestamptz,
+
+  -- P&L (stored in dollars; negative = loss)
+  gross_pnl        numeric(14,2),               -- before fees
+  fees             numeric(14,2) NOT NULL DEFAULT 0,
+  net_pnl          numeric(14,2)
+    GENERATED ALWAYS AS (
+      CASE WHEN gross_pnl IS NOT NULL THEN gross_pnl - fees ELSE NULL END
+    ) STORED,
+
+  -- Outcome
+  outcome          trade_outcome NOT NULL DEFAULT 'open',
+
+  -- Context
+  session          trading_session,
+  setup_tags       text[],                       -- e.g. ['OB','BOS','FVG']
+  confluence_notes text,                         -- what lined up for this trade
+  entry_notes      text,                         -- why you entered
+  exit_notes       text,                         -- why you exited
+  lessons          text,                         -- post-trade review
+  screenshots      text[],                       -- URLs (Supabase Storage or external)
+
+  -- Psychological
+  pre_emotion      text,                         -- how you felt before the trade
+  post_emotion     text,                         -- how you felt after
+
+  -- Flags
+  followed_rules   boolean,                      -- did you follow your strategy rules?
+  is_reviewed      boolean NOT NULL DEFAULT false,
+
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE trades ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own trades"
+  ON trades FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER trades_updated_at
+  BEFORE UPDATE ON trades
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- Indexes for common query patterns
+CREATE INDEX trades_user_entry_time ON trades (user_id, entry_time DESC);
+CREATE INDEX trades_user_instrument ON trades (user_id, instrument);
+CREATE INDEX trades_user_outcome    ON trades (user_id, outcome);
+CREATE INDEX trades_prop_account    ON trades (prop_account_id) WHERE prop_account_id IS NOT NULL;
+CREATE INDEX trades_strategy        ON trades (strategy_id)     WHERE strategy_id IS NOT NULL;
+
+-- ============================================================
+-- TABLE: trading_sessions
+-- Daily journal entry — one row per trading day per user
+-- ============================================================
+
+CREATE TABLE trading_sessions (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id          uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  session_date     date NOT NULL,
+
+  -- Pre-session
+  pre_market_notes text,                         -- bias, key levels, news
+  mood_before      mood_rating,                  -- 1-5
+  plan             text,                         -- what you planned to do
+
+  -- Post-session
+  post_market_notes text,
+  mood_after        mood_rating,
+  lessons           text,                        -- what did you learn today
+  followed_plan     boolean,
+
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now(),
+
+  UNIQUE (user_id, session_date)                 -- one journal entry per day per user
+);
+
+ALTER TABLE trading_sessions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own trading_sessions"
+  ON trading_sessions FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER trading_sessions_updated_at
+  BEFORE UPDATE ON trading_sessions
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE INDEX trading_sessions_user_date ON trading_sessions (user_id, session_date DESC);


### PR DESCRIPTION
## Summary
Implements a comprehensive trading journal and strategy management system, allowing users to log trades, track prop account performance, manage trading strategies, and review daily trading sessions with detailed analytics.

## Key Changes

### Database Schema
- Added `prop_accounts` table to track funded/prop trading accounts across multiple firms (FundedNext, AlphaFutures, TakeProfitTrader, YRM)
- Added `strategies` table to define and manage trading strategies with instruments, timeframes, and rules
- Added `trades` table to log individual trades with execution details, P&L, setup tags, and emotional tracking
- Added `trading_session_journal` table for daily pre/post-market notes and mood tracking
- Defined enums for instruments (NQ, Gold, CL, 6E), trade outcomes, trading sessions, and mood ratings

### Components
- **TradeForm**: Multi-tab form (Execution/Context/Review) for creating and editing trades with validation, setup tag suggestions, and custom tag support
- **TradesList**: Filterable trade log with search, date range, instrument, outcome, and strategy filters; displays summary stats
- **TradeDetail**: Slide-in detail panel showing complete trade information with edit/delete actions
- **TradingAnalytics**: Dashboard with summary metrics (net P&L, win rate, profit factor), daily P&L chart, and per-instrument statistics
- **SessionJournal**: Daily trading journal with date navigation, pre/post-market notes, mood tracking, and plan adherence
- **PropAccountsView**: Manage prop trading accounts with balance tracking and profit target progress
- **StrategiesView**: Create and manage trading strategies with instrument/timeframe selection and tagging
- **TradingView**: Main container orchestrating all trading features with tab navigation

### API Layer
- `getTrades()`, `createTrade()`, `updateTrade()`, `deleteTrade()` for trade CRUD operations
- `getPropAccounts()`, `createPropAccount()`, `updatePropAccount()`, `deletePropAccount()` for account management
- `getStrategies()`, `createStrategy()`, `updateStrategy()`, `deleteStrategy()` for strategy management
- `getTradingSession()`, `upsertTradingSession()` for session journal persistence
- `computeTradeStats()` and `buildDailyPnl()` for analytics calculations

### Validation & Types
- Zod schemas for prop accounts, strategies, trades, and trading sessions with comprehensive validation
- TypeScript types for all trading entities with proper union types for enums
- Constants and labels for UI rendering (instruments, firms, sessions, outcomes)

### Notable Implementation Details
- Trade form uses tabs to organize execution details, context (setup tags, confluence), and review (emotions, lessons)
- Setup tags include preset suggestions (OB, FVG, BOS, CHOCH, etc.) with custom tag support
- Datetime conversion utilities handle local input ↔ ISO conversion for timezone-aware storage
- Analytics compute win rate, profit factor, and daily P&L progression
- Row-level security policies ensure users only access their own data
- Form state management with error tracking and server error handling

https://claude.ai/code/session_01HQRJC5VhiUs8cG36DoScfT