### PR TITLE
Refactor Tradovate import to use Position_History.csv format

### DIFF
--- a/src/components/trading/tradovate-import.tsx
+++ b/src/components/trading/tradovate-import.tsx
@@ -5,313 +5,260 @@ import Papa from "papaparse";
 import { Upload, X, CheckCircle, AlertCircle, Loader2 } from "lucide-react";
 import { importTrades, type TradeImportInput } from "@/lib/supabase/trading";
 import { cn } from "@/lib/utils";
-import type { Instrument, TradeDirection, TradingSession, Trade, PropAccount, Strategy } from "@/lib/types";
+import type {
+  Instrument,
+  TradeDirection,
+  TradingSession,
+  Trade,
+  PropAccount,
+  Strategy,
+} from "@/lib/types";
 
-// ── CSV row shape ──────────────────────────────────────────────────────────
+// ── CSV row shape (Position_History.csv) ───────────────────────────────────
 
 interface CsvRow {
-  orderId: string;
-  "B/S": string;
+  "Position ID": string;
+  Timestamp: string;
+  "Trade Date": string;
+  "Net Pos": string;
+  "Net Price": string;
+  Bought: string;
+  "Avg. Buy": string;
+  Sold: string;
+  "Avg. Sell": string;
+  Account: string;
   Contract: string;
   Product: string;
-  avgPrice: string;
-  filledQty: string;
-  "Fill Time": string;
-  Status: string;
-  Text: string;
-  Type: string;
+  "Product Description": string;
+  _priceFormat: string;
+  _priceFormatType: string;
+  _tickSize: string;
+  "Pair ID": string;
+  "Buy Fill ID": string;
+  "Sell Fill ID": string;
+  "Paired Qty": string;
+  "Buy Price": string;
+  "Sell Price": string;
+  "P/L": string;
+  Currency: string;
+  "Bought Timestamp": string;
+  "Sold Timestamp": string;
   [key: string]: string;
 }
 
-// ── Instrument & point-value config ───────────────────────────────────────
+// ── Product → Instrument mapping ───────────────────────────────────────────
 
-// Map product symbol → app Instrument label
 const PRODUCT_TO_INSTRUMENT: Record<string, Instrument> = {
   MNQ: "NQ",
-  NQ:  "NQ",
+  NQ: "NQ",
   MES: "ES",
-  ES:  "ES",
+  ES: "ES",
   MGC: "Gold",
-  GC:  "Gold",
+  GC: "Gold",
   MCL: "CL",
-  CL:  "CL",
+  CL: "CL",
   M6E: "6E",
   "6E": "6E",
 };
 
