### PR TITLE
fix: fix prompt template causing JSON parse failure

### DIFF
--- a/src/app/api/ai/screenshot-analysis/route.ts
+++ b/src/app/api/ai/screenshot-analysis/route.ts
@@ -9,23 +9,22 @@ export const maxDuration = 30
 
 const EXTRACTION_PROMPT = `You are a professional futures trading chart analyzer. Analyze this trading chart screenshot and extract key trade details.
 
-Return ONLY a valid JSON object with this exact structure (no markdown, no explanation):
+Return ONLY a valid JSON object — no markdown, no code fences, no explanation. Example of the exact format to return:
 {
-  "instrument": { "value": "NQ" | "Gold" | "CL" | "6E" | null, "confidence": 0.0-1.0 },
-  "direction": { "value": "long" | "short" | null, "confidence": 0.0-1.0 },
-  "entry_price": { "value": <number> | null, "confidence": 0.0-1.0 },
-  "exit_price": { "value": <number> | null, "confidence": 0.0-1.0 },
-  "session": { "value": "london" | "new_york_am" | "new_york_pm" | "overnight" | "asia" | null, "confidence": 0.0-1.0 }
+  "instrument": { "value": "NQ", "confidence": 0.95 },
+  "direction": { "value": "long", "confidence": 0.9 },
+  "entry_price": { "value": 17234.5, "confidence": 0.85 },
+  "exit_price": { "value": 17289.0, "confidence": 0.8 },
+  "session": { "value": "new_york_am", "confidence": 0.75 }
 }
 
-Rules:
-- instrument: NQ = Nasdaq/MNQ futures, Gold = XAUUSD/GC/MGC, CL = Crude Oil, 6E = EUR/USD futures
-- direction: long if entry is below exit or arrow/label says BUY/LONG, short if entry is above exit or says SELL/SHORT
-- entry_price: the price where the trade was entered (look for entry markers, horizontal lines, order labels)
-- exit_price: the price where the trade was closed (look for exit markers, TP hit, SL hit, close labels)
-- session: based on time visible on chart — london=02:00-08:00 EST, new_york_am=08:00-12:00 EST, new_york_pm=12:00-17:00 EST, overnight=17:00-02:00 EST, asia=18:00-02:00 EST
-- confidence: 1.0 = certain, 0.8 = very likely, 0.5 = uncertain, 0.0 = cannot determine
-- Set value to null and confidence to 0.0 if you cannot determine a field
+Field rules:
+- instrument: one of "NQ" (Nasdaq/MNQ futures), "Gold" (XAUUSD/GC/MGC), "CL" (Crude Oil), "6E" (EUR/USD futures), or null
+- direction: "long" if BUY/LONG or entry below exit, "short" if SELL/SHORT or entry above exit, or null
+- entry_price: number where trade was entered (entry markers, horizontal lines, order labels), or null
+- exit_price: number where trade was closed (TP hit, SL hit, close labels), or null
+- session: "london" (02-08 EST), "new_york_am" (08-12 EST), "new_york_pm" (12-17 EST), "overnight" (17-02 EST), "asia" (18-02 EST), or null
+- confidence: 1.0 = certain, 0.8 = very likely, 0.5 = uncertain, 0.0 = cannot determine; use 0.0 and null when a field cannot be determined
 
 Return ONLY the JSON object, nothing else.`
 
@@ -56,27 +55,33 @@ export async function POST(req: Request) {
   const base64 = Buffer.from(bytes).toString('base64')
   const mimeType = file.type as 'image/jpeg' | 'image/png' | 'image/webp' | 'image/gif'
 
-  const result = await generateText({
-    model: google('gemini-1.5-flash-latest'),
-    messages: [
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'image',
-            image: base64,
-            mimeType,
-          },
-          {
-            type: 'text',
-            text: EXTRACTION_PROMPT,
-          },
-        ],
-      },
-    ],
-    maxOutputTokens: 512,
-    temperature: 0.1,
-  })
+  let result: Awaited<ReturnType<typeof generateText>>
+  try {
+    result = await generateText({
+      model: google('gemini-1.5-flash-latest'),
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image',
+              image: base64,
+              mimeType,
+            },
+            {
+              type: 'text',
+              text: EXTRACTION_PROMPT,
+            },
+          ],
+        },
+      ],
+      maxOutputTokens: 512,
+      temperature: 0.1,
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Gemini API error'
+    return Response.json({ error: msg }, { status: 502 })
+  }
 
   // Strip any markdown code fences Gemini may add, then extract the first JSON object
   const stripped = result.text.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '').trim()


### PR DESCRIPTION
The old prompt used | and 0.0-1.0 notation (invalid JSON syntax). Gemini was copying it literally, so JSON.parse always failed with 422. Replace with a concrete valid JSON example and add try/catch around generateText to surface API key/quota errors cleanly.