### PR TITLE
Auto-update account balance when trades are assigned

### DIFF
--- a/src/components/trading/trades-list.tsx
+++ b/src/components/trading/trades-list.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react";
 import { Plus, SlidersHorizontal, TrendingUp, TrendingDown, FileUp, CheckSquare } from "lucide-react";
 import { TradeForm } from "./trade-form";
 import { TradovateImport } from "./tradovate-import";
-import { getTrades, bulkUpdateTrades } from "@/lib/supabase/trading";
+import { getTrades, getPropAccounts, bulkUpdateTrades } from "@/lib/supabase/trading";
 import { INSTRUMENTS } from "@/lib/validations/trading";
 import { cn } from "@/lib/utils";
 import type { Trade, PropAccount, Strategy, Instrument, TradeOutcome } from "@/lib/types";
@@ -14,6 +14,7 @@ interface Props {
   propAccounts: PropAccount[];
   strategies: Strategy[];
   onTradesChange: (trades: Trade[]) => void;
+  onAccountsChange: (accounts: PropAccount[]) => void;
   onSelectTrade: (trade: Trade) => void;
 }
 
@@ -58,7 +59,7 @@ function OutcomeChip({ outcome }: { outcome: Trade["outcome"] }) {
   );
 }
 
-export function TradesList({ trades, propAccounts, strategies, onTradesChange, onSelectTrade }: Props) {
+export function TradesList({ trades, propAccounts, strategies, onTradesChange, onAccountsChange, onSelectTrade }: Props) {
   const [formOpen, setFormOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
@@ -87,8 +88,9 @@ export function TradesList({ trades, propAccounts, strategies, onTradesChange, o
   }
 
   async function handleImported() {
-    const refreshed = await getTrades();
-    onTradesChange(refreshed);
+    const [refreshedTrades, refreshedAccounts] = await Promise.all([getTrades(), getPropAccounts()]);
+    onTradesChange(refreshedTrades);
+    onAccountsChange(refreshedAccounts);
     setImportOpen(false);
   }
 
@@ -154,7 +156,8 @@ export function TradesList({ trades, propAccounts, strategies, onTradesChange, o
       if (bulkAccount !== "") patch.prop_account_id = bulkAccount || null;
       if (bulkStrategy !== "") patch.strategy_id = bulkStrategy || null;
       await bulkUpdateTrades(ids, patch);
-      // Reflect changes locally without a full re-fetch
+      // Reflect trade changes locally + refresh account balances from server
+      const refreshedAccounts = await getPropAccounts();
       onTradesChange(
         trades.map((t) =>
           selectedIds.has(t.id)
@@ -172,6 +175,7 @@ export function TradesList({ trades, propAccounts, strategies, onTradesChange, o
             : t
         )
       );
+      onAccountsChange(refreshedAccounts);
       setSelectedIds(new Set());
       setBulkAccount("");
       setBulkStrategy("");

--- a/src/components/trading/trading-view.tsx
+++ b/src/components/trading/trading-view.tsx
@@ -63,6 +63,7 @@ export function TradingView({ initialTrades, initialAccounts, initialStrategies 
             propAccounts={accounts}
             strategies={strategies}
             onTradesChange={setTrades}
+            onAccountsChange={setAccounts}
             onSelectTrade={(t) => setSelectedTrade(t)}
           />
         )}

--- a/src/lib/supabase/trading.ts
+++ b/src/lib/supabase/trading.ts
@@ -216,14 +216,56 @@ export async function deleteTrade(id: string): Promise<void> {
   if (error) throw error;
 }
 
+/**
+ * Recomputes a prop account's balance as:
+ *   account_size + SUM(net_pnl of all trades assigned to it)
+ * Call this after any trade ↔ account assignment change.
+ */
+export async function recomputeAccountBalance(accountId: string): Promise<void> {
+  const supabase = createClient();
+
+  const [{ data: tradePnls, error: tradesErr }, { data: account, error: accountErr }] =
+    await Promise.all([
+      supabase.from("trades").select("net_pnl").eq("prop_account_id", accountId),
+      supabase.from("prop_accounts").select("account_size").eq("id", accountId).single(),
+    ]);
+
+  if (tradesErr) throw tradesErr;
+  if (accountErr) throw accountErr;
+
+  const totalPnl = (tradePnls ?? []).reduce((s, t) => s + (t.net_pnl ?? 0), 0);
+  const newBalance = (account.account_size ?? 0) + totalPnl;
+
+  const { error: updateErr } = await supabase
+    .from("prop_accounts")
+    .update({ balance: newBalance })
+    .eq("id", accountId);
+  if (updateErr) throw updateErr;
+}
+
 export async function bulkUpdateTrades(
   ids: string[],
   input: { prop_account_id?: string | null; strategy_id?: string | null }
 ): Promise<void> {
   if (ids.length === 0) return;
   const supabase = createClient();
+
+  // Collect old account IDs before the update so we can recompute those balances too
+  const accountsToRecompute = new Set<string>();
+  if ("prop_account_id" in input) {
+    const { data: before } = await supabase
+      .from("trades")
+      .select("prop_account_id")
+      .in("id", ids);
+    (before ?? []).forEach((t) => { if (t.prop_account_id) accountsToRecompute.add(t.prop_account_id); });
+    if (input.prop_account_id) accountsToRecompute.add(input.prop_account_id);
+  }
+
   const { error } = await supabase.from("trades").update(input).in("id", ids);
   if (error) throw error;
+
+  // Recompute balances for all affected accounts
+  await Promise.all(Array.from(accountsToRecompute).map(recomputeAccountBalance));
 }
 
 export type TradeImportInput = Omit<
@@ -268,6 +310,7 @@ export async function importTrades(inputs: TradeImportInput[]): Promise<ImportRe
   const { error: bulkError } = await supabase.from("trades").insert(rows);
 
   if (!bulkError) {
+    await recomputeAffectedAccounts(toInsert);
     return { imported: toInsert.length, skipped: inputs.length - toInsert.length };
   }
 
@@ -293,8 +336,14 @@ export async function importTrades(inputs: TradeImportInput[]): Promise<ImportRe
     throw new Error(`Import failed: ${detail}`);
   }
 
-  // Partial success — return counts; caller can show skipped warning
+  // Partial success — recompute accounts and return counts
+  await recomputeAffectedAccounts(toInsert);
   return { imported, skipped: skipped + rowErrors.length };
+}
+
+function recomputeAffectedAccounts(inputs: TradeImportInput[]): Promise<void[]> {
+  const ids = Array.from(new Set(inputs.map((t) => t.prop_account_id).filter(Boolean))) as string[];
+  return Promise.all(ids.map(recomputeAccountBalance));
 }
 
 // ============================================================


### PR DESCRIPTION
- recomputeAccountBalance(accountId): fetches all net_pnl for trades in that account, sets balance = account_size + sum(net_pnl) — drift-free recompute
- bulkUpdateTrades: fetches old prop_account_ids before the update, then runs recompute for every affected account (old + new) in parallel
- importTrades: calls recomputeAffectedAccounts after any successful insert, covering both bulk-insert and row-by-row fallback paths
- TradesList: adds onAccountsChange prop; after bulk apply and after import both call getPropAccounts() and push refreshed accounts up
- TradingView: passes setAccounts as onAccountsChange so the Accounts tab immediately reflects updated balances without a page reload

https://claude.ai/code/session_01VeCuuzEgSuCYCSARwk2mQ3