### PR TITLE
fix: await streamText — ai v6 returns a Promise

### DIFF
--- a/src/app/api/ai/trade-analysis/route.ts
+++ b/src/app/api/ai/trade-analysis/route.ts
@@ -79,7 +79,7 @@ export async function POST(req: Request) {
 
   const system = `${TRADING_COACH_SYSTEM_PROMPT}\n\n---\n\n${contextBlock}`
 
-  const result = streamText({
+  const result = await streamText({
     model: google('gemini-2.5-flash'),
     system,
     messages: [


### PR DESCRIPTION
Without await, result was a Promise object which has neither toTextStreamResponse nor toDataStreamResponse, causing silent no-op on the client with a TypeError on the server.

https://claude.ai/code/session_01QhXhgLFmyF5hgu3QSTS6uw