### PR TITLE
Add bulk delete trades functionality and improve P&L calculation

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -102,17 +102,25 @@ export default async function DashboardPage() {
   const propAccountRow =
     propAccountResult.status === 'fulfilled' ? propAccountResult.value.data : null
 
-  // Today's P&L for the active prop account
+  // Today's P&L for the active prop account (fees included for open trades)
   let todayPnl = 0
   if (propAccountRow?.id) {
     const { data: todayTrades } = await supabase
       .from('trades')
-      .select('net_pnl')
+      .select('net_pnl, fees')
       .eq('prop_account_id', propAccountRow.id)
       .gte('entry_time', `${todayStr}T00:00:00`)
       .lte('entry_time', `${todayStr}T23:59:59`)
 
-    todayPnl = (todayTrades ?? []).reduce((s: number, t: { net_pnl: number | null }) => s + (t.net_pnl ?? 0), 0)
+    todayPnl = (todayTrades ?? []).reduce(
+      (s: number, t: { net_pnl: number | null; fees: number | null }) => {
+        // Closed trades: net_pnl already deducts fees
+        if (t.net_pnl !== null) return s + t.net_pnl
+        // Open trades: gross_pnl unknown, but fees are a realized cost
+        return s - (t.fees ?? 0)
+      },
+      0
+    )
   }
 
   // ── Derived data ──────────────────────────────────────────────────────────

--- a/src/components/trading/trades-list.tsx
+++ b/src/components/trading/trades-list.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { Plus, SlidersHorizontal, TrendingUp, TrendingDown, FileUp, CheckSquare } from "lucide-react";
+import { Plus, SlidersHorizontal, TrendingUp, TrendingDown, FileUp, CheckSquare, Trash2 } from "lucide-react";
 import { TradeForm } from "./trade-form";
 import { TradovateDualImport } from "./tradovate-dual-import";
-import { getTrades, getPropAccounts, bulkUpdateTrades } from "@/lib/supabase/trading";
+import { getTrades, getPropAccounts, bulkUpdateTrades, bulkDeleteTrades } from "@/lib/supabase/trading";
 import { INSTRUMENTS } from "@/lib/validations/trading";
 import { cn } from "@/lib/utils";
 import type { Trade, PropAccount, Strategy, Instrument, TradeOutcome } from "@/lib/types";
@@ -78,6 +78,7 @@ export function TradesList({ trades, propAccounts, strategies, onTradesChange, o
   const [bulkAccount, setBulkAccount] = useState("");
   const [bulkStrategy, setBulkStrategy] = useState("");
   const [bulkApplying, setBulkApplying] = useState(false);
+  const [bulkDeleting, setBulkDeleting] = useState(false);
 
   function handleSaved(saved: Trade) {
     if (trades.find((t) => t.id === saved.id)) {
@@ -183,6 +184,23 @@ export function TradesList({ trades, propAccounts, strategies, onTradesChange, o
       console.error(err);
     } finally {
       setBulkApplying(false);
+    }
+  }
+
+  async function deleteBulk() {
+    if (!confirm(`Delete ${selectedIds.size} trade${selectedIds.size === 1 ? "" : "s"}? This cannot be undone.`)) return;
+    setBulkDeleting(true);
+    try {
+      const ids = Array.from(selectedIds);
+      await bulkDeleteTrades(ids);
+      const refreshedAccounts = await getPropAccounts();
+      onTradesChange(trades.filter((t) => !selectedIds.has(t.id)));
+      onAccountsChange(refreshedAccounts);
+      setSelectedIds(new Set());
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setBulkDeleting(false);
     }
   }
 
@@ -336,10 +354,18 @@ export function TradesList({ trades, propAccounts, strategies, onTradesChange, o
             </select>
             <button
               onClick={applyBulk}
-              disabled={bulkApplying || (!bulkAccount && !bulkStrategy)}
+              disabled={bulkApplying || bulkDeleting || (!bulkAccount && !bulkStrategy)}
               className="rounded-md bg-primary px-3 py-1 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
             >
               {bulkApplying ? "Applying…" : "Apply"}
+            </button>
+            <button
+              onClick={deleteBulk}
+              disabled={bulkDeleting || bulkApplying}
+              className="flex items-center gap-1.5 rounded-md bg-destructive px-3 py-1 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              {bulkDeleting ? "Deleting…" : "Delete"}
             </button>
           </div>
           <button

--- a/src/lib/supabase/trading.ts
+++ b/src/lib/supabase/trading.ts
@@ -243,6 +243,25 @@ export async function recomputeAccountBalance(accountId: string): Promise<void> 
   if (updateErr) throw updateErr;
 }
 
+export async function bulkDeleteTrades(ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  const supabase = createClient();
+
+  // Collect affected account IDs before deletion for balance recompute
+  const { data: before } = await supabase
+    .from("trades")
+    .select("prop_account_id")
+    .in("id", ids);
+  const accountsToRecompute = new Set(
+    (before ?? []).map((t) => t.prop_account_id).filter(Boolean) as string[]
+  );
+
+  const { error } = await supabase.from("trades").delete().in("id", ids);
+  if (error) throw error;
+
+  await Promise.all(Array.from(accountsToRecompute).map(recomputeAccountBalance));
+}
+
 export async function bulkUpdateTrades(
   ids: string[],
   input: { prop_account_id?: string | null; strategy_id?: string | null }


### PR DESCRIPTION
## Summary
This PR adds the ability to bulk delete trades from the trades list and improves the today's P&L calculation to properly account for fees on open trades.

## Key Changes

- **Bulk Delete Trades**: Added a new `bulkDeleteTrades` function that deletes multiple trades by ID and automatically recomputes affected account balances
  - New delete button in the trades list UI with confirmation dialog
  - Proper state management with `bulkDeleting` flag to prevent concurrent operations
  - Button is disabled while applying bulk updates or deleting
  
- **P&L Calculation Fix**: Updated the today's P&L calculation on the dashboard to correctly handle fees
  - For closed trades: `net_pnl` already includes fee deductions, so use as-is
  - For open trades: fees are a realized cost even though the trade hasn't closed, so subtract fees from the total
  - Added clarifying comment explaining the fee handling logic

- **UI Improvements**: 
  - Added `Trash2` icon import from lucide-react
  - Delete button uses destructive styling (red background)
  - Proper button state management to prevent conflicts between bulk update and delete operations

## Implementation Details

The `bulkDeleteTrades` function:
1. Collects all affected account IDs before deletion
2. Performs the bulk delete operation
3. Recomputes balances for all affected accounts in parallel
4. Ensures data consistency after deletion

The P&L calculation now distinguishes between closed trades (where fees are already in `net_pnl`) and open trades (where fees need to be subtracted separately).

https://claude.ai/code/session_01QhAL4GvnyohQ3DVd4yaSts