### PR TITLE
Fix import: fault-tolerant row-by-row fallback + surface real error m…

### DIFF
--- a/src/components/trading/tradovate-import.tsx
+++ b/src/components/trading/tradovate-import.tsx
@@ -378,7 +378,12 @@ export function TradovateImport({ onImported, onClose }: Props) {
       setStep("done");
       onImported([]);
     } catch (err) {
-      setParseError(err instanceof Error ? err.message : "Import failed");
+      // PostgrestError is a plain object (not Error instance) — handle both shapes
+      const msg =
+        err instanceof Error
+          ? err.message
+          : (err as { message?: string })?.message ?? "Import failed";
+      setParseError(msg);
       setStep("preview");
     }
   }

--- a/src/lib/supabase/trading.ts
+++ b/src/lib/supabase/trading.ts
@@ -253,13 +253,38 @@ export async function importTrades(inputs: TradeImportInput[]): Promise<ImportRe
     return { imported: 0, skipped: inputs.length };
   }
 
-  const { error } = await supabase
-    .from("trades")
-    .insert(toInsert.map((t) => ({ ...t, user_id: user.id })));
+  // Try bulk insert first (fast path)
+  const rows = toInsert.map((t) => ({ ...t, user_id: user.id }));
+  const { error: bulkError } = await supabase.from("trades").insert(rows);
 
-  if (error) throw error;
+  if (!bulkError) {
+    return { imported: toInsert.length, skipped: inputs.length - toInsert.length };
+  }
 
-  return { imported: toInsert.length, skipped: inputs.length - toInsert.length };
+  // Bulk failed — fall back to row-by-row so partial batches still succeed.
+  // This handles cases like unsupported enum values (e.g. 'ES' before migration).
+  let imported = 0;
+  const rowErrors: string[] = [];
+
+  for (const row of rows) {
+    const { error: rowError } = await supabase.from("trades").insert(row);
+    if (rowError) {
+      rowErrors.push(`${row.instrument} ${row.direction} @ ${row.entry_price}: ${rowError.message}`);
+    } else {
+      imported++;
+    }
+  }
+
+  const skipped = inputs.length - toInsert.length;
+
+  if (imported === 0) {
+    // Every row failed — surface the first error clearly
+    const detail = rowErrors[0] ?? bulkError.message;
+    throw new Error(`Import failed: ${detail}`);
+  }
+
+  // Partial success — return counts; caller can show skipped warning
+  return { imported, skipped: skipped + rowErrors.length };
 }
 
 // ============================================================


### PR DESCRIPTION
…essage

- importTrades: try bulk insert first; if it fails (e.g. ES enum not yet migrated), fall back to row-by-row so valid-instrument trades still save
- Component catch: PostgrestError is a plain object, not an Error instance; extract .message correctly so the real DB error is shown to the user

https://claude.ai/code/session_01VeCuuzEgSuCYCSARwk2mQ3