### PR TITLE
feat: add inline edit/delete to book and project list cards

### DIFF
--- a/src/components/books/book-card.tsx
+++ b/src/components/books/book-card.tsx
@@ -2,12 +2,14 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { Star, BookOpen, CheckCircle2, XCircle, Clock } from "lucide-react";
+import { Star, BookOpen, CheckCircle2, XCircle, Clock, Pencil, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { Book } from "@/lib/types";
 
 interface BookCardProps {
   book: Book;
+  onEdit: (book: Book) => void;
+  onDelete: (id: string) => void;
 }
 
 const STATUS_CONFIG: Record<
@@ -36,13 +38,32 @@ const STATUS_CONFIG: Record<
   },
 };
 
-export function BookCard({ book }: BookCardProps) {
+export function BookCard({ book, onEdit, onDelete }: BookCardProps) {
   const statusCfg = STATUS_CONFIG[book.status];
   const StatusIcon = statusCfg.icon;
 
   return (
-    <Link href={`/books/${book.id}`} className="group">
-      <div className="flex gap-3 rounded-lg border bg-card p-4 transition-colors hover:bg-accent/40">
+    <div className="group relative rounded-lg border bg-card transition-colors hover:bg-accent/40">
+      {/* Action buttons — top-right, revealed on hover */}
+      <div className="absolute right-2 top-2 flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+        <button
+          onClick={() => onEdit(book)}
+          className="rounded p-1 text-muted-foreground hover:bg-background hover:text-foreground"
+          title="Edit"
+        >
+          <Pencil className="h-3.5 w-3.5" />
+        </button>
+        <button
+          onClick={() => onDelete(book.id)}
+          className="rounded p-1 text-muted-foreground hover:bg-background hover:text-destructive"
+          title="Delete"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {/* Clickable area navigates to detail */}
+      <Link href={`/books/${book.id}`} className="flex gap-3 p-4">
         {/* Cover image */}
         <div className="relative h-24 w-16 flex-shrink-0 overflow-hidden rounded">
           {book.cover_url ? (
@@ -63,9 +84,7 @@ export function BookCard({ book }: BookCardProps) {
 
         {/* Info */}
         <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <p className="truncate font-medium leading-tight group-hover:text-accent-foreground">
-            {book.title}
-          </p>
+          <p className="truncate pr-12 font-medium leading-tight">{book.title}</p>
           {book.author && (
             <p className="truncate text-sm text-muted-foreground">{book.author}</p>
           )}
@@ -90,7 +109,7 @@ export function BookCard({ book }: BookCardProps) {
             )}
           </div>
         </div>
-      </div>
-    </Link>
+      </Link>
+    </div>
   );
 }

--- a/src/components/books/books-view.tsx
+++ b/src/components/books/books-view.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { BookCard } from "./book-card";
 import { BookForm } from "./book-form";
 import { createClient } from "@/lib/supabase/client";
-import { createBook } from "@/lib/supabase/books";
+import { createBook, updateBook, deleteBook } from "@/lib/supabase/books";
 import type { Book } from "@/lib/types";
 import type { BookFormData } from "@/lib/validations/books";
 
@@ -28,6 +28,7 @@ export function BooksView({ initialBooks }: BooksViewProps) {
   const [books, setBooks] = useState<Book[]>(initialBooks);
   const [filter, setFilter] = useState<FilterStatus>("all");
   const [formOpen, setFormOpen] = useState(false);
+  const [editingBook, setEditingBook] = useState<Book | undefined>();
   const router = useRouter();
 
   const filtered =
@@ -39,10 +40,33 @@ export function BooksView({ initialBooks }: BooksViewProps) {
     done: books.filter((b) => b.status === "done").length,
   };
 
-  async function handleCreate(data: BookFormData) {
+  function openCreate() {
+    setEditingBook(undefined);
+    setFormOpen(true);
+  }
+
+  function openEdit(book: Book) {
+    setEditingBook(book);
+    setFormOpen(true);
+  }
+
+  async function handleSubmit(data: BookFormData) {
     const supabase = createClient();
-    const book = await createBook(supabase, data);
-    setBooks((prev) => [book, ...prev]);
+    if (editingBook) {
+      const updated = await updateBook(supabase, editingBook.id, data);
+      setBooks((prev) => prev.map((b) => (b.id === updated.id ? updated : b)));
+    } else {
+      const created = await createBook(supabase, data);
+      setBooks((prev) => [created, ...prev]);
+    }
+    router.refresh();
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm("Delete this book? This cannot be undone.")) return;
+    const supabase = createClient();
+    await deleteBook(supabase, id);
+    setBooks((prev) => prev.filter((b) => b.id !== id));
     router.refresh();
   }
 
@@ -58,7 +82,7 @@ export function BooksView({ initialBooks }: BooksViewProps) {
           </p>
         </div>
         <button
-          onClick={() => setFormOpen(true)}
+          onClick={openCreate}
           className="inline-flex items-center gap-1 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
         >
           <Plus className="h-4 w-4" />
@@ -91,12 +115,22 @@ export function BooksView({ initialBooks }: BooksViewProps) {
       ) : (
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {filtered.map((book) => (
-            <BookCard key={book.id} book={book} />
+            <BookCard
+              key={book.id}
+              book={book}
+              onEdit={openEdit}
+              onDelete={handleDelete}
+            />
           ))}
         </div>
       )}
 
-      <BookForm open={formOpen} onOpenChange={setFormOpen} onSubmit={handleCreate} />
+      <BookForm
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        book={editingBook}
+        onSubmit={handleSubmit}
+      />
     </div>
   );
 }

--- a/src/components/projects/project-card.tsx
+++ b/src/components/projects/project-card.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import Link from "next/link";
-import { CheckCircle2, Circle, Pause, XCircle } from "lucide-react";
+import { CheckCircle2, Circle, Pause, XCircle, Pencil, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { Project, ProjectTask } from "@/lib/types";
 
 interface ProjectCardProps {
   project: Project;
   tasks?: ProjectTask[];
+  onEdit: (project: Project) => void;
+  onDelete: (id: string) => void;
 }
 
 const STATUS_CONFIG: Record<
@@ -36,15 +38,34 @@ const STATUS_CONFIG: Record<
   },
 };
 
-export function ProjectCard({ project, tasks = [] }: ProjectCardProps) {
+export function ProjectCard({ project, tasks = [], onEdit, onDelete }: ProjectCardProps) {
   const statusCfg = STATUS_CONFIG[project.status];
   const StatusIcon = statusCfg.icon;
   const done = tasks.filter((t) => t.status === "done").length;
   const total = tasks.length;
 
   return (
-    <Link href={`/projects/${project.id}`} className="group">
-      <div className="rounded-lg border bg-card p-4 transition-colors hover:bg-accent/40">
+    <div className="group relative rounded-lg border bg-card transition-colors hover:bg-accent/40">
+      {/* Action buttons — top-right, revealed on hover */}
+      <div className="absolute right-2 top-2 flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+        <button
+          onClick={() => onEdit(project)}
+          className="rounded p-1 text-muted-foreground hover:bg-background hover:text-foreground"
+          title="Edit"
+        >
+          <Pencil className="h-3.5 w-3.5" />
+        </button>
+        <button
+          onClick={() => onDelete(project.id)}
+          className="rounded p-1 text-muted-foreground hover:bg-background hover:text-destructive"
+          title="Delete"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {/* Clickable area navigates to detail */}
+      <Link href={`/projects/${project.id}`} className="block p-4">
         <div className="flex items-start gap-3">
           {/* Color dot */}
           <div
@@ -53,9 +74,7 @@ export function ProjectCard({ project, tasks = [] }: ProjectCardProps) {
           />
 
           <div className="flex-1 min-w-0">
-            <p className="truncate font-medium group-hover:text-accent-foreground">
-              {project.name}
-            </p>
+            <p className="truncate pr-12 font-medium">{project.name}</p>
             {project.description && (
               <p className="mt-0.5 truncate text-sm text-muted-foreground">
                 {project.description}
@@ -91,7 +110,7 @@ export function ProjectCard({ project, tasks = [] }: ProjectCardProps) {
             )}
           </div>
         </div>
-      </div>
-    </Link>
+      </Link>
+    </div>
   );
 }

--- a/src/components/projects/projects-view.tsx
+++ b/src/components/projects/projects-view.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { ProjectCard } from "./project-card";
 import { ProjectForm } from "./project-form";
 import { createClient } from "@/lib/supabase/client";
-import { createProject } from "@/lib/supabase/projects";
+import { createProject, updateProject, deleteProject } from "@/lib/supabase/projects";
 import type { Project } from "@/lib/types";
 import type { ProjectFormData } from "@/lib/validations/projects";
 
@@ -28,6 +28,7 @@ export function ProjectsView({ initialProjects }: ProjectsViewProps) {
   const [projects, setProjects] = useState<Project[]>(initialProjects);
   const [filter, setFilter] = useState<FilterStatus>("active");
   const [formOpen, setFormOpen] = useState(false);
+  const [editingProject, setEditingProject] = useState<Project | undefined>();
   const router = useRouter();
 
   const filtered =
@@ -35,10 +36,33 @@ export function ProjectsView({ initialProjects }: ProjectsViewProps) {
 
   const active = projects.filter((p) => p.status === "active").length;
 
-  async function handleCreate(data: ProjectFormData) {
+  function openCreate() {
+    setEditingProject(undefined);
+    setFormOpen(true);
+  }
+
+  function openEdit(project: Project) {
+    setEditingProject(project);
+    setFormOpen(true);
+  }
+
+  async function handleSubmit(data: ProjectFormData) {
     const supabase = createClient();
-    const project = await createProject(supabase, data);
-    setProjects((prev) => [project, ...prev]);
+    if (editingProject) {
+      const updated = await updateProject(supabase, editingProject.id, data);
+      setProjects((prev) => prev.map((p) => (p.id === updated.id ? updated : p)));
+    } else {
+      const created = await createProject(supabase, data);
+      setProjects((prev) => [created, ...prev]);
+    }
+    router.refresh();
+  }
+
+  async function handleDelete(id: string) {
+    if (!confirm("Delete this project and all its tasks? This cannot be undone.")) return;
+    const supabase = createClient();
+    await deleteProject(supabase, id);
+    setProjects((prev) => prev.filter((p) => p.id !== id));
     router.refresh();
   }
 
@@ -53,7 +77,7 @@ export function ProjectsView({ initialProjects }: ProjectsViewProps) {
           </p>
         </div>
         <button
-          onClick={() => setFormOpen(true)}
+          onClick={openCreate}
           className="inline-flex items-center gap-1 rounded-md bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
         >
           <Plus className="h-4 w-4" />
@@ -86,12 +110,22 @@ export function ProjectsView({ initialProjects }: ProjectsViewProps) {
       ) : (
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {filtered.map((project) => (
-            <ProjectCard key={project.id} project={project} />
+            <ProjectCard
+              key={project.id}
+              project={project}
+              onEdit={openEdit}
+              onDelete={handleDelete}
+            />
           ))}
         </div>
       )}
 
-      <ProjectForm open={formOpen} onOpenChange={setFormOpen} onSubmit={handleCreate} />
+      <ProjectForm
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        project={editingProject}
+        onSubmit={handleSubmit}
+      />
     </div>
   );
 }


### PR DESCRIPTION
- BookCard: hover-reveal pencil + trash buttons (top-right corner)
- ProjectCard: same hover-reveal pattern
- BooksView: manages editingBook state; single BookForm handles both create and update; handleDelete removes from list optimistically
- ProjectsView: same pattern for projects + confirm before delete

https://claude.ai/code/session_013EcGFdZo8KqWdkyDpgPkAd