### PR TITLE
fix: pass month/year via useChat body instead of append options

### DIFF
--- a/src/components/ai/bulk-trade-analysis.tsx
+++ b/src/components/ai/bulk-trade-analysis.tsx
@@ -70,6 +70,7 @@ export function BulkTradeAnalysis() {
 
   const { messages, append, isLoading, stop, setMessages } = useChat({
     api: '/api/ai/trade-analysis',
+    body: { month, year },
   })
 
   const completion = messages.filter(m => m.role === 'assistant').at(-1)?.content ?? ''
@@ -82,7 +83,7 @@ export function BulkTradeAnalysis() {
 
   const handleAnalyse = () => {
     setMessages([])
-    append({ role: 'user', content: `Analyse ${monthLabel}` }, { body: { month, year } })
+    append({ role: 'user', content: `Analyse ${monthLabel}` })
   }
 
   // Year options: current year and previous 2


### PR DESCRIPTION
append() in this version of @ai-sdk/react does not accept a second options argument. Moving month/year to the hook-level body is reactive to state and gets merged into every request automatically.

https://claude.ai/code/session_01QhXhgLFmyF5hgu3QSTS6uw