-// Point value in $ per 1-point move per contract
-// MGC: tick=0.1, tick value=$1 → $10/full point
-// M6E: tick=0.0001, tick value=$6.25 → use tick-based calc below
-const POINT_VALUE: Record<string, number> = {
-  MNQ: 2,
-  NQ:  20,
-  MES: 5,
-  ES:  50,
-  MGC: 10,
-  GC:  100,
-  MCL: 10,
-  CL:  1000,
+// ── Default commission rates (round-turn per contract) ─────────────────────
+
+export const DEFAULT_COMMISSIONS: Record<string, number> = {
+  MNQ: 0.75,
+  NQ: 2.8,
+  MES: 0.75,
+  ES: 2.8,
+  MGC: 1.05,
+  GC: 3.25,
+  MCL: 1.05,
+  CL: 3.05,
+  M6E: 0.52,
+  "6E": 0,
 };
 
-// Tick-based overrides: {tickSize, tickValue}
-const TICK_BASED: Record<string, { tickSize: number; tickValue: number }> = {
-  M6E: { tickSize: 0.0001, tickValue: 6.25 },
-  "6E": { tickSize: 0.0001, tickValue: 12.50 },
-};
-
-function calcPnl(product: string, priceDiff: number, qty: number): number {
-  const p = product.toUpperCase();
-  const tick = TICK_BASED[p];
-  if (tick) return (priceDiff / tick.tickSize) * tick.tickValue * qty;
-  return priceDiff * (POINT_VALUE[p] ?? 1) * qty;
-}
-
-function mapInstrument(product: string): Instrument {
-  const inst = PRODUCT_TO_INSTRUMENT[product.toUpperCase()];
-  if (!inst) throw new Error(`Unknown product: "${product}"`);
-  return inst;
-}
+const COMMISSION_PRODUCTS = [
+  "MNQ", "NQ",
+  "MES", "ES",
+  "MGC", "GC",
+  "MCL", "CL",
+  "M6E", "6E",
+];
 
 // ── Time helpers ───────────────────────────────────────────────────────────
 
-const CYPRUS_TZ = "Asia/Nicosia";  // Tradovate timestamps are in Cyprus time
-const NY_TZ      = "America/New_York";
+const CYPRUS_TZ = "Asia/Nicosia"; // Tradovate exports in Cyprus local time
 
 /**
- * Parse a Tradovate "M/D/YYYY H:MM:SS" timestamp (Cyprus local time)
+ * Parse a Tradovate "M/D/YYYY H:MM:SS" timestamp (Cyprus local time / EET = UTC+2)
  * and return the true UTC Date.
  *
- * Strategy: treat the raw string as if it were UTC (asUtc), ask Intl what
- * Cyprus local time that UTC moment corresponds to, compute the offset, then
- * subtract it so we get the real UTC for the given Cyprus local time.
- * sv-SE locale gives a stable "YYYY-MM-DD HH:MM:SS" format across all browsers.
+ * Strategy: treat the raw string as UTC first, ask Intl what Cyprus local time
+ * that UTC moment represents, compute the offset, then subtract it so we get
+ * the real UTC for the given Cyprus local wall-clock time.
  */
-function parseFillTime(raw: string): Date {
-  const t = raw.trim();
-  const [datePart, timePart] = t.split(" ");
-  const [m, d, y] = datePart.split("/");
-  const asUtc = new Date(`${y}-${m.padStart(2, "0")}-${d.padStart(2, "0")}T${timePart}Z`);
-  // What Cyprus says this UTC moment is (e.g. "2024-01-15 11:30:00" when UTC is 09:30)
-  const cyprusLocalStr = asUtc.toLocaleString("sv-SE", { timeZone: CYPRUS_TZ });
-  const cyprusMs = new Date(cyprusLocalStr.replace(" ", "T") + "Z").getTime();
-  const offsetMs = cyprusMs - asUtc.getTime(); // how many ms ahead Cyprus is
-  return new Date(asUtc.getTime() - offsetMs); // true UTC
+function parseCyprusTimestamp(raw: string): Date {
+  const t = raw?.trim();
+  if (!t) return new Date(NaN);
+  const spaceIdx = t.indexOf(" ");
+  if (spaceIdx === -1) return new Date(NaN);
+  const datePart = t.slice(0, spaceIdx);
+  const timePart = t.slice(spaceIdx + 1);
+  const parts = datePart.split("/");
+  if (parts.length !== 3) return new Date(NaN);
+  const [m, d, y] = parts;
+  const asUtc = new Date(
+    `${y}-${m.padStart(2, "0")}-${d.padStart(2, "0")}T${timePart}Z`
+  );
+  if (isNaN(asUtc.getTime())) return new Date(NaN);
+  // What Cyprus clock shows for this UTC moment
+  const cyprusStr = asUtc.toLocaleString("sv-SE", { timeZone: CYPRUS_TZ });
+  const cyprusMs = new Date(cyprusStr.replace(" ", "T") + "Z").getTime();
+  const offsetMs = cyprusMs - asUtc.getTime(); // how many ms Cyprus is ahead of UTC
+  return new Date(asUtc.getTime() - offsetMs);  // true UTC
 }
 
-/** Format a UTC Date as an ISO string in New York local time (no Z — stored as-is in timestamptz). */
-function toNYIso(d: Date): string {
-  // sv-SE gives "YYYY-MM-DD HH:MM:SS" in the requested timezone — reliable cross-browser
-  return d.toLocaleString("sv-SE", { timeZone: NY_TZ }).replace(" ", "T");
-}
-
+/**
+ * Detect trading session from the entry UTC time.
+ * Uses Cyprus local hour directly (EET = UTC+2 for March 2026).
+ *
+ * Boundaries in Cyprus local time:
+ *   09:00–15:00 → London
+ *   15:00–19:00 → New York AM
+ *   19:00–00:00 → New York PM
+ *   00:00–09:00 → Overnight / Asia
+ */
 function detectSession(utcDate: Date): TradingSession {
-  const nyHour = parseInt(
-    new Intl.DateTimeFormat("en-US", { timeZone: NY_TZ, hour: "numeric", hour12: false }).format(utcDate),
+  const h = parseInt(
+    new Intl.DateTimeFormat("en-US", {
+      timeZone: CYPRUS_TZ,
+      hour: "numeric",
+      hour12: false,
+    }).format(utcDate),
     10
   );
-  if (nyHour >= 2  && nyHour < 8)  return "london";
-  if (nyHour >= 8  && nyHour < 12) return "new_york_am";
-  if (nyHour >= 12 && nyHour < 17) return "new_york_pm";
+  if (h >= 9 && h < 15) return "london";
+  if (h >= 15 && h < 19) return "new_york_am";
+  if (h >= 19) return "new_york_pm";
   return "overnight";
 }
 
-// Strip expiry code: MNQH6 → MNQ, MESH25 → MES
-function stripExpiry(contract: string): string {
-  return contract.trim().replace(/[A-Z]\d{1,2}$/, "");
-}
-
-// ── FIFO position tracker ──────────────────────────────────────────────────
-
-interface PositionEntry {
-  sign: 1 | -1;   // +1 long, -1 short
-  qty: number;
-  price: number;
-  fillTime: Date; // UTC
-}
-
-interface CompletedLeg {
-  product: string;
-  direction: TradeDirection;
-  entryPrice: number;
-  exitPrice: number;
-  qty: number;
-  entryTime: Date; // UTC
-  exitTime: Date;  // UTC
-}
-
-/**
- * Core FIFO algorithm.
- * Processes rows sorted by Fill Time ascending.
- * Each time an opposing fill closes (part of) an open position,
- * one CompletedLeg is emitted.
- */
-function runFifo(rows: CsvRow[]): CompletedLeg[] {
-  // 1. Filter: Filled rows with a non-empty avgPrice
-  type FillRow = {
-    product: string;
-    sign: 1 | -1;
-    qty: number;
-    price: number;
-    fillTime: Date; // UTC
-  };
-
-  const fills: FillRow[] = [];
-  for (const row of rows) {
-    const status = row.Status?.trim();
-    if (status !== "Filled") continue;
-
-    const avgPrice = parseFloat(row.avgPrice);
-    if (!row.avgPrice?.trim() || isNaN(avgPrice) || avgPrice <= 0) continue;
-
-    const qty = parseFloat(row.filledQty);
-    if (isNaN(qty) || qty <= 0) continue;
-
-    // Accept Buy/Sell or B/S (Tradovate uses full words)
-    const bs = row["B/S"]?.trim().toLowerCase();
-    const sign: 1 | -1 = bs.startsWith("s") ? -1 : 1;
-
-    // Use Product column, but fall back to stripped Contract
-    const rawProduct = row.Product?.trim() || stripExpiry(row.Contract?.trim() ?? "");
-    if (!rawProduct) continue;
-
-    fills.push({
-      product: rawProduct,
-      sign,
-      qty,
-      price: avgPrice,
-      fillTime: parseFillTime(row["Fill Time"]), // → UTC
-    });
-  }
-
-  // 2. Sort by fill time ascending
-  fills.sort((a, b) => a.fillTime.getTime() - b.fillTime.getTime());
-
-  // 3. FIFO position queue per product
-  const positions: Record<string, PositionEntry[]> = {};
-  const completed: CompletedLeg[] = [];
-
-  for (const fill of fills) {
-    const { product, sign, price, fillTime } = fill;
-    let remaining = fill.qty;
-
-    if (!positions[product]) positions[product] = [];
-    const queue = positions[product];
-
-    // Try to close existing opposite-side positions from the front (FIFO)
-    while (remaining > 0 && queue.length > 0) {
-      const top = queue[0];
-      if (top.sign === sign) break; // same direction → stop, will add to queue
-
-      const closeQty = Math.min(remaining, top.qty);
-      top.qty -= closeQty;
-      remaining -= closeQty;
-
-      const direction: TradeDirection = top.sign === 1 ? "long" : "short";
-      const priceDiff =
-        direction === "long" ? price - top.price : top.price - price;
-
-      completed.push({
-        product,
-        direction,
-        entryPrice: top.price,
-        exitPrice: price,
-        qty: closeQty,
-        entryTime: top.fillTime,
-        exitTime: fillTime,
-      });
-
-      if (top.qty < 0.0001) queue.shift(); // fully consumed
-    }
-
-    // Any remaining quantity opens / adds to a position
-    if (remaining > 0.0001) {
-      const last = queue[queue.length - 1];
-      if (last && last.sign === sign) {
-        // Merge into last entry via weighted average
-        const merged =
-          (last.price * last.qty + price * remaining) / (last.qty + remaining);
-        last.price = merged;
-        last.qty += remaining;
-      } else {
-        queue.push({ sign, qty: remaining, price, fillTime });
-      }
-    }
-  }
-
-  return completed;
-}
-
-// ── Convert legs → PreviewTrade ───────────────────────────────────────────
+// ── Parse Position_History.csv rows → preview trades ──────────────────────
 
 interface PreviewTrade {
+  pair_id: string;
+  position_id: string;
+  product: string;
   instrument: Instrument;
   direction: TradeDirection;
   entry_price: number;
   exit_price: number;
-  contracts: number;
-  entry_time: string;
-  exit_time: string;
+  size: number;
   gross_pnl: number;
+  commission: number;
+  net_pnl: number;
+  entry_time: string; // UTC ISO
+  exit_time: string;  // UTC ISO
   session: TradingSession;
 }
 
-function legsToPreview(legs: CompletedLeg[]): PreviewTrade[] {
+function parsePositionHistory(
+  rows: CsvRow[],
+  commissionRates: Record<string, number>
+): PreviewTrade[] {
   const trades: PreviewTrade[] = [];
-  for (const leg of legs) {
-    let instrument: Instrument;
-    try {
-      instrument = mapInstrument(leg.product);
-    } catch {
-      continue; // skip unknown products
-    }
 
-    const pnl =
-      Math.round(calcPnl(leg.product, leg.exitPrice - leg.entryPrice, leg.qty) *
-        (leg.direction === "long" ? 1 : -1) * 100) / 100;
+  for (const row of rows) {
+    const boughtRaw = row["Bought Timestamp"]?.trim();
+    const soldRaw   = row["Sold Timestamp"]?.trim();
+    if (!boughtRaw || !soldRaw) continue;
+
+    const boughtTime = parseCyprusTimestamp(boughtRaw);
+    const soldTime   = parseCyprusTimestamp(soldRaw);
+    if (isNaN(boughtTime.getTime()) || isNaN(soldTime.getTime())) continue;
+
+    // Direction: earlier timestamp = entry
+    const isLong = boughtTime < soldTime;
+    const direction: TradeDirection = isLong ? "long" : "short";
+
+    const buyPrice  = parseFloat(row["Buy Price"]);
+    const sellPrice = parseFloat(row["Sell Price"]);
+    if (isNaN(buyPrice) || isNaN(sellPrice)) continue;
+
+    // LONG:  entry = Buy Price,  exit = Sell Price
+    // SHORT: entry = Sell Price, exit = Buy Price
+    const entryPrice = isLong ? buyPrice  : sellPrice;
+    const exitPrice  = isLong ? sellPrice : buyPrice;
+    const entryTime  = isLong ? boughtTime : soldTime;
+    const exitTime   = isLong ? soldTime   : boughtTime;
+
+    const grossPnl = parseFloat(row["P/L"]);
+    if (isNaN(grossPnl)) continue;
+
+    const pairedQty = parseInt(row["Paired Qty"], 10);
+    if (isNaN(pairedQty) || pairedQty <= 0) continue;
+
+    const product    = row["Product"]?.trim().toUpperCase();
+    const instrument = product ? PRODUCT_TO_INSTRUMENT[product] : undefined;
+    if (!instrument) continue;
+
+    const rate       = commissionRates[product] ?? 0;
+    const commission = Math.round(pairedQty * rate * 100) / 100;
+    const netPnl     = Math.round((grossPnl - commission) * 100) / 100;
 
     trades.push({
+      pair_id:     row["Pair ID"]?.trim()     ?? "",
+      position_id: row["Position ID"]?.trim() ?? "",
+      product,
       instrument,
-      direction: leg.direction,
-      entry_price: Math.round(leg.entryPrice * 100000) / 100000,
-      exit_price:  Math.round(leg.exitPrice  * 100000) / 100000,
-      contracts:   leg.qty,
-      entry_time:  toNYIso(leg.entryTime),
-      exit_time:   toNYIso(leg.exitTime),
-      gross_pnl:   pnl,
-      session:     detectSession(leg.entryTime),
+      direction,
+      entry_price: entryPrice,
+      exit_price:  exitPrice,
+      size:        pairedQty,
+      gross_pnl:   Math.round(grossPnl * 100) / 100,
+      commission,
+      net_pnl:     netPnl,
+      entry_time:  entryTime.toISOString(),
+      exit_time:   exitTime.toISOString(),
+      session:     detectSession(entryTime),
     });
   }
+
   trades.sort((a, b) => a.entry_time.localeCompare(b.entry_time));
   return trades;
 }
 
-function toImportInput(t: PreviewTrade): TradeImportInput {
+function toImportInput(
+  t: PreviewTrade,
+  overrides: { prop_account_id: string | null; strategy_id: string | null }
+): TradeImportInput {
   const outcome =
-    t.gross_pnl > 0 ? "win" : t.gross_pnl < 0 ? "loss" : "break_even";
+    t.net_pnl > 0 ? "win" : t.net_pnl < 0 ? "loss" : "break_even";
   return {
-    instrument: t.instrument,
-    direction: t.direction,
-    entry_price: t.entry_price,
-    exit_price: t.exit_price,
-    contracts: t.contracts,
-    entry_time: t.entry_time,
-    exit_time: t.exit_time,
-    gross_pnl: t.gross_pnl,
-    fees: 0,
+    instrument:       t.instrument,
+    direction:        t.direction,
+    entry_price:      t.entry_price,
+    exit_price:       t.exit_price,
+    contracts:        t.size,
+    entry_time:       t.entry_time,
+    exit_time:        t.exit_time,
+    gross_pnl:        t.gross_pnl,
+    fees:             t.commission,
     outcome,
-    session: t.session,
-    prop_account_id: null,
-    strategy_id: null,
-    setup_tags: null,
+    session:          t.session,
+    position_id:      t.position_id || null,
+    pair_id:          t.pair_id     || null,
+    prop_account_id:  overrides.prop_account_id,
+    strategy_id:      overrides.strategy_id,
+    setup_tags:       null,
     confluence_notes: null,
-    entry_notes: null,
-    exit_notes: null,
-    lessons: null,
-    screenshots: null,
-    pre_emotion: null,
-    post_emotion: null,
-    followed_rules: null,
-    is_reviewed: false,
+    entry_notes:      null,
+    exit_notes:       null,
+    lessons:          null,
+    screenshots:      null,
+    pre_emotion:      null,
+    post_emotion:     null,
+    followed_rules:   null,
+    is_reviewed:      false,
   };
 }
 
@@ -338,21 +285,37 @@ function formatDateTime(iso: string) {
 
 interface Props {
   propAccounts: PropAccount[];
-  strategies: Strategy[];
-  onImported: (newTrades: Trade[]) => void;
-  onClose: () => void;
+  strategies:   Strategy[];
+  onImported:   (newTrades: Trade[]) => void;
+  onClose:      () => void;
 }
 
 type Step = "idle" | "preview" | "importing" | "done";
 
-export function TradovateImport({ propAccounts, strategies, onImported, onClose }: Props) {
+export function TradovateImport({
+  propAccounts,
+  strategies,
+  onImported,
+  onClose,
+}: Props) {
   const fileRef = useRef<HTMLInputElement>(null);
-  const [step, setStep]         = useState<Step>("idle");
-  const [preview, setPreview]   = useState<PreviewTrade[]>([]);
-  const [parseError, setParseError] = useState<string | null>(null);
-  const [result, setResult]     = useState<{ imported: number; skipped: number } | null>(null);
-  const [selectedAccountId, setSelectedAccountId] = useState("");
+  const [step,        setStep]       = useState<Step>("idle");
+  const [preview,     setPreview]    = useState<PreviewTrade[]>([]);
+  const [parseError,  setParseError] = useState<string | null>(null);
+  const [result,      setResult]     = useState<{ imported: number; skipped: number } | null>(null);
+
+  // Commission rates — user can override in the upload screen
+  const [commissions, setCommissions] = useState<Record<string, number>>(
+    () => ({ ...DEFAULT_COMMISSIONS })
+  );
+
+  const [selectedAccountId,  setSelectedAccountId]  = useState("");
   const [selectedStrategyId, setSelectedStrategyId] = useState("");
+
+  function handleCommissionChange(product: string, raw: string) {
+    const val = parseFloat(raw);
+    setCommissions((prev) => ({ ...prev, [product]: isNaN(val) ? 0 : val }));
+  }
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -364,19 +327,20 @@ export function TradovateImport({ propAccounts, strategies, onImported, onClose 
       skipEmptyLines: true,
       complete(results) {
         try {
-          const legs    = runFifo(results.data);
-          const trades  = legsToPreview(legs);
+          const trades = parsePositionHistory(results.data, commissions);
           if (trades.length === 0) {
             setParseError(
-              "No completed trades found. Ensure the CSV has Filled rows where " +
-              "both an opening and a closing fill exist for the same product."
+              "No paired trades found. Make sure this is a Position_History.csv " +
+              "file exported from Tradovate with 'Bought Timestamp' and 'Sold Timestamp' columns."
             );
             return;
           }
           setPreview(trades);
           setStep("preview");
         } catch (err) {
-          setParseError(err instanceof Error ? err.message : "Failed to parse CSV");
+          setParseError(
+            err instanceof Error ? err.message : "Failed to parse CSV"
+          );
         }
       },
       error(err) {
@@ -390,15 +354,16 @@ export function TradovateImport({ propAccounts, strategies, onImported, onClose 
     setStep("importing");
     try {
       const overrides = {
-        prop_account_id: selectedAccountId || null,
-        strategy_id: selectedStrategyId || null,
+        prop_account_id: selectedAccountId  || null,
+        strategy_id:     selectedStrategyId || null,
       };
-      const res = await importTrades(preview.map((t) => ({ ...toImportInput(t), ...overrides })));
+      const res = await importTrades(
+        preview.map((t) => toImportInput(t, overrides))
+      );
       setResult(res);
       setStep("done");
       onImported([]);
     } catch (err) {
-      // PostgrestError is a plain object (not Error instance) — handle both shapes
       const msg =
         err instanceof Error
           ? err.message
@@ -408,9 +373,10 @@ export function TradovateImport({ propAccounts, strategies, onImported, onClose 
     }
   }
 
-  const totalPnl   = preview.reduce((s, t) => s + t.gross_pnl, 0);
-  const wins       = preview.filter((t) => t.gross_pnl > 0).length;
-  const losses     = preview.filter((t) => t.gross_pnl < 0).length;
+  // Preview summary
+  const totalGross      = preview.reduce((s, t) => s + t.gross_pnl,  0);
+  const totalCommission = preview.reduce((s, t) => s + t.commission, 0);
+  const totalNet        = preview.reduce((s, t) => s + t.net_pnl,    0);
 
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 overflow-y-auto p-4">
@@ -421,7 +387,7 @@ export function TradovateImport({ propAccounts, strategies, onImported, onClose 
           <div>
             <h2 className="text-base font-semibold">Import Tradovate CSV</h2>
             <p className="text-sm text-muted-foreground">
-              Upload an order history CSV exported from Tradovate
+              Upload a <span className="font-mono text-xs">Position_History.csv</span> file exported from Tradovate
             </p>
           </div>
           <button onClick={onClose} className="rounded-md p-1.5 hover:bg-accent">
@@ -438,36 +404,111 @@ export function TradovateImport({ propAccounts, strategies, onImported, onClose 
             </div>
           )}
 
-          {/* ── Idle ── */}
+          {/* ── Step 1: Upload + commission rates ── */}
           {step === "idle" && (
-            <div className="flex flex-col items-center gap-4 py-12">
-              <div className="rounded-full bg-muted p-4">
-                <Upload className="h-8 w-8 text-muted-foreground" />
+            <div className="space-y-6">
+              {/* Drop zone */}
+              <div className="flex flex-col items-center gap-4 rounded-xl border-2 border-dashed border-muted-foreground/25 py-10">
+                <div className="rounded-full bg-muted p-4">
+                  <Upload className="h-8 w-8 text-muted-foreground" />
+                </div>
+                <div className="text-center">
+                  <p className="font-medium">
+                    Choose your <span className="font-mono text-sm">Position_History.csv</span>
+                  </p>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Each row is a pre-matched fill pair — no FIFO reconstruction needed.
+                  </p>
+                </div>
+                <button
+                  onClick={() => fileRef.current?.click()}
+                  className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+                >
+                  Browse CSV file
+                </button>
+                <input
+                  ref={fileRef}
+                  type="file"
+                  accept=".csv"
+                  className="hidden"
+                  onChange={handleFileChange}
+                />
               </div>
-              <div className="text-center">
-                <p className="font-medium">Choose a Tradovate order history CSV</p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  All Filled orders are processed. Scale-ins and partial exits are
-                  handled via FIFO position tracking.
+
+              {/* Commission rate table */}
+              <div>
+                <p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Commission rates (round-turn per contract)
                 </p>
+                <div className="overflow-hidden rounded-lg border">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b bg-muted/40">
+                        <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground">
+                          Product
+                        </th>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground">
+                          Rate ($)
+                        </th>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground">
+                          Product
+                        </th>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground">
+                          Rate ($)
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {Array.from({ length: Math.ceil(COMMISSION_PRODUCTS.length / 2) }, (_, i) => {
+                        const left  = COMMISSION_PRODUCTS[i * 2];
+                        const right = COMMISSION_PRODUCTS[i * 2 + 1];
+                        return (
+                          <tr key={left} className="border-b last:border-0">
+                            <td className="px-4 py-2 font-mono text-xs font-medium">{left}</td>
+                            <td className="px-4 py-2">
+                              <input
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                value={commissions[left] ?? 0}
+                                onChange={(e) => handleCommissionChange(left, e.target.value)}
+                                className="w-20 rounded border bg-background px-2 py-1 text-sm tabular-nums outline-none focus:ring-2 focus:ring-ring"
+                              />
+                            </td>
+                            {right ? (
+                              <>
+                                <td className="px-4 py-2 font-mono text-xs font-medium">{right}</td>
+                                <td className="px-4 py-2">
+                                  <input
+                                    type="number"
+                                    step="0.01"
+                                    min="0"
+                                    value={commissions[right] ?? 0}
+                                    onChange={(e) => handleCommissionChange(right, e.target.value)}
+                                    className="w-20 rounded border bg-background px-2 py-1 text-sm tabular-nums outline-none focus:ring-2 focus:ring-ring"
+                                  />
+                                </td>
+                              </>
+                            ) : (
+                              <><td /><td /></>
+                            )}
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
               </div>
-              <button
-                onClick={() => fileRef.current?.click()}
-                className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-              >
-                Browse CSV file
-              </button>
-              <input ref={fileRef} type="file" accept=".csv" className="hidden" onChange={handleFileChange} />
             </div>
           )}
 
-          {/* ── Preview ── */}
+          {/* ── Step 2: Preview ── */}
           {step === "preview" && (
             <div className="space-y-4">
               <p className="text-sm text-muted-foreground">
                 Found{" "}
                 <span className="font-medium text-foreground">{preview.length}</span>{" "}
-                completed trade{preview.length !== 1 ? "s" : ""}. Review below, then
+                paired trade{preview.length !== 1 ? "s" : ""}. Review below, then
                 confirm to save.
               </p>
 
@@ -475,22 +516,40 @@ export function TradovateImport({ propAccounts, strategies, onImported, onClose 
                 <table className="w-full text-sm">
                   <thead>
                     <tr className="border-b bg-muted/40">
-                      {["Date", "Instrument", "Dir", "Entry", "Exit", "Qty", "P&L", "Session"].map(
-                        (h) => (
-                          <th key={h} className="px-3 py-2.5 text-left text-xs font-medium text-muted-foreground">
-                            {h}
-                          </th>
-                        )
-                      )}
+                      {[
+                        "Date",
+                        "Instrument",
+                        "Direction",
+                        "Entry",
+                        "Exit",
+                        "Qty",
+                        "Gross P/L",
+                        "Commission",
+                        "Net P/L",
+                        "Session",
+                      ].map((h) => (
+                        <th
+                          key={h}
+                          className="px-3 py-2.5 text-left text-xs font-medium text-muted-foreground whitespace-nowrap"
+                        >
+                          {h}
+                        </th>
+                      ))}
                     </tr>
                   </thead>
                   <tbody>
                     {preview.map((t, i) => (
                       <tr
-                        key={i}
+                        key={t.pair_id || i}
                         className={cn(
                           "border-b last:border-0",
-                          i % 2 === 0 ? "bg-background" : "bg-muted/20"
+                          t.net_pnl > 0
+                            ? "bg-emerald-500/5"
+                            : t.net_pnl < 0
+                            ? "bg-red-500/5"
+                            : i % 2 === 0
+                            ? "bg-background"
+                            : "bg-muted/20"
                         )}
                       >
                         <td className="px-3 py-2 text-xs text-muted-foreground whitespace-nowrap">
@@ -498,12 +557,14 @@ export function TradovateImport({ propAccounts, strategies, onImported, onClose 
                         </td>
                         <td className="px-3 py-2 font-medium">{t.instrument}</td>
                         <td className="px-3 py-2">
-                          <span className={cn(
-                            "rounded-full px-2 py-0.5 text-xs font-medium",
-                            t.direction === "long"
-                              ? "bg-emerald-500/15 text-emerald-600"
-                              : "bg-red-500/15 text-red-600"
-                          )}>
+                          <span
+                            className={cn(
+                              "rounded-full px-2 py-0.5 text-xs font-medium",
+                              t.direction === "long"
+                                ? "bg-emerald-500/15 text-emerald-600"
+                                : "bg-red-500/15 text-red-600"
+                            )}
+                          >
                             {t.direction === "long" ? "Long" : "Short"}
                           </span>
                         </td>
@@ -513,12 +574,25 @@ export function TradovateImport({ propAccounts, strategies, onImported, onClose 
                         <td className="px-3 py-2 tabular-nums">
                           {t.exit_price.toLocaleString(undefined, { maximumFractionDigits: 5 })}
                         </td>
-                        <td className="px-3 py-2 tabular-nums">{t.contracts}</td>
-                        <td className={cn(
-                          "px-3 py-2 font-medium tabular-nums",
-                          t.gross_pnl >= 0 ? "text-emerald-600" : "text-red-600"
-                        )}>
+                        <td className="px-3 py-2 tabular-nums">{t.size}</td>
+                        <td
+                          className={cn(
+                            "px-3 py-2 tabular-nums",
+                            t.gross_pnl >= 0 ? "text-emerald-600" : "text-red-600"
+                          )}
+                        >
                           {formatMoney(t.gross_pnl)}
+                        </td>
+                        <td className="px-3 py-2 tabular-nums text-muted-foreground">
+                          {formatMoney(t.commission)}
+                        </td>
+                        <td
+                          className={cn(
+                            "px-3 py-2 font-medium tabular-nums",
+                            t.net_pnl >= 0 ? "text-emerald-600" : "text-red-600"
+                          )}
+                        >
+                          {formatMoney(t.net_pnl)}
                         </td>
                         <td className="px-3 py-2 text-xs capitalize text-muted-foreground whitespace-nowrap">
                           {t.session.replace(/_/g, " ")}
@@ -529,32 +603,54 @@ export function TradovateImport({ propAccounts, strategies, onImported, onClose 
                 </table>
               </div>
 
-              {/* Summary */}
+              {/* Summary footer */}
               <div className="flex flex-wrap items-center gap-x-6 gap-y-2 rounded-lg border bg-muted/30 px-4 py-3 text-sm">
                 <span className="text-muted-foreground">
-                  Total P&L:{" "}
-                  <span className={cn("font-semibold", totalPnl >= 0 ? "text-emerald-600" : "text-red-600")}>
-                    {formatMoney(totalPnl)}
+                  Rows:{" "}
+                  <span className="font-medium text-foreground">{preview.length}</span>
+                </span>
+                <span className="text-muted-foreground">
+                  Gross P/L:{" "}
+                  <span
+                    className={cn(
+                      "font-semibold",
+                      totalGross >= 0 ? "text-emerald-600" : "text-red-600"
+                    )}
+                  >
+                    {formatMoney(totalGross)}
                   </span>
                 </span>
                 <span className="text-muted-foreground">
-                  Wins: <span className="font-medium text-foreground">{wins}</span>
+                  Commission:{" "}
+                  <span className="font-medium text-foreground">
+                    {formatMoney(totalCommission)}
+                  </span>
                 </span>
                 <span className="text-muted-foreground">
-                  Losses: <span className="font-medium text-foreground">{losses}</span>
+                  Net P/L:{" "}
+                  <span
+                    className={cn(
+                      "font-semibold",
+                      totalNet >= 0 ? "text-emerald-600" : "text-red-600"
+                    )}
+                  >
+                    {formatMoney(totalNet)}
+                  </span>
                 </span>
               </div>
 
-              {/* Assign on import */}
+              {/* Optional account / strategy assignment */}
               {(propAccounts.length > 0 || strategies.length > 0) && (
                 <div className="rounded-lg border bg-card px-4 py-3 space-y-2">
-                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                     Assign to (optional)
                   </p>
                   <div className="flex flex-wrap gap-3">
                     {propAccounts.length > 0 && (
                       <div className="flex items-center gap-2">
-                        <label className="text-sm text-muted-foreground whitespace-nowrap">Account</label>
+                        <label className="text-sm text-muted-foreground whitespace-nowrap">
+                          Account
+                        </label>
                         <select
                           value={selectedAccountId}
                           onChange={(e) => setSelectedAccountId(e.target.value)}
@@ -562,14 +658,18 @@ export function TradovateImport({ propAccounts, strategies, onImported, onClose 
                         >
                           <option value="">None</option>
                           {propAccounts.map((a) => (
-                            <option key={a.id} value={a.id}>{a.firm} · {a.account_label}</option>
+                            <option key={a.id} value={a.id}>
+                              {a.firm} · {a.account_label}
+                            </option>
                           ))}
                         </select>
                       </div>
                     )}
                     {strategies.length > 0 && (
                       <div className="flex items-center gap-2">
-                        <label className="text-sm text-muted-foreground whitespace-nowrap">Strategy</label>
+                        <label className="text-sm text-muted-foreground whitespace-nowrap">
+                          Strategy
+                        </label>
                         <select
                           value={selectedStrategyId}
                           onChange={(e) => setSelectedStrategyId(e.target.value)}
@@ -577,7 +677,9 @@ export function TradovateImport({ propAccounts, strategies, onImported, onClose 
                         >
                           <option value="">None</option>
                           {strategies.map((s) => (
-                            <option key={s.id} value={s.id}>{s.name}</option>
+                            <option key={s.id} value={s.id}>
+                              {s.name}
+                            </option>
                           ))}
                         </select>
                       </div>
@@ -588,7 +690,7 @@ export function TradovateImport({ propAccounts, strategies, onImported, onClose 
             </div>
           )}
 
-          {/* ── Importing ── */}
+          {/* ── Importing spinner ── */}
           {step === "importing" && (
             <div className="flex flex-col items-center gap-3 py-12">
               <Loader2 className="h-8 w-8 animate-spin text-primary" />
@@ -606,7 +708,9 @@ export function TradovateImport({ propAccounts, strategies, onImported, onClose 
                 <p className="font-semibold">Import complete</p>
                 <p className="mt-1 text-sm text-muted-foreground">
                   {result.imported} trade{result.imported !== 1 ? "s" : ""} imported
-                  {result.skipped > 0 && `, ${result.skipped} skipped (duplicates)`}.
+                  {result.skipped > 0 &&
+                    `, ${result.skipped} skipped (duplicates)`}
+                  .
                 </p>
               </div>
             </div>
@@ -616,14 +720,20 @@ export function TradovateImport({ propAccounts, strategies, onImported, onClose 
         {/* Footer */}
         <div className="flex items-center justify-end gap-2 border-t px-6 py-4">
           {step === "idle" && (
-            <button onClick={onClose} className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-accent">
+            <button
+              onClick={onClose}
+              className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-accent"
+            >
               Cancel
             </button>
           )}
           {step === "preview" && (
             <>
               <button
-                onClick={() => { setStep("idle"); setPreview([]); }}
+                onClick={() => {
+                  setStep("idle");
+                  setPreview([]);
+                }}
                 className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-accent"
               >
                 Back
@@ -632,7 +742,7 @@ export function TradovateImport({ propAccounts, strategies, onImported, onClose 
                 onClick={handleConfirm}
                 className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
               >
-                Confirm import ({preview.length})
+                Import {preview.length} trade{preview.length !== 1 ? "s" : ""}
               </button>
             </>
           )}

--- a/src/lib/supabase/trading.ts
+++ b/src/lib/supabase/trading.ts
@@ -283,22 +283,41 @@ export async function importTrades(inputs: TradeImportInput[]): Promise<ImportRe
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) throw new Error("Not authenticated");
 
-  // Fetch existing trades to check duplicates by date + instrument + entry_price + direction
-  const { data: existing, error: fetchError } = await supabase
-    .from("trades")
-    .select("entry_time, instrument, entry_price, direction")
-    .eq("user_id", user.id);
-  if (fetchError) throw fetchError;
+  // Split inputs: those with a pair_id use the new dedup key; others use the legacy composite key.
+  const inputsWithPairId    = inputs.filter((t) => t.pair_id);
+  const inputsWithoutPairId = inputs.filter((t) => !t.pair_id);
 
-  const existingKeys = new Set(
-    (existing ?? []).map(
-      (t) => `${t.entry_time.substring(0, 10)}|${t.instrument}|${t.entry_price}|${t.direction}`
-    )
-  );
+  // Fetch existing pair_ids for new-style dedup
+  let existingPairIds = new Set<string>();
+  if (inputsWithPairId.length > 0) {
+    const { data, error } = await supabase
+      .from("trades")
+      .select("pair_id")
+      .eq("user_id", user.id)
+      .not("pair_id", "is", null);
+    if (error) throw error;
+    existingPairIds = new Set((data ?? []).map((t) => t.pair_id as string));
+  }
+
+  // Fetch legacy composite keys for backward-compat dedup
+  let existingCompositeKeys = new Set<string>();
+  if (inputsWithoutPairId.length > 0) {
+    const { data, error } = await supabase
+      .from("trades")
+      .select("entry_time, instrument, entry_price, direction")
+      .eq("user_id", user.id);
+    if (error) throw error;
+    existingCompositeKeys = new Set(
+      (data ?? []).map(
+        (t) => `${t.entry_time.substring(0, 10)}|${t.instrument}|${t.entry_price}|${t.direction}`
+      )
+    );
+  }
 
   const toInsert = inputs.filter((t) => {
+    if (t.pair_id) return !existingPairIds.has(t.pair_id);
     const key = `${t.entry_time.substring(0, 10)}|${t.instrument}|${t.entry_price}|${t.direction}`;
-    return !existingKeys.has(key);
+    return !existingCompositeKeys.has(key);
   });
 
   if (toInsert.length === 0) {

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -113,6 +113,9 @@ export interface Trade {
   post_emotion: string | null;
   followed_rules: boolean | null;
   is_reviewed: boolean;
+  // Tradovate Position_History.csv import identifiers
+  position_id: string | null;
+  pair_id: string | null;
   created_at: string;
   updated_at: string;
   // joined relations (optional)

--- a/supabase/migrations/20240109000001_add_trade_pair_columns.sql
+++ b/supabase/migrations/20240109000001_add_trade_pair_columns.sql
@@ -1,0 +1,11 @@
+-- Add Position_History.csv import columns to trades table
+-- position_id: Tradovate Position ID (groups related pair rows)
+-- pair_id:     Tradovate Pair ID (unique per matched fill row — used for dedup)
+
+ALTER TABLE trades ADD COLUMN IF NOT EXISTS position_id text;
+ALTER TABLE trades ADD COLUMN IF NOT EXISTS pair_id     text;
+
+-- Unique per user so the same file can be safely re-imported (duplicates are skipped)
+CREATE UNIQUE INDEX IF NOT EXISTS trades_user_pair_id
+  ON trades (user_id, pair_id)
+  WHERE pair_id IS NOT NULL;


### PR DESCRIPTION
## Summary

Refactored the Tradovate CSV import feature to parse the `Position_History.csv` export format instead of order history. This eliminates the need for complex FIFO position tracking since Tradovate pre-matches buy/sell pairs in the export.

## Key Changes

- **CSV Format Migration**: Changed from parsing individual order fills to parsing pre-matched position pairs from `Position_History.csv`
  - Removed FIFO position tracking algorithm (`runFifo`, `PositionEntry`, `CompletedLeg` interfaces)
  - Simplified parsing to directly extract paired trades with `Bought Timestamp` and `Sold Timestamp` columns

- **Commission Handling**: Added user-configurable commission rates per product
  - New `DEFAULT_COMMISSIONS` table with round-turn rates for all supported products
  - Commission input UI in the upload step allowing users to override rates before import
  - Commission is now calculated and stored separately from gross P/L

- **Improved P/L Tracking**: Enhanced trade data to distinguish gross vs. net P/L
  - Preview table now shows `Gross P/L`, `Commission`, and `Net P/L` columns
  - Summary footer displays totals for all three metrics
  - Row highlighting based on net P/L outcome (green for wins, red for losses)

- **Deduplication Strategy**: Implemented dual-key deduplication
  - New trades with `pair_id` use Tradovate's unique pair identifier for dedup
  - Legacy trades without `pair_id` fall back to composite key (date + instrument + entry_price + direction)
  - Added database migration to create `pair_id` column and unique index

- **Timezone Handling**: Simplified timezone logic
  - Removed New York timezone conversion; trades now stored in UTC
  - Session detection uses Cyprus local time (EET = UTC+2) directly
  - Clearer timestamp parsing with better error handling

- **UI/UX Improvements**
  - Updated instructions to reference `Position_History.csv` specifically
  - Added commission rate configuration table in upload step
  - Improved preview table with better visual hierarchy and row coloring
  - More descriptive error messages for parsing failures

## Database Changes

Added migration to support new import identifiers:
- `position_id`: Groups related position rows from Tradovate
- `pair_id`: Unique identifier per matched fill pair (used for deduplication)
- Unique index on `(user_id, pair_id)` for safe re-imports

## Type Updates

Extended `Trade` interface with `position_id` and `pair_id` fields to support Tradovate import metadata.

https://claude.ai/code/session_018r6vq1zcAf5Y3cK4b42KUK