### PR TITLE
Convert AI Daily Brief to on-demand generation

### DIFF
--- a/src/components/dashboard/ai-daily-brief.tsx
+++ b/src/components/dashboard/ai-daily-brief.tsx
@@ -1,32 +1,29 @@
 'use client'
 
-// AI Daily Brief — loads async from Gemini via /api/ai/daily-brief
+// AI Daily Brief — on-demand generation via /api/ai/daily-brief
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { Sparkles, RefreshCw } from 'lucide-react'
 import { Skeleton } from '@/components/ui/skeleton'
 
+type Status = 'idle' | 'loading' | 'done' | 'error'
+
 export function AIDailyBrief() {
   const [brief, setBrief] = useState<string | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState(false)
+  const [status, setStatus] = useState<Status>('idle')
 
-  async function load() {
-    setLoading(true)
-    setError(false)
+  async function generate() {
+    setStatus('loading')
     try {
       const res = await fetch('/api/ai/daily-brief')
       if (!res.ok) throw new Error('bad response')
       const json = await res.json()
       setBrief(json.brief ?? null)
+      setStatus('done')
     } catch {
-      setError(true)
-    } finally {
-      setLoading(false)
+      setStatus('error')
     }
   }
-
-  useEffect(() => { load() }, [])
 
   return (
     <div className="rounded-xl border bg-card p-5 shadow-sm">
@@ -38,9 +35,9 @@ export function AIDailyBrief() {
           </p>
           <span className="text-[10px] text-muted-foreground/60 font-normal">Gemini</span>
         </div>
-        {!loading && (
+        {status === 'done' && (
           <button
-            onClick={load}
+            onClick={generate}
             className="rounded-md p-1.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
             title="Refresh brief"
           >
@@ -49,17 +46,34 @@ export function AIDailyBrief() {
         )}
       </div>
 
-      {loading ? (
+      {status === 'idle' && (
+        <div className="flex flex-col items-center gap-3 py-2">
+          <p className="text-sm text-muted-foreground">Your AI brief is ready to generate.</p>
+          <button
+            onClick={generate}
+            className="inline-flex items-center gap-1.5 rounded-md bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-700 transition-colors"
+          >
+            <Sparkles className="h-3.5 w-3.5" />
+            Generate Brief
+          </button>
+        </div>
+      )}
+
+      {status === 'loading' && (
         <div className="space-y-2">
           <Skeleton className="h-4 w-full" />
           <Skeleton className="h-4 w-5/6" />
           <Skeleton className="h-4 w-4/5" />
         </div>
-      ) : error || !brief ? (
+      )}
+
+      {status === 'error' && (
         <p className="text-sm text-muted-foreground italic">
           Unable to generate brief — check that GOOGLE_GENERATIVE_AI_API_KEY is set.
         </p>
-      ) : (
+      )}
+
+      {status === 'done' && brief && (
         <p className="text-sm leading-relaxed">{brief}</p>
       )}
     </div>


### PR DESCRIPTION
## Summary
Changed the AI Daily Brief component from automatically loading on mount to an on-demand generation model, giving users explicit control over when the brief is generated.

## Key Changes
- **Removed auto-load behavior**: Eliminated `useEffect` that automatically fetched the brief on component mount
- **Simplified state management**: Replaced separate `loading` and `error` boolean states with a single `status` state machine ('idle' | 'loading' | 'done' | 'error')
- **Added idle state UI**: New initial state displays a message and "Generate Brief" button, allowing users to trigger generation on-demand
- **Renamed function**: Changed `load()` to `generate()` to better reflect the on-demand nature
- **Improved conditional rendering**: Replaced nested ternary operators with explicit status checks for better readability

## Implementation Details
- The component now starts in an 'idle' state with a call-to-action button
- Refresh button only appears when a brief has been successfully generated (status === 'done')
- Error state is now explicitly handled with its own conditional block
- All four states (idle, loading, done, error) have distinct UI presentations

https://claude.ai/code/session_01Kn4HiAwZJ8SbWEXzHg8YYD