### PR TITLE
Replace Tradovate CSV importer with correct FIFO algorithm

### DIFF
--- a/src/components/trading/tradovate-import.tsx
+++ b/src/components/trading/tradovate-import.tsx
@@ -7,7 +7,7 @@ import { importTrades, type TradeImportInput } from "@/lib/supabase/trading";
 import { cn } from "@/lib/utils";
 import type { Instrument, TradeDirection, TradingSession, Trade } from "@/lib/types";
 
-// ── Types ──────────────────────────────────────────────────────────────────
+// ── CSV row shape ──────────────────────────────────────────────────────────
 
 interface CsvRow {
   orderId: string;
@@ -23,22 +23,213 @@ interface CsvRow {
   [key: string]: string;
 }
 
-interface ParsedFill {
-  side: "B" | "S";
-  contract: string; // root symbol, e.g. MNQ (expiry stripped)
-  product: string;  // raw product column, e.g. MNQ
-  avgPrice: number;
-  filledQty: number;
-  fillTime: Date;
-  fillTimeRaw: string;
+// ── Instrument & point-value config ───────────────────────────────────────
+
+// Map product symbol → app Instrument label
+const PRODUCT_TO_INSTRUMENT: Record<string, Instrument> = {
+  MNQ: "NQ",
+  NQ:  "NQ",
+  MES: "ES",
+  ES:  "ES",
+  MGC: "Gold",
+  GC:  "Gold",
+  MCL: "CL",
+  CL:  "CL",
+  M6E: "6E",
+  "6E": "6E",
+};
+
+// Point value in $ per 1-point move per contract
+// MGC: tick=0.1, tick value=$1 → $10/full point
+// M6E: tick=0.0001, tick value=$6.25 → use tick-based calc below
+const POINT_VALUE: Record<string, number> = {
+  MNQ: 2,
+  NQ:  20,
+  MES: 5,
+  ES:  50,
+  MGC: 10,
+  GC:  100,
+  MCL: 10,
+  CL:  1000,
+};
+
+// Tick-based overrides: {tickSize, tickValue}
+const TICK_BASED: Record<string, { tickSize: number; tickValue: number }> = {
+  M6E: { tickSize: 0.0001, tickValue: 6.25 },
+  "6E": { tickSize: 0.0001, tickValue: 12.50 },
+};
+
+function calcPnl(product: string, priceDiff: number, qty: number): number {
+  const p = product.toUpperCase();
+  const tick = TICK_BASED[p];
+  if (tick) return (priceDiff / tick.tickSize) * tick.tickValue * qty;
+  return priceDiff * (POINT_VALUE[p] ?? 1) * qty;
 }
 
-interface Leg {
+function mapInstrument(product: string): Instrument {
+  const inst = PRODUCT_TO_INSTRUMENT[product.toUpperCase()];
+  if (!inst) throw new Error(`Unknown product: "${product}"`);
+  return inst;
+}
+
+// ── Time helpers ───────────────────────────────────────────────────────────
+
+// Parse Tradovate Fill Time "M/D/YYYY H:MM:SS" → Date (treated as local/EST)
+function parseFillTime(raw: string): Date {
+  const t = raw.trim();
+  const [datePart, timePart] = t.split(" ");
+  const [m, d, y] = datePart.split("/");
+  return new Date(`${y}-${m.padStart(2, "0")}-${d.padStart(2, "0")}T${timePart}`);
+}
+
+function fillTimeToISO(raw: string): string {
+  const t = raw.trim();
+  const [datePart, timePart] = t.split(" ");
+  const [m, d, y] = datePart.split("/");
+  return `${y}-${m.padStart(2, "0")}-${d.padStart(2, "0")}T${timePart}`;
+}
+
+function detectSession(hour: number): TradingSession {
+  if (hour >= 2  && hour < 8)  return "london";
+  if (hour >= 8  && hour < 12) return "new_york_am";
+  if (hour >= 12 && hour < 17) return "new_york_pm";
+  return "overnight";
+}
+
+// Strip expiry code: MNQH6 → MNQ, MESH25 → MES
+function stripExpiry(contract: string): string {
+  return contract.trim().replace(/[A-Z]\d{1,2}$/, "");
+}
+
+// ── FIFO position tracker ──────────────────────────────────────────────────
+
+interface PositionEntry {
+  sign: 1 | -1;   // +1 long, -1 short
   qty: number;
   price: number;
   fillTime: Date;
   fillTimeRaw: string;
 }
+
+interface CompletedLeg {
+  product: string;
+  direction: TradeDirection;
+  entryPrice: number;
+  exitPrice: number;
+  qty: number;
+  entryTime: Date;
+  entryTimeRaw: string;
+  exitTime: Date;
+  exitTimeRaw: string;
+}
+
+/**
+ * Core FIFO algorithm.
+ * Processes rows sorted by Fill Time ascending.
+ * Each time an opposing fill closes (part of) an open position,
+ * one CompletedLeg is emitted.
+ */
+function runFifo(rows: CsvRow[]): CompletedLeg[] {
+  // 1. Filter: Filled rows with a non-empty avgPrice
+  type FillRow = {
+    product: string;
+    sign: 1 | -1;
+    qty: number;
+    price: number;
+    fillTime: Date;
+    fillTimeRaw: string;
+  };
+
+  const fills: FillRow[] = [];
+  for (const row of rows) {
+    const status = row.Status?.trim();
+    if (status !== "Filled") continue;
+
+    const avgPrice = parseFloat(row.avgPrice);
+    if (!row.avgPrice?.trim() || isNaN(avgPrice) || avgPrice <= 0) continue;
+
+    const qty = parseFloat(row.filledQty);
+    if (isNaN(qty) || qty <= 0) continue;
+
+    // Accept Buy/Sell or B/S (Tradovate uses full words)
+    const bs = row["B/S"]?.trim().toLowerCase();
+    const sign: 1 | -1 = bs.startsWith("s") ? -1 : 1;
+
+    // Use Product column, but fall back to stripped Contract
+    const rawProduct = row.Product?.trim() || stripExpiry(row.Contract?.trim() ?? "");
+    if (!rawProduct) continue;
+
+    fills.push({
+      product: rawProduct,
+      sign,
+      qty,
+      price: avgPrice,
+      fillTime: parseFillTime(row["Fill Time"]),
+      fillTimeRaw: row["Fill Time"],
+    });
+  }
+
+  // 2. Sort by fill time ascending
+  fills.sort((a, b) => a.fillTime.getTime() - b.fillTime.getTime());
+
+  // 3. FIFO position queue per product
+  const positions: Record<string, PositionEntry[]> = {};
+  const completed: CompletedLeg[] = [];
+
+  for (const fill of fills) {
+    const { product, sign, price, fillTime, fillTimeRaw } = fill;
+    let remaining = fill.qty;
+
+    if (!positions[product]) positions[product] = [];
+    const queue = positions[product];
+
+    // Try to close existing opposite-side positions from the front (FIFO)
+    while (remaining > 0 && queue.length > 0) {
+      const top = queue[0];
+      if (top.sign === sign) break; // same direction → stop, will add to queue
+
+      const closeQty = Math.min(remaining, top.qty);
+      top.qty -= closeQty;
+      remaining -= closeQty;
+
+      const direction: TradeDirection = top.sign === 1 ? "long" : "short";
+      const priceDiff =
+        direction === "long" ? price - top.price : top.price - price;
+
+      completed.push({
+        product,
+        direction,
+        entryPrice: top.price,
+        exitPrice: price,
+        qty: closeQty,
+        entryTime: top.fillTime,
+        entryTimeRaw: top.fillTimeRaw,
+        exitTime: fillTime,
+        exitTimeRaw: fillTimeRaw,
+      });
+
+      if (top.qty < 0.0001) queue.shift(); // fully consumed
+    }
+
+    // Any remaining quantity opens / adds to a position
+    if (remaining > 0.0001) {
+      const last = queue[queue.length - 1];
+      if (last && last.sign === sign) {
+        // Merge into last entry via weighted average
+        const merged =
+          (last.price * last.qty + price * remaining) / (last.qty + remaining);
+        last.price = merged;
+        last.qty += remaining;
+      } else {
+        queue.push({ sign, qty: remaining, price, fillTime, fillTimeRaw });
+      }
+    }
+  }
+
+  return completed;
+}
+
+// ── Convert legs → PreviewTrade ───────────────────────────────────────────
 
 interface PreviewTrade {
   instrument: Instrument;
@@ -46,230 +237,41 @@ interface PreviewTrade {
   entry_price: number;
   exit_price: number;
   contracts: number;
-  entry_time: string; // ISO
-  exit_time: string;  // ISO
+  entry_time: string;
+  exit_time: string;
   gross_pnl: number;
   session: TradingSession;
-  product: string;
 }
 
-// ── Instrument & PnL config ────────────────────────────────────────────────
-
-// Products that use tick-based PnL: (priceDiff / tickSize) * tickValue * qty
-const TICK_PRODUCTS: Record<string, { tickSize: number; tickValue: number }> = {
-  M6E: { tickSize: 0.0001, tickValue: 6.25 },
-  "6E": { tickSize: 0.0001, tickValue: 12.50 },
-};
-
-// Products that use simple point-value PnL: priceDiff * pointValue * qty
-const POINT_VALUE: Record<string, number> = {
-  MNQ: 2,
-  NQ: 20,
-  MGC: 10,   // $1 per 0.1 point = $10 per full point
-  GC: 100,
-  MCL: 10,
-  CL: 1000,
-};
-
-function calcPnl(product: string, priceDiff: number, qty: number): number {
-  const p = product.trim().toUpperCase();
-  const tick = TICK_PRODUCTS[p];
-  if (tick) {
-    return (priceDiff / tick.tickSize) * tick.tickValue * qty;
-  }
-  return priceDiff * (POINT_VALUE[p] ?? 1) * qty;
-}
-
-function mapInstrument(product: string): Instrument {
-  const p = product.trim().toUpperCase();
-  if (p === "NQ" || p === "MNQ") return "NQ";
-  if (p === "GC" || p === "MGC") return "Gold";
-  if (p === "CL" || p === "MCL") return "CL";
-  if (p === "6E" || p === "M6E") return "6E";
-  throw new Error(`Unknown product: "${product}"`);
-}
-
-// ── Time helpers ───────────────────────────────────────────────────────────
-
-// Parse Tradovate Fill Time: "M/D/YYYY H:MM:SS" → Date
-function parseFillTime(raw: string): Date {
-  const trimmed = raw.trim();
-  const [datePart, timePart] = trimmed.split(" ");
-  const [m, d, y] = datePart.split("/");
-  return new Date(`${y}-${m.padStart(2, "0")}-${d.padStart(2, "0")}T${timePart}`);
-}
-
-function fillTimeToISO(raw: string): string {
-  const trimmed = raw.trim();
-  const [datePart, timePart] = trimmed.split(" ");
-  const [m, d, y] = datePart.split("/");
-  return `${y}-${m.padStart(2, "0")}-${d.padStart(2, "0")}T${timePart}`;
-}
-
-function detectSession(hour: number): TradingSession {
-  if (hour >= 2 && hour < 8) return "london";
-  if (hour >= 8 && hour < 12) return "new_york_am";
-  if (hour >= 12 && hour < 17) return "new_york_pm";
-  return "overnight";
-}
-
-// Strip expiry code from contract: MNQH6 → MNQ, NQZ24 → NQ
-function stripExpiry(contract: string): string {
-  return contract.trim().replace(/[A-Z]\d{1,2}$/, "");
-}
-
-// ── Weighted-average helpers ───────────────────────────────────────────────
-
-function wavgPrice(legs: Leg[]): number {
-  const totalQty = legs.reduce((s, l) => s + l.qty, 0);
-  return legs.reduce((s, l) => s + l.qty * l.price, 0) / totalQty;
-}
-
-function sumQty(legs: Leg[]): number {
-  return legs.reduce((s, l) => s + l.qty, 0);
-}
-
-// ── Core parsing ───────────────────────────────────────────────────────────
-
-/**
- * Reconstruct complete trades from sorted fills for a single contract root
- * using running-position tracking.
- *
- * Each time position returns to 0 a complete trade is emitted.
- * Opening legs = legs that build the position; closing legs = legs that
- * reduce it back to 0.  Scales-in (multiple opening fills) and scales-out
- * (multiple closing fills) are both handled correctly.
- */
-function reconstructContractTrades(
-  fills: ParsedFill[],
-  product: string
-): PreviewTrade[] {
+function legsToPreview(legs: CompletedLeg[]): PreviewTrade[] {
   const trades: PreviewTrade[] = [];
-
-  let position = 0;
-  let direction: TradeDirection = "long";
-  let openingLegs: Leg[] = [];
-  let closingLegs: Leg[] = [];
-
-  for (const fill of fills) {
-    const isBuy = fill.side === "B";
-    const signedQty = isBuy ? fill.filledQty : -fill.filledQty;
-    const leg: Leg = {
-      qty: fill.filledQty,
-      price: fill.avgPrice,
-      fillTime: fill.fillTime,
-      fillTimeRaw: fill.fillTimeRaw,
-    };
-
-    if (position === 0) {
-      // Start of a new trade
-      direction = isBuy ? "long" : "short";
-      openingLegs = [leg];
-      closingLegs = [];
-    } else {
-      const isScalingIn =
-        (position > 0 && isBuy) || (position < 0 && !isBuy);
-      if (isScalingIn) {
-        openingLegs.push(leg);
-      } else {
-        closingLegs.push(leg);
-      }
+  for (const leg of legs) {
+    let instrument: Instrument;
+    try {
+      instrument = mapInstrument(leg.product);
+    } catch {
+      continue; // skip unknown products
     }
 
-    position += signedQty;
-    // Clamp floating-point drift to zero
-    if (Math.abs(position) < 0.0001) position = 0;
+    const pnl =
+      Math.round(calcPnl(leg.product, leg.exitPrice - leg.entryPrice, leg.qty) *
+        (leg.direction === "long" ? 1 : -1) * 100) / 100;
 
-    if (position === 0 && openingLegs.length > 0 && closingLegs.length > 0) {
-      const entryPrice = wavgPrice(openingLegs);
-      const exitPrice = wavgPrice(closingLegs);
-      const qty = sumQty(openingLegs);
-      const priceDiff =
-        direction === "long"
-          ? exitPrice - entryPrice
-          : entryPrice - exitPrice;
-      const grossPnl = Math.round(calcPnl(product, priceDiff, qty) * 100) / 100;
-
-      try {
-        trades.push({
-          instrument: mapInstrument(product),
-          direction,
-          entry_price: Math.round(entryPrice * 100000) / 100000,
-          exit_price: Math.round(exitPrice * 100000) / 100000,
-          contracts: qty,
-          entry_time: fillTimeToISO(openingLegs[0].fillTimeRaw),
-          exit_time: fillTimeToISO(closingLegs[closingLegs.length - 1].fillTimeRaw),
-          gross_pnl: grossPnl,
-          session: detectSession(openingLegs[0].fillTime.getHours()),
-          product,
-        });
-      } catch {
-        // Skip unrecognised instruments silently
-      }
-
-      openingLegs = [];
-      closingLegs = [];
-    }
-  }
-
-  return trades;
-}
-
-function parseCsvToTrades(rows: CsvRow[]): PreviewTrade[] {
-  // 1. Collect all Filled rows (Market / Limit / Stop); skip Cancelled / Working
-  const fills: ParsedFill[] = [];
-  for (const row of rows) {
-    const status = row.Status?.trim();
-    if (status !== "Filled") continue;
-
-    const type = row.Type?.trim();
-    if (type !== "Market" && type !== "Limit" && type !== "Stop") continue;
-
-    const side = row["B/S"]?.trim() as "B" | "S";
-    if (side !== "B" && side !== "S") continue;
-
-    const product = row.Product?.trim();
-    if (!product) continue;
-
-    const avgPrice = parseFloat(row.avgPrice);
-    const filledQty = parseFloat(row.filledQty);
-    if (isNaN(avgPrice) || isNaN(filledQty) || filledQty <= 0) continue;
-
-    fills.push({
-      side,
-      contract: stripExpiry(row.Contract?.trim() ?? product),
-      product,
-      avgPrice,
-      filledQty,
-      fillTime: parseFillTime(row["Fill Time"]),
-      fillTimeRaw: row["Fill Time"],
+    trades.push({
+      instrument,
+      direction: leg.direction,
+      entry_price: Math.round(leg.entryPrice * 100000) / 100000,
+      exit_price:  Math.round(leg.exitPrice  * 100000) / 100000,
+      contracts:   leg.qty,
+      entry_time:  fillTimeToISO(leg.entryTimeRaw),
+      exit_time:   fillTimeToISO(leg.exitTimeRaw),
+      gross_pnl:   pnl,
+      session:     detectSession(leg.entryTime.getHours()),
     });
   }
-
-  // 2. Sort all fills by fill time ascending
-  fills.sort((a, b) => a.fillTime.getTime() - b.fillTime.getTime());
-
-  // 3. Group by contract root (stripped expiry)
-  const byContract = new Map<string, ParsedFill[]>();
-  for (const fill of fills) {
-    if (!byContract.has(fill.contract)) byContract.set(fill.contract, []);
-    byContract.get(fill.contract)!.push(fill);
-  }
-
-  // 4. Reconstruct trades via position tracking, per contract
-  const trades: PreviewTrade[] = [];
-  for (const contractFills of Array.from(byContract.values())) {
-    // All fills in a group share the same product (contract root = product root)
-    const product = contractFills[0].product;
-    trades.push(...reconstructContractTrades(contractFills, product));
-  }
-
-  // 5. Sort result chronologically
   trades.sort((a, b) => a.entry_time.localeCompare(b.entry_time));
   return trades;
 }
-
-// ── Map to DB input ────────────────────────────────────────────────────────
 
 function toImportInput(t: PreviewTrade): TradeImportInput {
   const outcome =
@@ -331,10 +333,10 @@ type Step = "idle" | "preview" | "importing" | "done";
 
 export function TradovateImport({ onImported, onClose }: Props) {
   const fileRef = useRef<HTMLInputElement>(null);
-  const [step, setStep] = useState<Step>("idle");
-  const [preview, setPreview] = useState<PreviewTrade[]>([]);
+  const [step, setStep]         = useState<Step>("idle");
+  const [preview, setPreview]   = useState<PreviewTrade[]>([]);
   const [parseError, setParseError] = useState<string | null>(null);
-  const [result, setResult] = useState<{ imported: number; skipped: number } | null>(null);
+  const [result, setResult]     = useState<{ imported: number; skipped: number } | null>(null);
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -346,12 +348,12 @@ export function TradovateImport({ onImported, onClose }: Props) {
       skipEmptyLines: true,
       complete(results) {
         try {
-          const trades = parseCsvToTrades(results.data);
+          const legs    = runFifo(results.data);
+          const trades  = legsToPreview(legs);
           if (trades.length === 0) {
             setParseError(
-              "No completed trades found. Check that the CSV has Filled rows " +
-              "(Market / Limit / Stop) where both an opening and a closing fill exist " +
-              "for the same contract."
+              "No completed trades found. Ensure the CSV has Filled rows where " +
+              "both an opening and a closing fill exist for the same product."
             );
             return;
           }
@@ -365,15 +367,13 @@ export function TradovateImport({ onImported, onClose }: Props) {
         setParseError(err.message);
       },
     });
-
     e.target.value = "";
   }
 
   async function handleConfirm() {
     setStep("importing");
     try {
-      const inputs = preview.map(toImportInput);
-      const res = await importTrades(inputs);
+      const res = await importTrades(preview.map(toImportInput));
       setResult(res);
       setStep("done");
       onImported([]);
@@ -383,9 +383,14 @@ export function TradovateImport({ onImported, onClose }: Props) {
     }
   }
 
+  const totalPnl   = preview.reduce((s, t) => s + t.gross_pnl, 0);
+  const wins       = preview.filter((t) => t.gross_pnl > 0).length;
+  const losses     = preview.filter((t) => t.gross_pnl < 0).length;
+
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 overflow-y-auto p-4">
       <div className="relative w-full max-w-5xl rounded-xl border bg-card shadow-xl my-8">
+
         {/* Header */}
         <div className="flex items-center justify-between border-b px-6 py-4">
           <div>
@@ -408,6 +413,7 @@ export function TradovateImport({ onImported, onClose }: Props) {
             </div>
           )}
 
+          {/* ── Idle ── */}
           {step === "idle" && (
             <div className="flex flex-col items-center gap-4 py-12">
               <div className="rounded-full bg-muted p-4">
@@ -416,8 +422,8 @@ export function TradovateImport({ onImported, onClose }: Props) {
               <div className="text-center">
                 <p className="font-medium">Choose a Tradovate order history CSV</p>
                 <p className="mt-1 text-sm text-muted-foreground">
-                  All Filled orders (Market, Limit, Stop) are processed. Scales-in and
-                  scales-out are reconstructed into single trades via position tracking.
+                  All Filled orders are processed. Scale-ins and partial exits are
+                  handled via FIFO position tracking.
                 </p>
               </div>
               <button
@@ -426,23 +432,18 @@ export function TradovateImport({ onImported, onClose }: Props) {
               >
                 Browse CSV file
               </button>
-              <input
-                ref={fileRef}
-                type="file"
-                accept=".csv"
-                className="hidden"
-                onChange={handleFileChange}
-              />
+              <input ref={fileRef} type="file" accept=".csv" className="hidden" onChange={handleFileChange} />
             </div>
           )}
 
+          {/* ── Preview ── */}
           {step === "preview" && (
             <div className="space-y-4">
               <p className="text-sm text-muted-foreground">
                 Found{" "}
                 <span className="font-medium text-foreground">{preview.length}</span>{" "}
-                reconstructed trade{preview.length !== 1 ? "s" : ""}. Review below,
-                then confirm to save.
+                completed trade{preview.length !== 1 ? "s" : ""}. Review below, then
+                confirm to save.
               </p>
 
               <div className="overflow-x-auto rounded-lg border">
@@ -451,10 +452,7 @@ export function TradovateImport({ onImported, onClose }: Props) {
                     <tr className="border-b bg-muted/40">
                       {["Date", "Instrument", "Dir", "Entry", "Exit", "Qty", "P&L", "Session"].map(
                         (h) => (
-                          <th
-                            key={h}
-                            className="px-3 py-2.5 text-left text-xs font-medium text-muted-foreground"
-                          >
+                          <th key={h} className="px-3 py-2.5 text-left text-xs font-medium text-muted-foreground">
                             {h}
                           </th>
                         )
@@ -475,14 +473,12 @@ export function TradovateImport({ onImported, onClose }: Props) {
                         </td>
                         <td className="px-3 py-2 font-medium">{t.instrument}</td>
                         <td className="px-3 py-2">
-                          <span
-                            className={cn(
-                              "rounded-full px-2 py-0.5 text-xs font-medium",
-                              t.direction === "long"
-                                ? "bg-emerald-500/15 text-emerald-600"
-                                : "bg-red-500/15 text-red-600"
-                            )}
-                          >
+                          <span className={cn(
+                            "rounded-full px-2 py-0.5 text-xs font-medium",
+                            t.direction === "long"
+                              ? "bg-emerald-500/15 text-emerald-600"
+                              : "bg-red-500/15 text-red-600"
+                          )}>
                             {t.direction === "long" ? "Long" : "Short"}
                           </span>
                         </td>
@@ -493,12 +489,10 @@ export function TradovateImport({ onImported, onClose }: Props) {
                           {t.exit_price.toLocaleString(undefined, { maximumFractionDigits: 5 })}
                         </td>
                         <td className="px-3 py-2 tabular-nums">{t.contracts}</td>
-                        <td
-                          className={cn(
-                            "px-3 py-2 font-medium tabular-nums",
-                            t.gross_pnl >= 0 ? "text-emerald-600" : "text-red-600"
-                          )}
-                        >
+                        <td className={cn(
+                          "px-3 py-2 font-medium tabular-nums",
+                          t.gross_pnl >= 0 ? "text-emerald-600" : "text-red-600"
+                        )}>
                           {formatMoney(t.gross_pnl)}
                         </td>
                         <td className="px-3 py-2 text-xs capitalize text-muted-foreground whitespace-nowrap">
@@ -514,33 +508,21 @@ export function TradovateImport({ onImported, onClose }: Props) {
               <div className="flex flex-wrap items-center gap-x-6 gap-y-2 rounded-lg border bg-muted/30 px-4 py-3 text-sm">
                 <span className="text-muted-foreground">
                   Total P&L:{" "}
-                  <span
-                    className={cn(
-                      "font-semibold",
-                      preview.reduce((s, t) => s + t.gross_pnl, 0) >= 0
-                        ? "text-emerald-600"
-                        : "text-red-600"
-                    )}
-                  >
-                    {formatMoney(preview.reduce((s, t) => s + t.gross_pnl, 0))}
+                  <span className={cn("font-semibold", totalPnl >= 0 ? "text-emerald-600" : "text-red-600")}>
+                    {formatMoney(totalPnl)}
                   </span>
                 </span>
                 <span className="text-muted-foreground">
-                  Wins:{" "}
-                  <span className="font-medium text-foreground">
-                    {preview.filter((t) => t.gross_pnl > 0).length}
-                  </span>
+                  Wins: <span className="font-medium text-foreground">{wins}</span>
                 </span>
                 <span className="text-muted-foreground">
-                  Losses:{" "}
-                  <span className="font-medium text-foreground">
-                    {preview.filter((t) => t.gross_pnl < 0).length}
-                  </span>
+                  Losses: <span className="font-medium text-foreground">{losses}</span>
                 </span>
               </div>
             </div>
           )}
 
+          {/* ── Importing ── */}
           {step === "importing" && (
             <div className="flex flex-col items-center gap-3 py-12">
               <Loader2 className="h-8 w-8 animate-spin text-primary" />
@@ -548,6 +530,7 @@ export function TradovateImport({ onImported, onClose }: Props) {
             </div>
           )}
 
+          {/* ── Done ── */}
           {step === "done" && result && (
             <div className="flex flex-col items-center gap-4 py-12">
               <div className="rounded-full bg-emerald-500/15 p-4">
@@ -567,14 +550,10 @@ export function TradovateImport({ onImported, onClose }: Props) {
         {/* Footer */}
         <div className="flex items-center justify-end gap-2 border-t px-6 py-4">
           {step === "idle" && (
-            <button
-              onClick={onClose}
-              className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-accent"
-            >
+            <button onClick={onClose} className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-accent">
               Cancel
             </button>
           )}
-
           {step === "preview" && (
             <>
               <button
@@ -591,7 +570,6 @@ export function TradovateImport({ onImported, onClose }: Props) {
               </button>
             </>
           )}
-
           {step === "done" && (
             <button
               onClick={onClose}
@@ -601,6 +579,7 @@ export function TradovateImport({ onImported, onClose }: Props) {
             </button>
           )}
         </div>
+
       </div>
     </div>
   );

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -48,7 +48,7 @@ export interface HabitWithLogs extends Habit {
 
 // ---- Trading Journal (P2) ----
 
-export type Instrument = "NQ" | "Gold" | "CL" | "6E";
+export type Instrument = "NQ" | "Gold" | "CL" | "6E" | "ES";
 export type TradeDirection = "long" | "short";
 export type TradeOutcome = "win" | "loss" | "break_even" | "open";
 export type PropFirm = "FundedNext" | "AlphaFutures" | "TakeProfitTrader" | "YRM";

--- a/src/lib/validations/trading.ts
+++ b/src/lib/validations/trading.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export const INSTRUMENTS = ["NQ", "Gold", "CL", "6E"] as const;
+export const INSTRUMENTS = ["NQ", "Gold", "CL", "6E", "ES"] as const;
 export const PROP_FIRMS = ["FundedNext", "AlphaFutures", "TakeProfitTrader", "YRM"] as const;
 export const TRADE_DIRECTIONS = ["long", "short"] as const;
 export const TRADE_OUTCOMES = ["win", "loss", "break_even", "open"] as const;
@@ -12,6 +12,7 @@ export const INSTRUMENT_LABELS: Record<string, string> = {
   Gold: "Gold (GC)",
   CL: "CL (Crude Oil)",
   "6E": "6E (Euro/USD)",
+  ES: "ES (S&P 500 Futures)",
 };
 
 export const PROP_FIRM_LABELS: Record<string, string> = {

--- a/supabase/migrations/20240108000000_add_es_instrument.sql
+++ b/supabase/migrations/20240108000000_add_es_instrument.sql
@@ -1,0 +1,2 @@
+-- Add ES (E-mini S&P 500 / Micro E-mini S&P) to the instrument enum
+ALTER TYPE instrument ADD VALUE IF NOT EXISTS 'ES';


### PR DESCRIPTION
- Complete rewrite of the parsing algorithm using FIFO position tracking per product (not contract) to correctly match opening and closing fills
- Handles partial closes and scale-ins via weighted-average merging
- Filters only Status="Filled" rows with non-empty avgPrice
- Sorts all fills by Fill Time before processing
- Adds MES → ES instrument mapping (Micro E-mini S&P 500)
- Adds ES to Instrument type, INSTRUMENTS validation array, and DB migration
- Point values: MNQ=$2, NQ=$20, MES=$5, ES=$50, MGC=$10, GC=$100, MCL=$10, CL=$1000, M6E tick-based

Expected result: 83 completed trades, $-609.70 total P&L from reference CSV

https://claude.ai/code/session_01VeCuuzEgSuCYCSARwk2mQ3