### PR TITLE
Switch trade analysis API to use DataStreamResponse

### DIFF
--- a/src/app/api/ai/trade-analysis/route.ts
+++ b/src/app/api/ai/trade-analysis/route.ts
@@ -92,5 +92,5 @@ export async function POST(req: Request) {
     temperature: 0.5,
   })
 
-  return result.toTextStreamResponse()
+  return result.toDataStreamResponse()
 }


### PR DESCRIPTION
## Summary
Updated the trade analysis API endpoint to use `toDataStreamResponse()` instead of `toTextStreamResponse()` for streaming responses.

## Key Changes
- Changed the response method from `toTextStreamResponse()` to `toDataStreamResponse()` in the trade analysis POST handler
- This affects how the AI-generated trade analysis results are streamed back to the client

## Implementation Details
The change modifies the response format of the `/api/ai/trade-analysis` endpoint. The `toDataStreamResponse()` method likely provides a more structured data streaming format compared to the plain text streaming approach, potentially enabling better client-side handling of the streamed analysis data.

https://claude.ai/code/session_01QhXhgLFmyF5hgu3QSTS6uw