### PR TITLE
Refactor form reset logic to use useEffect hook

### DIFF
--- a/src/components/books/book-form.tsx
+++ b/src/components/books/book-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as Dialog from "@radix-ui/react-dialog";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { X } from "lucide-react";
 import { bookSchema, type BookFormData } from "@/lib/validations/books";
 import type { Book } from "@/lib/types";
@@ -52,11 +52,14 @@ export function BookForm({ open, onOpenChange, book, onSubmit }: BookFormProps) 
   const [errors, setErrors] = useState<Partial<Record<keyof BookFormData, string>>>({});
   const [submitting, setSubmitting] = useState(false);
 
-  function handleOpenChange(val: boolean) {
-    if (val) {
+  useEffect(() => {
+    if (open) {
       setForm(defaultForm(book));
       setErrors({});
     }
+  }, [open, book]);
+
+  function handleOpenChange(val: boolean) {
     onOpenChange(val);
   }
 

--- a/src/components/finance/debt-form.tsx
+++ b/src/components/finance/debt-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as Dialog from "@radix-ui/react-dialog";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { X } from "lucide-react";
 import { debtSchema, type DebtFormValues } from "@/lib/validations/finance";
 import type { Debt } from "@/lib/types";
@@ -45,11 +45,14 @@ export function DebtForm({ open, onOpenChange, debt, onSubmit }: DebtFormProps) 
   const [errors, setErrors] = useState<Partial<Record<keyof DebtFormValues, string>>>({});
   const [submitting, setSubmitting] = useState(false);
 
-  function handleOpenChange(val: boolean) {
-    if (val) {
+  useEffect(() => {
+    if (open) {
       setForm(debt ? fromDebt(debt) : defaultValues);
       setErrors({});
     }
+  }, [open, debt]);
+
+  function handleOpenChange(val: boolean) {
     onOpenChange(val);
   }
 

--- a/src/components/finance/expense-form.tsx
+++ b/src/components/finance/expense-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as Dialog from "@radix-ui/react-dialog";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { X } from "lucide-react";
 import {
   monthlyExpenseSchema,
@@ -53,11 +53,14 @@ export function ExpenseForm({
   >({});
   const [submitting, setSubmitting] = useState(false);
 
-  function handleOpenChange(val: boolean) {
-    if (val) {
+  useEffect(() => {
+    if (open) {
       setForm(expense ? fromExpense(expense) : defaultValues);
       setErrors({});
     }
+  }, [open, expense]);
+
+  function handleOpenChange(val: boolean) {
     onOpenChange(val);
   }
 

--- a/src/components/finance/payout-form.tsx
+++ b/src/components/finance/payout-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as Dialog from "@radix-ui/react-dialog";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { X } from "lucide-react";
 import {
   propPayoutSchema,
@@ -53,11 +53,14 @@ export function PayoutForm({
   >({});
   const [submitting, setSubmitting] = useState(false);
 
-  function handleOpenChange(val: boolean) {
-    if (val) {
+  useEffect(() => {
+    if (open) {
       setForm(payout ? fromPayout(payout) : { ...defaultValues, payout_date: todayStr() });
       setErrors({});
     }
+  }, [open, payout]);
+
+  function handleOpenChange(val: boolean) {
     onOpenChange(val);
   }
 

--- a/src/components/habits/habit-form.tsx
+++ b/src/components/habits/habit-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as Dialog from "@radix-ui/react-dialog";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { X } from "lucide-react";
 import { habitSchema, HABIT_COLORS, type HabitFormData } from "@/lib/validations/habit";
 import type { Habit } from "@/lib/types";
@@ -38,9 +38,8 @@ export function HabitForm({ open, onOpenChange, habit, onSubmit }: HabitFormProp
   const [errors, setErrors] = useState<Partial<Record<keyof HabitFormData, string>>>({});
   const [submitting, setSubmitting] = useState(false);
 
-  // Reset form when dialog opens
-  function handleOpenChange(val: boolean) {
-    if (val) {
+  useEffect(() => {
+    if (open) {
       setForm(
         habit
           ? {
@@ -54,6 +53,9 @@ export function HabitForm({ open, onOpenChange, habit, onSubmit }: HabitFormProp
       );
       setErrors({});
     }
+  }, [open, habit]);
+
+  function handleOpenChange(val: boolean) {
     onOpenChange(val);
   }
 

--- a/src/components/projects/project-form.tsx
+++ b/src/components/projects/project-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as Dialog from "@radix-ui/react-dialog";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { X } from "lucide-react";
 import { projectSchema, PROJECT_COLORS, type ProjectFormData } from "@/lib/validations/projects";
 import type { Project } from "@/lib/types";
@@ -42,11 +42,14 @@ export function ProjectForm({ open, onOpenChange, project, onSubmit }: ProjectFo
   const [errors, setErrors] = useState<Partial<Record<keyof ProjectFormData, string>>>({});
   const [submitting, setSubmitting] = useState(false);
 
-  function handleOpenChange(val: boolean) {
-    if (val) {
+  useEffect(() => {
+    if (open) {
       setForm(defaultForm(project));
       setErrors({});
     }
+  }, [open, project]);
+
+  function handleOpenChange(val: boolean) {
     onOpenChange(val);
   }
 

--- a/src/components/trading/prop-account-form.tsx
+++ b/src/components/trading/prop-account-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as Dialog from "@radix-ui/react-dialog";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { X } from "lucide-react";
 import {
   propAccountSchema,
@@ -60,12 +60,15 @@ export function PropAccountForm({ open, onClose, onSaved, initial }: Props) {
   const [saving, setSaving] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
 
-  function handleOpen(val: boolean) {
-    if (val) {
+  useEffect(() => {
+    if (open) {
       setForm(initial ? fromAccount(initial) : emptyForm());
       setErrors({});
       setServerError(null);
     }
+  }, [open, initial]);
+
+  function handleOpen(val: boolean) {
     if (!val) onClose();
   }
 

--- a/src/components/trading/strategy-form.tsx
+++ b/src/components/trading/strategy-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as Dialog from "@radix-ui/react-dialog";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { X } from "lucide-react";
 import {
   strategySchema,
@@ -57,13 +57,16 @@ export function StrategyForm({ open, onClose, onSaved, initial }: Props) {
   const [serverError, setServerError] = useState<string | null>(null);
   const [tagInput, setTagInput] = useState("");
 
-  function handleOpen(val: boolean) {
-    if (val) {
+  useEffect(() => {
+    if (open) {
       setForm(initial ? fromStrategy(initial) : emptyForm());
       setErrors({});
       setServerError(null);
       setTagInput("");
     }
+  }, [open, initial]);
+
+  function handleOpen(val: boolean) {
     if (!val) onClose();
   }
 

--- a/src/components/trading/trade-form.tsx
+++ b/src/components/trading/trade-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as Dialog from "@radix-ui/react-dialog";
-import { useState, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { X, Upload, Loader2, ImageIcon, CheckCircle2, AlertTriangle } from "lucide-react";
 import {
   tradeSchema,
@@ -160,8 +160,8 @@ export function TradeForm({ open, onClose, onSaved, initial, propAccounts, strat
   const [dragOver, setDragOver] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  function handleOpen(val: boolean) {
-    if (val) {
+  useEffect(() => {
+    if (open) {
       setForm(initial ? fromTrade(initial) : emptyForm());
       setErrors({});
       setServerError(null);
@@ -173,6 +173,9 @@ export function TradeForm({ open, onClose, onSaved, initial, propAccounts, strat
       setAiResult(null);
       setAiConfidence({});
     }
+  }, [open, initial]);
+
+  function handleOpen(val: boolean) {
     if (!val) onClose();
   }
 


### PR DESCRIPTION
## Summary
Refactored form initialization logic across all dialog-based form components to use the `useEffect` hook instead of handling reset logic inside the `handleOpenChange`/`handleOpen` callback. This improves code organization and ensures form state is properly synchronized with the dialog's open state.

## Key Changes
- Migrated form reset logic from `handleOpenChange`/`handleOpen` callbacks to `useEffect` hooks in 9 form components:
  - `habit-form.tsx`
  - `book-form.tsx`
  - `debt-form.tsx`
  - `expense-form.tsx`
  - `payout-form.tsx`
  - `project-form.tsx`
  - `prop-account-form.tsx`
  - `strategy-form.tsx`
  - `trade-form.tsx`

- Each `useEffect` hook:
  - Depends on the `open` prop and the item being edited (e.g., `habit`, `book`, `debt`, etc.)
  - Resets form state, clears validation errors, and clears server errors when the dialog opens
  - Runs whenever the dialog opens or the edited item changes

- Simplified `handleOpenChange`/`handleOpen` callbacks to only handle the `onOpenChange`/`onClose` callback invocation

## Implementation Details
- Added `useEffect` import to all modified components
- Form reset logic now runs as a side effect of the `open` prop changing, following React best practices
- Dependency arrays include both `open` and the item prop to ensure proper re-initialization when editing different items
- No changes to form submission logic or validation behavior

https://claude.ai/code/session_01NmvVbpzwWhB8Vwp3G1Sj2q