### PR TITLE
Add complete Marathon Training Module

### DIFF
--- a/src/app/(dashboard)/marathon/history/page.tsx
+++ b/src/app/(dashboard)/marathon/history/page.tsx
@@ -1,0 +1,120 @@
+// Marathon history — session calendar, pace discipline chart, stats
+
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { getRecentSessions, getTrainingWeeks } from '@/lib/supabase/marathon'
+import { TRAINING_PLAN, SESSION_TYPE_LABELS, SESSION_TYPE_COLORS } from '@/lib/marathon/plan'
+import { PaceDisciplineChart } from '@/components/marathon/PaceDisciplineChart'
+import { cn } from '@/lib/utils'
+
+export const metadata: Metadata = {
+  title: 'Marathon History',
+  description: 'All training sessions and pace discipline tracker',
+}
+
+export default async function HistoryPage() {
+  const [sessions, dbWeeks] = await Promise.all([
+    getRecentSessions(100),
+    getTrainingWeeks(),
+  ])
+
+  const completed = sessions.filter((s) => s.status !== 'pending' && s.status !== 'skipped')
+  const tooFastCount = sessions.filter((s) => s.went_too_fast).length
+  const warmupsSkipped = sessions.filter((s) => s.skipped_warmup).length
+  const totalKm = completed.reduce((sum, s) => sum + (s.actual_km ?? 0), 0)
+  const longestRun = Math.max(...completed.map((s) => s.actual_km ?? 0), 0)
+  const warmupCompliance = completed.length > 0
+    ? Math.round(((completed.length - warmupsSkipped) / completed.length) * 100)
+    : 100
+  const paceCompliance = completed.length > 0
+    ? Math.round(((completed.length - tooFastCount) / completed.length) * 100)
+    : 100
+
+  return (
+    <div className="space-y-8">
+      <Link href="/marathon" className="flex items-center gap-2 text-sm text-white/40 hover:text-white/70 transition-colors">
+        <ArrowLeft className="h-4 w-4" /> Training hub
+      </Link>
+
+      <div>
+        <h1 className="text-2xl font-bold text-white">Training History</h1>
+        <p className="text-sm text-white/40 mt-1">Belgrade Marathon · 9-week block</p>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+        {[
+          { label: 'Sessions done', value: `${completed.length}` },
+          { label: 'Total km', value: `${totalKm.toFixed(0)}km` },
+          { label: 'Longest run', value: `${longestRun.toFixed(1)}km` },
+          { label: 'Pace discipline', value: `${paceCompliance}%`, note: `${tooFastCount} too fast`, warn: tooFastCount > 0 },
+          { label: 'Warmup done', value: `${warmupCompliance}%`, note: `${warmupsSkipped} skipped`, warn: warmupsSkipped > 0 },
+        ].map((s) => (
+          <div key={s.label} className="rounded-xl bg-white/5 border border-white/10 p-4">
+            <p className="text-xs text-white/40">{s.label}</p>
+            <p className={cn('text-xl font-bold font-mono mt-1', (s as { warn?: boolean }).warn ? 'text-amber-400' : 'text-white')}>{s.value}</p>
+            {(s as { note?: string }).note && <p className="text-xs text-white/30 mt-0.5">{(s as { note?: string }).note}</p>}
+          </div>
+        ))}
+      </div>
+
+      {/* Pace discipline chart */}
+      {completed.length > 0 && (
+        <div className="rounded-xl bg-white/5 border border-white/10 p-5 space-y-3">
+          <h2 className="text-sm font-semibold text-white">Pace Discipline</h2>
+          <p className="text-xs text-white/30">Planned vs actual pace — red dots went too fast</p>
+          <PaceDisciplineChart sessions={completed} />
+        </div>
+      )}
+
+      {/* Session log */}
+      <div className="space-y-3">
+        <h2 className="text-sm font-semibold text-white">All Sessions</h2>
+        {sessions.length === 0 ? (
+          <p className="text-sm text-white/30">No sessions logged yet.</p>
+        ) : (
+          <div className="space-y-2">
+            {sessions.map((s) => {
+              const typeColor = SESSION_TYPE_COLORS[s.planned_type as keyof typeof SESSION_TYPE_COLORS] ?? 'text-white/40 bg-white/5'
+              return (
+                <div
+                  key={s.id}
+                  className={cn(
+                    'flex items-center gap-3 rounded-lg px-4 py-3 text-sm',
+                    'bg-white/[0.03] border border-white/[0.06]',
+                    s.went_too_fast && 'border-amber-400/20',
+                  )}
+                >
+                  <span className="text-white/30 font-mono text-xs w-20 shrink-0">{s.session_date}</span>
+                  <span className={cn('text-xs font-medium px-1.5 py-0.5 rounded shrink-0', typeColor)}>
+                    {SESSION_TYPE_LABELS[s.planned_type as keyof typeof SESSION_TYPE_LABELS] ?? s.planned_type}
+                  </span>
+                  <div className="flex-1 min-w-0 flex items-center gap-3">
+                    {s.actual_km && <span className="text-white/60 font-mono">{s.actual_km}km</span>}
+                    {s.actual_avg_pace && <span className="text-white/50 font-mono">@ {s.actual_avg_pace}/km</span>}
+                    {s.actual_avg_hr && <span className="text-white/30 text-xs">HR {s.actual_avg_hr}</span>}
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    {s.went_too_fast && (
+                      <span className="text-xs text-amber-400 font-mono">+{s.pace_deviation_sec}s</span>
+                    )}
+                    <span className={cn(
+                      'text-xs px-2 py-0.5 rounded',
+                      s.status === 'completed' ? 'text-emerald-400 bg-emerald-400/10' :
+                      s.status === 'modified' ? 'text-blue-400 bg-blue-400/10' :
+                      s.status === 'skipped' ? 'text-red-400 bg-red-400/10' :
+                      'text-white/20 bg-white/5',
+                    )}>
+                      {s.status}
+                    </span>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/marathon/page.tsx
+++ b/src/app/(dashboard)/marathon/page.tsx
@@ -1,0 +1,163 @@
+// Marathon Training Hub — Week at a glance + today's session
+
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ChevronRight, BarChart2 } from 'lucide-react'
+import { TRAINING_PLAN, getCurrentWeek, getSessionForDate } from '@/lib/marathon/plan'
+import { getTrainingWeeks, getSessionsForWeek } from '@/lib/supabase/marathon'
+import { RaceCountdown } from '@/components/marathon/RaceCountdown'
+import { SessionCard } from '@/components/marathon/SessionCard'
+import { WeeklyProgress } from '@/components/marathon/WeeklyProgress'
+import { AICoach } from '@/components/marathon/AICoach'
+
+export const metadata: Metadata = {
+  title: 'Marathon Training',
+  description: 'Belgrade Marathon April 19 — 9-week training hub',
+}
+
+export default async function MarathonPage() {
+  const today = new Date().toISOString().split('T')[0]
+  const currentPlanWeek = getCurrentWeek()
+  const weekNumber = currentPlanWeek?.weekNumber ?? 3
+
+  const [dbWeeks, dbSessions] = await Promise.all([
+    getTrainingWeeks(),
+    getSessionsForWeek(weekNumber),
+  ])
+
+  const todayPlanned = getSessionForDate(today)
+  const todayDb = dbSessions.find((s) => s.session_date === today) ?? null
+
+  // Build week session pairs
+  const planWeek = TRAINING_PLAN.find((w) => w.weekNumber === weekNumber)
+  const weekDates = planWeek ? planWeek.sessions.map((_, i) => {
+    const start = new Date(planWeek.dateRange.start + 'T12:00:00')
+    start.setDate(start.getDate() + i)
+    return start.toISOString().split('T')[0]
+  }) : []
+
+  // Total actual km this week
+  const weekActualKm = dbSessions
+    .filter((s) => s.status !== 'pending' && s.actual_km)
+    .reduce((sum, s) => sum + (s.actual_km ?? 0), 0)
+
+  // Recent pace flag
+  const recentFlag = dbSessions.find((s) => s.went_too_fast)
+
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Marathon</h1>
+          <p className="text-sm text-white/40 mt-1">Belgrade April 19 · Week {weekNumber} of 9</p>
+        </div>
+        <div className="flex gap-2">
+          <Link
+            href="/marathon/history"
+            className="flex items-center gap-1.5 text-xs text-white/40 hover:text-white/70 transition-colors px-3 py-2 rounded-lg bg-white/5 border border-white/10"
+          >
+            <BarChart2 className="h-3.5 w-3.5" />
+            History
+          </Link>
+        </div>
+      </div>
+
+      {/* Countdown */}
+      <RaceCountdown currentWeek={weekNumber} />
+
+      {/* Today's session */}
+      {todayPlanned && (
+        <div className="space-y-3">
+          <h2 className="text-xs font-semibold text-white/40 uppercase tracking-wider">
+            Today — {new Date(today + 'T12:00:00').toLocaleDateString('en-GB', { weekday: 'long', day: 'numeric', month: 'long' })}
+          </h2>
+          <SessionCard
+            planned={todayPlanned}
+            actual={todayDb}
+            date={today}
+            isToday
+          />
+        </div>
+      )}
+
+      {/* AI Coach */}
+      <AICoach mode="chat" />
+
+      {/* Pace flag */}
+      {recentFlag && (
+        <div className="rounded-lg bg-amber-400/10 border border-amber-400/20 px-4 py-3 text-sm text-amber-300">
+          Recent flag: {recentFlag.session_date} {recentFlag.planned_type} — went {recentFlag.pace_deviation_sec}s/km too fast
+        </div>
+      )}
+
+      {/* Week sessions */}
+      {planWeek && (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-white">
+              Week {weekNumber} — {planWeek.label}
+            </h2>
+            <Link
+              href={`/marathon/week/${weekNumber}`}
+              className="text-xs text-white/30 hover:text-white/60 flex items-center gap-0.5 transition-colors"
+            >
+              Full week <ChevronRight className="h-3 w-3" />
+            </Link>
+          </div>
+
+          {/* km summary */}
+          <div className="flex gap-4 text-sm">
+            <span className="text-white/40">
+              <span className="text-white font-mono">{weekActualKm.toFixed(1)}</span> / {planWeek.plannedKm}km
+            </span>
+          </div>
+
+          {/* Session list */}
+          <div className="space-y-2">
+            {planWeek.sessions.map((session, i) => {
+              const sessionDate = weekDates[i]
+              const dbSession = dbSessions.find((s) => s.session_date === sessionDate) ?? null
+              const isToday = sessionDate === today
+              return (
+                <SessionCard
+                  key={session.dayOfWeek}
+                  planned={session}
+                  actual={dbSession}
+                  date={sessionDate}
+                  isToday={isToday}
+                  compact
+                />
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Volume chart */}
+      <WeeklyProgress planWeeks={TRAINING_PLAN} dbWeeks={dbWeeks} />
+
+      {/* Week navigation */}
+      <div className="grid grid-cols-3 gap-3">
+        {[weekNumber - 1, weekNumber, weekNumber + 1].filter((n) => n >= 1 && n <= 9).map((n) => {
+          const w = TRAINING_PLAN.find((p) => p.weekNumber === n)
+          if (!w) return null
+          return (
+            <Link
+              key={n}
+              href={`/marathon/week/${n}`}
+              className={`rounded-xl p-4 border text-sm transition-colors ${
+                n === weekNumber
+                  ? 'bg-orange-500/10 border-orange-500/30 text-orange-300'
+                  : 'bg-white/5 border-white/10 text-white/50 hover:bg-white/8'
+              }`}
+            >
+              <p className="font-semibold">Week {n}</p>
+              <p className="text-xs text-white/30 mt-0.5">{w.plannedKm}km · {w.weekType}</p>
+            </Link>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(dashboard)/marathon/race/belgrade/page.tsx
+++ b/src/app/(dashboard)/marathon/race/belgrade/page.tsx
@@ -1,0 +1,129 @@
+// Belgrade Marathon race day tracker
+
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { daysUntil, RACE_DATE } from '@/lib/marathon/plan'
+import { getRaceResult } from '@/lib/supabase/marathon'
+import { AICoach } from '@/components/marathon/AICoach'
+
+export const metadata: Metadata = {
+  title: 'Belgrade Marathon',
+  description: 'April 19, 2026 — Target 3:32:00',
+}
+
+const PACING_PLAN = [
+  { segment: 'km 0-10', target: '5:05-5:08/km', split: '~51:30', strategy: 'Conservative — resist temptation' },
+  { segment: 'km 10-21', target: '5:00/km', split: '~1:45:00', strategy: 'Settle into rhythm, gel at km 10' },
+  { segment: 'km 21-30', target: '5:00/km', split: '~2:30:00', strategy: 'Hold steady, gel at km 20 & 28' },
+  { segment: 'km 30-38', target: '5:00-5:05/km', split: '~3:10:00', strategy: 'Suffering zone — keep running' },
+  { segment: 'km 38-42.2', target: '4:55-5:00/km', split: '3:32:00', strategy: 'Empty the tank' },
+]
+
+const FUELING = [
+  { km: 10, detail: 'Gel #1 + water (Maurten or SIS ONLY)' },
+  { km: 20, detail: 'Gel #2 + water' },
+  { km: 28, detail: 'Gel #3 + water' },
+  { km: 36, detail: 'Gel #4 + water' },
+]
+
+export default async function BelgradePage() {
+  const result = await getRaceResult('Belgrade Marathon')
+  const daysToRace = daysUntil(RACE_DATE)
+  const isRaceWeek = daysToRace <= 7 && daysToRace >= 0
+  const isPostRace = daysToRace < 0
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-8">
+      <Link href="/marathon" className="flex items-center gap-2 text-sm text-white/40 hover:text-white/70 transition-colors">
+        <ArrowLeft className="h-4 w-4" /> Training hub
+      </Link>
+
+      <div className="space-y-1">
+        <p className="text-xs text-white/40 uppercase tracking-wider">A-Race · April 19, 2026 · Belgrade</p>
+        <h1 className="text-2xl font-bold text-white">Belgrade Marathon</h1>
+        <p className="text-lg text-orange-400 font-mono font-semibold">Target: 3:32:00</p>
+      </div>
+
+      {/* Countdown */}
+      {!isPostRace && (
+        <div className="rounded-xl bg-orange-500/10 border border-orange-500/30 p-5 flex items-center justify-between">
+          <div>
+            <p className="text-sm text-orange-300 font-medium">5:00/km average</p>
+            <p className="text-xs text-white/40 mt-0.5">
+              {isRaceWeek ? 'RACE WEEK — stay calm, trust the training' : 'Train. Trust. Execute.'}
+            </p>
+          </div>
+          <div className="text-right">
+            <p className="text-4xl font-mono font-bold text-white">{daysToRace}</p>
+            <p className="text-xs text-white/40">days</p>
+          </div>
+        </div>
+      )}
+
+      {/* Result */}
+      {isPostRace && result && (
+        <div className="rounded-xl bg-white/5 border border-white/10 p-6 space-y-3">
+          <h2 className="text-sm font-semibold text-white/40 uppercase tracking-wider">Final Result</h2>
+          <p className="text-5xl font-mono font-bold text-white">{result.finish_time}</p>
+          {result.avg_pace && (
+            <p className="text-lg text-white/50 font-mono">@ {result.avg_pace}/km</p>
+          )}
+        </div>
+      )}
+
+      {/* Race day pacing */}
+      <div className="rounded-xl bg-white/5 border border-white/10 p-5 space-y-4">
+        <h2 className="text-sm font-semibold text-white">Race Pacing Plan</h2>
+        <div className="space-y-3">
+          {PACING_PLAN.map((s) => (
+            <div key={s.segment} className="space-y-0.5">
+              <div className="flex items-center gap-3 text-sm">
+                <span className="text-white/40 font-mono w-20 shrink-0 text-xs">{s.segment}</span>
+                <span className="text-orange-400 font-mono font-semibold w-28 shrink-0">{s.target}</span>
+                <span className="text-white/30 font-mono text-xs">{s.split}</span>
+              </div>
+              <p className="text-xs text-white/50 pl-20">{s.strategy}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Fueling */}
+      <div className="rounded-xl bg-white/5 border border-white/10 p-5 space-y-3">
+        <h2 className="text-sm font-semibold text-white">Fueling Plan</h2>
+        <div className="space-y-2">
+          {FUELING.map((f) => (
+            <div key={f.km} className="flex items-center gap-3 text-sm">
+              <span className="text-white font-mono font-bold w-10 shrink-0">km {f.km}</span>
+              <span className="text-white/60">{f.detail}</span>
+            </div>
+          ))}
+        </div>
+        <p className="text-xs text-red-400 border-t border-white/10 pt-3">
+          ONLY Maurten or SIS gels — never pre-workout supplements
+        </p>
+      </div>
+
+      {/* Race week prep */}
+      {(isRaceWeek || daysToRace <= 10) && !isPostRace && (
+        <div className="rounded-xl bg-white/5 border border-white/10 p-5 space-y-3">
+          <h2 className="text-sm font-semibold text-white">Race Week</h2>
+          <ul className="space-y-2 text-sm text-white/70">
+            <li>Wed Apr 16: Start carb loading — pasta, rice, quinoa, potatoes</li>
+            <li>Thu-Fri Apr 17-18: Continue carb loading · 3L water · sleep 8h+ · NO new foods</li>
+            <li>Race morning (2.5-3h before): Oats + banana + nut butter OR toast + jam</li>
+            <li>30min before: 10min easy jog · 5min dynamic stretches · 4×100m strides</li>
+          </ul>
+        </div>
+      )}
+
+      {/* AI */}
+      <AICoach
+        mode={isPostRace ? 'post' : 'chat'}
+        sessionData={{ type: 'RACE', race: 'Belgrade Marathon', target: '3:32:00', daysToRace }}
+        initialPrompt={isPostRace ? 'Give me a full race debrief.' : 'What should I focus on for race day execution?'}
+      />
+    </div>
+  )
+}

--- a/src/app/(dashboard)/marathon/race/limassol/page.tsx
+++ b/src/app/(dashboard)/marathon/race/limassol/page.tsx
@@ -1,0 +1,159 @@
+// Limassol Half Marathon page — pre-race briefing + post-race result entry
+
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { getRaceResult } from '@/lib/supabase/marathon'
+import { daysUntil, LIMASSOL_DATE } from '@/lib/marathon/plan'
+import { LimassolResultForm } from '@/components/marathon/LimassolResultForm'
+import { AICoach } from '@/components/marathon/AICoach'
+
+export const metadata: Metadata = {
+  title: 'Limassol Half Marathon',
+  description: 'March 22 checkpoint race — target 1:44-1:45',
+}
+
+function parseTimeToSeconds(time: string): number {
+  const parts = time.split(':').map(Number)
+  if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2]
+  return parts[0] * 60 + (parts[1] ?? 0)
+}
+
+function getBelgradeAdjustment(finishTimeSec: number): { label: string; target: string; color: string } {
+  const target144 = parseTimeToSeconds('1:44:59')
+  const target148 = parseTimeToSeconds('1:48:00')
+
+  if (finishTimeSec <= target144) {
+    return { label: 'Belgrade 3:32 CONFIRMED', target: '3:32:00', color: 'text-emerald-400' }
+  }
+  if (finishTimeSec < target148) {
+    return { label: 'Belgrade target marginal', target: '3:33-3:34', color: 'text-yellow-400' }
+  }
+  return { label: 'Belgrade target ADJUSTED', target: '3:35:00', color: 'text-amber-400' }
+}
+
+export default async function LimassolPage() {
+  const result = await getRaceResult('Limassol Half Marathon')
+  const daysToRace = daysUntil(LIMASSOL_DATE)
+  const isPostRace = daysToRace < 0 || result !== null
+
+  const belgradeAdj = result?.finish_time_seconds
+    ? getBelgradeAdjustment(result.finish_time_seconds)
+    : null
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-8">
+      <Link href="/marathon" className="flex items-center gap-2 text-sm text-white/40 hover:text-white/70 transition-colors">
+        <ArrowLeft className="h-4 w-4" /> Training hub
+      </Link>
+
+      <div className="space-y-1">
+        <p className="text-xs text-white/40 uppercase tracking-wider">Checkpoint Race · March 22, 2026</p>
+        <h1 className="text-2xl font-bold text-white">Limassol Half Marathon</h1>
+      </div>
+
+      {/* Pre-race or result */}
+      {!isPostRace && (
+        <div className="space-y-6">
+          {/* Countdown */}
+          <div className="rounded-xl bg-yellow-400/10 border border-yellow-400/20 p-5 flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-yellow-300">Target: 1:44-1:45</p>
+              <p className="text-xs text-white/40 mt-0.5">4:55-5:00/km average</p>
+            </div>
+            <div className="text-right">
+              <p className="text-3xl font-mono font-bold text-yellow-400">{daysToRace}</p>
+              <p className="text-xs text-white/40">days</p>
+            </div>
+          </div>
+
+          {/* Race strategy */}
+          <div className="rounded-xl bg-white/5 border border-white/10 p-5 space-y-4">
+            <h2 className="text-sm font-semibold text-white">Race Strategy</h2>
+            <div className="space-y-2">
+              {[
+                { segment: 'km 0-5', pace: '5:05/km', note: 'Conservative start — resist the crowd' },
+                { segment: 'km 5-15', pace: '5:00/km', note: 'Settle in, find rhythm' },
+                { segment: 'km 15-21', pace: '4:55/km', note: 'Negative split finish — empty the tank' },
+              ].map((s) => (
+                <div key={s.segment} className="flex items-center gap-4 text-sm">
+                  <span className="text-white/40 font-mono w-16 shrink-0">{s.segment}</span>
+                  <span className="text-orange-400 font-mono font-bold w-16 shrink-0">{s.pace}</span>
+                  <span className="text-white/60">{s.note}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Outcome logic */}
+          <div className="rounded-xl bg-white/5 border border-white/10 p-5 space-y-3">
+            <h2 className="text-sm font-semibold text-white">What the result means</h2>
+            {[
+              { result: '≤ 1:44:59', label: 'Belgrade 3:32 CONFIRMED', color: 'text-emerald-400' },
+              { result: '1:45-1:47:59', label: 'Belgrade 3:33-3:34 (marginal)', color: 'text-yellow-400' },
+              { result: '≥ 1:48:00', label: 'Belgrade adjusted to 3:35', color: 'text-amber-400' },
+            ].map((o) => (
+              <div key={o.result} className="flex items-center gap-3 text-sm">
+                <span className="font-mono text-white/50 w-24 shrink-0">{o.result}</span>
+                <span className={`font-medium ${o.color}`}>{o.label}</span>
+              </div>
+            ))}
+          </div>
+
+          {/* Gel rule */}
+          <div className="rounded-lg bg-white/5 border border-white/10 px-4 py-3 text-sm text-white/60">
+            Gels: <span className="text-white font-medium">Maurten or SIS ONLY</span> — never pre-workout supplements
+          </div>
+
+          {/* AI pre-race */}
+          <AICoach
+            mode="pre"
+            sessionData={{ type: 'RACE', race: 'Limassol Half Marathon', target: '1:44-1:45', date: '2026-03-22' }}
+            initialPrompt="Give me a pre-race briefing for Limassol Half Marathon."
+          />
+        </div>
+      )}
+
+      {/* Post-race */}
+      {isPostRace && (
+        <div className="space-y-6">
+          {result ? (
+            <>
+              {/* Result */}
+              <div className="rounded-xl bg-white/5 border border-white/10 p-6 space-y-4">
+                <h2 className="text-sm font-semibold text-white/40 uppercase tracking-wider">Official Result</h2>
+                <div className="flex items-end gap-4">
+                  <p className="text-4xl font-mono font-bold text-white">{result.finish_time}</p>
+                  {result.avg_pace && (
+                    <p className="text-lg text-white/50 font-mono mb-1">@ {result.avg_pace}/km</p>
+                  )}
+                </div>
+                {belgradeAdj && (
+                  <div className={`rounded-lg px-4 py-3 text-sm font-semibold ${belgradeAdj.color} bg-white/5 border border-white/10`}>
+                    {belgradeAdj.label} → {belgradeAdj.target}
+                  </div>
+                )}
+              </div>
+
+              {/* AI debrief */}
+              {result.ai_debrief && (
+                <div className="rounded-xl bg-orange-400/10 border border-orange-400/20 p-5 space-y-2">
+                  <p className="text-xs font-semibold text-orange-400 uppercase tracking-wider">Coach Debrief</p>
+                  <p className="text-sm text-white/80 leading-relaxed whitespace-pre-wrap">{result.ai_debrief}</p>
+                </div>
+              )}
+
+              <AICoach
+                mode="post"
+                sessionData={{ type: 'RACE', race: 'Limassol Half Marathon', result: result.finish_time, target: '1:44-1:45' }}
+                initialPrompt="Give me a full debrief of the Limassol race and what it means for Belgrade."
+              />
+            </>
+          ) : (
+            <LimassolResultForm />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/(dashboard)/marathon/session/[date]/page.tsx
+++ b/src/app/(dashboard)/marathon/session/[date]/page.tsx
@@ -1,0 +1,105 @@
+// Session log page — pre-filled with plan, user fills actuals
+
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ArrowLeft } from 'lucide-react'
+import { getSessionForDate as getPlanSession } from '@/lib/marathon/plan'
+import { getSessionForDate as getDbSession } from '@/lib/supabase/marathon'
+import { SESSION_TYPE_LABELS } from '@/lib/marathon/plan'
+import { SessionLogForm } from '@/components/marathon/SessionLogForm'
+import { AICoach } from '@/components/marathon/AICoach'
+
+export async function generateMetadata({ params }: { params: { date: string } }): Promise<Metadata> {
+  return { title: `Log Session — ${params.date}` }
+}
+
+export default async function SessionLogPage({ params }: { params: { date: string } }) {
+  const { date } = params
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) notFound()
+
+  const planned = getPlanSession(date)
+  if (!planned) {
+    return (
+      <div className="space-y-6">
+        <Link href="/marathon" className="flex items-center gap-2 text-sm text-white/40 hover:text-white/70 transition-colors">
+          <ArrowLeft className="h-4 w-4" /> Back to training hub
+        </Link>
+        <p className="text-white/40">No session planned for {date}.</p>
+      </div>
+    )
+  }
+
+  const existing = await getDbSession(date)
+
+  const sessionData = {
+    date,
+    type: planned.type,
+    description: planned.description,
+    plannedKm: planned.plannedKm,
+    paceMin: planned.paceMin,
+    paceMax: planned.paceMax,
+    weekNumber: planned.weekNumber,
+  }
+
+  return (
+    <div className="max-w-xl mx-auto space-y-8">
+      {/* Back */}
+      <Link href="/marathon" className="flex items-center gap-2 text-sm text-white/40 hover:text-white/70 transition-colors">
+        <ArrowLeft className="h-4 w-4" /> Training hub
+      </Link>
+
+      {/* Header */}
+      <div className="space-y-1">
+        <p className="text-xs text-white/40 uppercase tracking-wider">
+          {new Date(date + 'T12:00:00').toLocaleDateString('en-GB', { weekday: 'long', day: 'numeric', month: 'long' })}
+          {' · '}Week {planned.weekNumber}
+        </p>
+        <h1 className="text-2xl font-bold text-white">{SESSION_TYPE_LABELS[planned.type]}</h1>
+        {planned.description && (
+          <p className="text-sm text-white/60 leading-relaxed">{planned.description}</p>
+        )}
+      </div>
+
+      {/* AI pre-session */}
+      {!existing && planned.type !== 'REST' && (
+        <AICoach
+          mode="pre"
+          sessionData={sessionData}
+          initialPrompt="What should I focus on today?"
+        />
+      )}
+
+      {/* Log form */}
+      <div className="rounded-xl bg-white/5 border border-white/10 p-6">
+        <SessionLogForm
+          date={date}
+          planned={planned}
+          weekNumber={planned.weekNumber}
+          existingActual={existing}
+        />
+      </div>
+
+      {/* AI post-session (if already logged) */}
+      {existing && existing.status !== 'pending' && (
+        <AICoach
+          mode="post"
+          sessionData={{
+            ...sessionData,
+            actualKm: existing.actual_km,
+            actualPace: existing.actual_avg_pace,
+            actualHr: existing.actual_avg_hr,
+            perceivedEffort: existing.perceived_effort,
+            wentTooFast: existing.went_too_fast,
+            paceDeviationSec: existing.pace_deviation_sec,
+            warmupDone: existing.warmup_done,
+            skippedWarmup: existing.skipped_warmup,
+            notes: existing.notes,
+          }}
+          initialPrompt="Give me feedback on today's session."
+        />
+      )}
+    </div>
+  )
+}

--- a/src/app/(dashboard)/marathon/week/[n]/page.tsx
+++ b/src/app/(dashboard)/marathon/week/[n]/page.tsx
@@ -1,0 +1,122 @@
+// Full week view — all sessions, planned vs actual
+
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { ArrowLeft, ChevronLeft, ChevronRight } from 'lucide-react'
+import { TRAINING_PLAN } from '@/lib/marathon/plan'
+import { getSessionsForWeek } from '@/lib/supabase/marathon'
+import { SessionCard } from '@/components/marathon/SessionCard'
+
+export async function generateMetadata({ params }: { params: { n: string } }): Promise<Metadata> {
+  return { title: `Week ${params.n} — Marathon Training` }
+}
+
+export default async function WeekPage({ params }: { params: { n: string } }) {
+  const weekNumber = parseInt(params.n, 10)
+  if (isNaN(weekNumber) || weekNumber < 1 || weekNumber > 9) notFound()
+
+  const planWeek = TRAINING_PLAN.find((w) => w.weekNumber === weekNumber)
+  if (!planWeek) notFound()
+
+  const dbSessions = await getSessionsForWeek(weekNumber)
+  const today = new Date().toISOString().split('T')[0]
+
+  // Generate ISO dates for each session day
+  const weekDates = planWeek.sessions.map((_, i) => {
+    const start = new Date(planWeek.dateRange.start + 'T12:00:00')
+    start.setDate(start.getDate() + i)
+    return start.toISOString().split('T')[0]
+  })
+
+  const weekActualKm = dbSessions
+    .filter((s) => s.actual_km)
+    .reduce((sum, s) => sum + (s.actual_km ?? 0), 0)
+
+  const tooFastCount = dbSessions.filter((s) => s.went_too_fast).length
+  const completedCount = dbSessions.filter((s) => s.status === 'completed' || s.status === 'modified').length
+
+  const weekTypeLabels: Record<string, string> = {
+    normal: '',
+    limassol: '· Limassol Race Week',
+    post_limassol: '· Recovery',
+    peak: '· Peak Week',
+    taper: '· Taper',
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-8">
+      {/* Back */}
+      <Link href="/marathon" className="flex items-center gap-2 text-sm text-white/40 hover:text-white/70 transition-colors">
+        <ArrowLeft className="h-4 w-4" /> Training hub
+      </Link>
+
+      {/* Header */}
+      <div className="space-y-1">
+        <p className="text-xs text-white/40 uppercase tracking-wider">
+          Week {weekNumber} of 9{weekTypeLabels[planWeek.weekType]}
+        </p>
+        <h1 className="text-2xl font-bold text-white">{planWeek.label}</h1>
+        {planWeek.bloodDonationRecovery && (
+          <p className="text-xs text-amber-400 bg-amber-400/10 border border-amber-400/20 px-3 py-1.5 rounded-lg inline-block mt-2">
+            Blood donation recovery week — modified training load
+          </p>
+        )}
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {[
+          { label: 'Planned km', value: `${planWeek.plannedKm}km` },
+          { label: 'Actual km', value: `${weekActualKm.toFixed(1)}km` },
+          { label: 'Sessions done', value: `${completedCount}/${planWeek.sessions.filter(s => s.type !== 'REST').length}` },
+          { label: 'Pace alerts', value: tooFastCount > 0 ? `${tooFastCount} too fast` : 'Clean', valueClass: tooFastCount > 0 ? 'text-amber-400' : 'text-emerald-400' },
+        ].map((s) => (
+          <div key={s.label} className="rounded-xl bg-white/5 border border-white/10 p-4">
+            <p className="text-xs text-white/40">{s.label}</p>
+            <p className={`text-lg font-bold font-mono mt-1 ${(s as { valueClass?: string }).valueClass ?? 'text-white'}`}>{s.value}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Sessions */}
+      <div className="space-y-4">
+        {planWeek.sessions.map((session, i) => {
+          const sessionDate = weekDates[i]
+          const dbSession = dbSessions.find((s) => s.session_date === sessionDate) ?? null
+          const isToday = sessionDate === today
+          return (
+            <div key={session.dayOfWeek}>
+              <SessionCard
+                planned={session}
+                actual={dbSession}
+                date={sessionDate}
+                isToday={isToday}
+              />
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Week navigation */}
+      <div className="flex justify-between pt-4 border-t border-white/10">
+        {weekNumber > 1 ? (
+          <Link
+            href={`/marathon/week/${weekNumber - 1}`}
+            className="flex items-center gap-1 text-sm text-white/40 hover:text-white/70 transition-colors"
+          >
+            <ChevronLeft className="h-4 w-4" /> Week {weekNumber - 1}
+          </Link>
+        ) : <div />}
+        {weekNumber < 9 ? (
+          <Link
+            href={`/marathon/week/${weekNumber + 1}`}
+            className="flex items-center gap-1 text-sm text-white/40 hover:text-white/70 transition-colors"
+          >
+            Week {weekNumber + 1} <ChevronRight className="h-4 w-4" />
+          </Link>
+        ) : <div />}
+      </div>
+    </div>
+  )
+}

--- a/src/app/api/ai/marathon-coach/route.ts
+++ b/src/app/api/ai/marathon-coach/route.ts
@@ -1,0 +1,159 @@
+// Marathon Coach AI — streaming API route
+// Strict coaching for Belgrade Marathon prep (Gemini 2.5 Flash)
+
+import { google } from '@ai-sdk/google'
+import { streamText, convertToModelMessages } from 'ai'
+import { createClient } from '@/lib/supabase/server'
+import { TRAINING_PLAN, getCurrentWeek, getSessionForDate } from '@/lib/marathon/plan'
+
+export const runtime = 'nodejs'
+export const maxDuration = 60
+
+const ATHLETE_PROFILE = `
+ATHLETE: Silviya, 43F, Cyprus (EET UTC+2). Vegan. Trains fasted 04:00-06:30 EET. Nike Alphafly 3.
+A-RACE: Belgrade Marathon April 19, 2026 — TARGET 3:32:00 (5:00/km average).
+CHECKPOINT: Limassol Half Marathon March 22 — Target 1:44-1:45 (4:55-5:00/km).
+RECENT PRs: Marathon 3:46 Amsterdam Oct 2025 | Half 1:43 Nicosia Jan 2026.
+BLOOD DONATION: Week 2 (Feb 23-Mar 1) — iron supplementation daily for 2 weeks after.
+GEL RULE: ONLY Maurten or SIS gels — NEVER pre-workout supplements (caused panic attack).
+KNOWN PATTERN (CRITICAL): Consistently runs 4-10 sec/km FASTER than prescribed. This is the #1 threat to her plan.
+MENTAL: Needs external structure. Collapsed at km 18 Amsterdam when partner left. Belgrade is redemption.
+RHR BASELINE: 42-49 bpm. Flag if +5 bpm above recent average.
+`.trim()
+
+const TRAINING_PACES = `
+PRESCRIBED PACES:
+- Easy: 6:10-6:30/km | HR 130-145 bpm
+- Goal Marathon Pace (GMP): 5:00/km | HR 165-170 bpm
+- Tempo: 4:50-4:55/km | HR 165-175 bpm
+- VO2 Max: 4:30-4:40/km | 90%+ max HR
+- Hills: effort-based, 85-90% effort (not pace-based)
+WARM-UP RULES: Tempo = 2km @ 5:30/km. VO2 Max = 15min easy jog + dynamic stretches + 4×100m strides.
+`.trim()
+
+function buildSessionContext(mode: 'pre' | 'post', sessionData: Record<string, unknown>) {
+  if (mode === 'pre') {
+    return `
+MODE: Pre-session coaching
+TODAY'S SESSION: ${JSON.stringify(sessionData, null, 2)}
+
+PRE-SESSION coaching (max 120 words):
+- Today's ONE focus (be specific)
+- Exact pace reminder with numbers
+- Warm-up reminder if TEMPO or VO2_MAX
+- Any red flags from recent data to watch for
+`.trim()
+  }
+  return `
+MODE: Post-session debrief
+LOGGED SESSION: ${JSON.stringify(sessionData, null, 2)}
+
+POST-SESSION coaching (max 120 words):
+- Pace discipline verdict — did she nail it or go too fast AGAIN?
+- Execution quality (warmup done? fueling?)
+- One sentence on how this fits the bigger picture
+- One specific thing to do differently next time
+`.trim()
+}
+
+function buildRecentContext(recentSessions: unknown[]) {
+  if (!recentSessions.length) return 'No recent sessions logged.'
+  return (recentSessions as Array<Record<string, unknown>>)
+    .slice(0, 5)
+    .map((s) => {
+      const pace = s.actual_avg_pace ? `@ ${s.actual_avg_pace}/km` : '(no pace)'
+      const flag = s.went_too_fast ? ` ⚠️ TOO FAST (+${s.pace_deviation_sec}s/km)` : ''
+      const warmup = s.warmup_done === false && ['TEMPO','VO2_MAX'].includes(s.planned_type as string) ? ' ❌ NO WARMUP' : ''
+      return `- ${s.session_date} ${s.planned_type} ${pace} [${s.status}]${flag}${warmup}`
+    })
+    .join('\n')
+}
+
+export async function POST(req: Request) {
+  const { messages, mode = 'chat', sessionData, includeData = true } = await req.json()
+
+  const currentWeek = getCurrentWeek()
+  const today = new Date().toISOString().split('T')[0]
+  const todaySession = getSessionForDate(today)
+
+  let contextBlock = ''
+
+  if (includeData) {
+    try {
+      const supabase = createClient()
+
+      const [recentRes, rhrRes] = await Promise.all([
+        supabase
+          .from('training_sessions')
+          .select('session_date, planned_type, status, actual_avg_pace, went_too_fast, pace_deviation_sec, warmup_done, resting_hr, perceived_effort')
+          .neq('status', 'pending')
+          .order('session_date', { ascending: false })
+          .limit(5),
+        supabase
+          .from('resting_hr_logs')
+          .select('logged_date, resting_hr, is_spike')
+          .order('logged_date', { ascending: false })
+          .limit(7),
+      ])
+
+      const recentSessions = recentRes.data ?? []
+      const rhrLogs = rhrRes.data ?? []
+
+      const rhrSummary = rhrLogs.length
+        ? rhrLogs.map((r) => `${r.logged_date}: ${r.resting_hr}bpm${r.is_spike ? ' ⚠️ SPIKE' : ''}`).join(', ')
+        : 'No RHR data'
+
+      const tooFastCount = recentSessions.filter((s) => s.went_too_fast).length
+
+      contextBlock = `
+CURRENT WEEK: Week ${currentWeek?.weekNumber ?? '?'} — ${currentWeek?.label ?? 'Unknown'} (${TRAINING_PLAN.find(w => w.weekNumber === currentWeek?.weekNumber)?.plannedKm ?? '?'}km planned)
+TODAY: ${today} — ${todaySession ? `${todaySession.type}: ${todaySession.description}` : 'No session'}
+DAYS TO BELGRADE: ${Math.ceil((new Date('2026-04-19').getTime() - Date.now()) / 86400000)}
+DAYS TO LIMASSOL: ${Math.ceil((new Date('2026-03-22').getTime() - Date.now()) / 86400000)}
+
+RECENT SESSIONS (last 5):
+${buildRecentContext(recentSessions)}
+
+PACE DISCIPLINE ALERT: ${tooFastCount} of last ${recentSessions.length} sessions went too fast.
+
+RESTING HR (last 7 days): ${rhrSummary}
+`.trim()
+    } catch {
+      contextBlock = '(Training data unavailable — coaching from message context only.)'
+    }
+  }
+
+  const sessionContext = sessionData
+    ? buildSessionContext(mode as 'pre' | 'post', sessionData)
+    : ''
+
+  const systemPrompt = `You are a strict marathon coach. No padding. No waffle. Direct feedback only.
+
+${ATHLETE_PROFILE}
+
+${TRAINING_PACES}
+
+COACHING RULES:
+1. Call out going too fast EVERY time it happens. No softening.
+2. Warmups are non-negotiable for Tempo and VO2 Max — call out skips.
+3. Easy pace is 6:10-6:30/km. Not 6:05. Not 6:00. 6:10-6:30.
+4. Max 120 words per response unless asked for detail.
+5. Style: Direct. Brief. No praise unless genuinely earned.
+6. She does not melt from criticism — she needs it.
+
+${contextBlock ? `LIVE TRAINING DATA:\n${contextBlock}` : ''}
+
+${sessionContext}`
+
+  const modelMessages = await convertToModelMessages(messages)
+
+  const result = streamText({
+    model: google('gemini-2.5-flash'),
+    system: systemPrompt,
+    messages: modelMessages,
+    maxOutputTokens: 600,
+    temperature: 0.6,
+  })
+
+  return result.toUIMessageStreamResponse()
+}

--- a/src/app/api/marathon/race-result/route.ts
+++ b/src/app/api/marathon/race-result/route.ts
@@ -1,0 +1,22 @@
+// POST /api/marathon/race-result — upsert a race result
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function POST(req: NextRequest) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const body = await req.json()
+
+  const { error } = await supabase
+    .from('race_results')
+    .upsert(
+      { ...body, user_id: user.id },
+      { onConflict: 'user_id,race_date' },
+    )
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/marathon/session/[date]/route.ts
+++ b/src/app/api/marathon/session/[date]/route.ts
@@ -1,0 +1,76 @@
+// POST /api/marathon/session/[date] — upsert a training session log
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { date: string } },
+) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const body = await req.json()
+  const { date } = params
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return NextResponse.json({ error: 'Invalid date format' }, { status: 400 })
+  }
+
+  const { error } = await supabase
+    .from('training_sessions')
+    .upsert(
+      { ...body, user_id: user.id, session_date: date },
+      { onConflict: 'user_id,session_date' },
+    )
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+
+  // Update week actual_km
+  if (body.week_number && body.actual_km != null) {
+    const { data: weekSessions } = await supabase
+      .from('training_sessions')
+      .select('actual_km')
+      .eq('user_id', user.id)
+      .eq('week_number', body.week_number)
+      .not('actual_km', 'is', null)
+
+    const weekTotal = (weekSessions ?? []).reduce((s: number, r: { actual_km: number | null }) => s + (r.actual_km ?? 0), 0)
+
+    await supabase
+      .from('training_weeks')
+      .upsert(
+        {
+          user_id: user.id,
+          week_number: body.week_number,
+          week_label: body.week_label ?? `Week ${body.week_number}`,
+          week_type: body.week_type ?? 'normal',
+          actual_km: weekTotal,
+          status: 'in_progress',
+        },
+        { onConflict: 'user_id,week_number' },
+      )
+  }
+
+  return NextResponse.json({ ok: true })
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { date: string } },
+) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { data, error } = await supabase
+    .from('training_sessions')
+    .select('*')
+    .eq('user_id', user.id)
+    .eq('session_date', params.date)
+    .single()
+
+  if (error) return NextResponse.json(null)
+  return NextResponse.json(data)
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -16,6 +16,7 @@ import {
   X,
   ShieldCheck,
   Salad,
+  Timer,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { createClient } from "@/lib/supabase/client";
@@ -28,6 +29,7 @@ const navItems: Array<{ href: string; label: string; icon: React.ElementType; in
   { href: "/trading", label: "Trading", icon: TrendingUp },
   { href: "/trading/accountability", label: "Accountability", icon: ShieldCheck, indent: true },
   { href: "/running", label: "Running", icon: Footprints },
+  { href: "/marathon", label: "Marathon", icon: Timer },
   { href: "/nutrition", label: "Nutrition", icon: Salad },
   { href: "/finance", label: "Finance", icon: Wallet },
   { href: "/books", label: "Books", icon: BookOpen },

--- a/src/components/marathon/AICoach.tsx
+++ b/src/components/marathon/AICoach.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { CoachChat } from '@/components/ai/coach-chat'
+
+interface AICoachProps {
+  mode?: 'pre' | 'post' | 'chat'
+  sessionData?: Record<string, unknown>
+  initialPrompt?: string
+}
+
+export function AICoach({ mode = 'chat', sessionData, initialPrompt }: AICoachProps) {
+  const subtitleMap = {
+    pre: 'Pre-session · What to focus on today',
+    post: 'Post-session debrief · Pace verdict + feedback',
+    chat: 'Belgrade Marathon prep · 3:32 target',
+  }
+
+  const placeholderMap = {
+    pre: 'What should I focus on today?',
+    post: 'How did I do? Any concerns?',
+    chat: 'How is my training going? Am I on track for 3:32?',
+  }
+
+  return (
+    <CoachChat
+      apiEndpoint="/api/ai/marathon-coach"
+      title="Marathon Coach"
+      subtitle={subtitleMap[mode]}
+      placeholder={initialPrompt ?? placeholderMap[mode]}
+      accentClass="text-orange-400"
+      accentBgClass="bg-orange-400/10"
+      accentBorderClass="border-orange-400/20"
+      extraBody={{ mode, sessionData: sessionData ?? null, includeData: true }}
+    />
+  )
+}

--- a/src/components/marathon/LimassolResultForm.tsx
+++ b/src/components/marathon/LimassolResultForm.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { Loader2 } from 'lucide-react'
+
+function timeToSeconds(time: string): number {
+  const parts = time.split(':').map(Number)
+  if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2]
+  return parts[0] * 60 + (parts[1] ?? 0)
+}
+
+export function LimassolResultForm() {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [finish, setFinish] = useState('')
+  const [notes, setNotes] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!finish.match(/^\d+:\d{2}:\d{2}$/)) {
+      setError('Use format H:MM:SS (e.g. 1:44:32)')
+      return
+    }
+
+    const finishSec = timeToSeconds(finish)
+    const avgPaceSec = Math.round(finishSec / 21.0975)
+    const m = Math.floor(avgPaceSec / 60)
+    const s = avgPaceSec % 60
+    const avgPace = `${m}:${String(s).padStart(2, '0')}`
+
+    try {
+      const res = await fetch('/api/marathon/race-result', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          race_date: '2026-03-22',
+          race_name: 'Limassol Half Marathon',
+          distance_km: 21.0975,
+          finish_time: finish,
+          finish_time_seconds: finishSec,
+          avg_pace: avgPace,
+          notes,
+          official: true,
+        }),
+      })
+      if (!res.ok) throw new Error(await res.text())
+      startTransition(() => router.refresh())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save')
+    }
+  }
+
+  return (
+    <div className="rounded-xl bg-white/5 border border-white/10 p-6 space-y-6">
+      <h2 className="text-sm font-semibold text-white">Log Limassol Result</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <label className="text-xs font-medium text-white/40 uppercase tracking-wider">Finish Time (H:MM:SS)</label>
+          <input
+            type="text"
+            value={finish}
+            onChange={(e) => setFinish(e.target.value)}
+            placeholder="1:44:32"
+            className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white font-mono text-lg placeholder:text-white/20 focus:outline-none focus:border-white/25"
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-xs font-medium text-white/40 uppercase tracking-wider">Notes</label>
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="How did the race go? Splits? How you felt at km 15?"
+            rows={3}
+            className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-sm text-white placeholder:text-white/20 focus:outline-none focus:border-white/25 resize-none"
+          />
+        </div>
+        {error && <p className="text-sm text-red-400">{error}</p>}
+        <button
+          type="submit"
+          disabled={isPending}
+          className="w-full py-3 rounded-xl text-sm font-semibold bg-orange-500 hover:bg-orange-400 disabled:opacity-50 text-white transition-colors flex items-center justify-center gap-2"
+        >
+          {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+          Save Result
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/components/marathon/PaceDisciplineAlert.tsx
+++ b/src/components/marathon/PaceDisciplineAlert.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useState } from 'react'
+import { AlertTriangle } from 'lucide-react'
+
+interface PaceDisciplineAlertProps {
+  plannedPace: string
+  actualPace: string
+  deviationSec: number
+  sessionType: string
+  onAcknowledge: () => void
+}
+
+export function PaceDisciplineAlert({
+  plannedPace,
+  actualPace,
+  deviationSec,
+  sessionType,
+  onAcknowledge,
+}: PaceDisciplineAlertProps) {
+  const [acknowledged, setAcknowledged] = useState(false)
+
+  if (acknowledged) return null
+
+  const handleAck = () => {
+    setAcknowledged(true)
+    onAcknowledge()
+  }
+
+  return (
+    <div className="rounded-xl bg-red-500/15 border-2 border-red-500/50 p-5 space-y-4">
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="h-5 w-5 text-red-400 shrink-0 mt-0.5" />
+        <div className="space-y-1">
+          <p className="text-sm font-bold text-red-300">YOU DID IT AGAIN</p>
+          <p className="text-sm text-white/80">
+            Planned: <span className="font-mono font-bold text-white">{plannedPace}/km</span>
+            {' '}— Actual: <span className="font-mono font-bold text-red-300">{actualPace}/km</span>
+            {' '}({deviationSec} sec/km too fast)
+          </p>
+        </div>
+      </div>
+      <p className="text-sm text-white/70 leading-relaxed">
+        This is the <strong className="text-white">#1 risk to your Belgrade goal.</strong>{' '}
+        {sessionType === 'TEMPO' && 'Tempo runs at the right pace build lactate clearance. Faster = junk miles that don\'t build fitness.'}
+        {sessionType === 'EASY' && 'Easy runs must be easy — they are what allow you to perform on hard days. Going too fast now costs you on race day.'}
+        {sessionType === 'LONG_RUN' && 'Long runs should be aerobic base building. Going too fast turns recovery into stress.'}
+        {!['TEMPO', 'EASY', 'LONG_RUN'].includes(sessionType) && 'Pace discipline is the #1 predictor of a successful marathon block.'}
+      </p>
+      <button
+        onClick={handleAck}
+        className="w-full py-2.5 rounded-lg text-sm font-semibold bg-red-500/20 text-red-300 hover:bg-red-500/30 border border-red-500/30 transition-colors"
+      >
+        I acknowledge this
+      </button>
+    </div>
+  )
+}

--- a/src/components/marathon/PaceDisciplineChart.tsx
+++ b/src/components/marathon/PaceDisciplineChart.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import {
+  LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer,
+  Dot,
+} from 'recharts'
+import { parsePaceToSeconds, formatPace } from '@/lib/marathon/plan'
+import type { TrainingSessionRow } from '@/lib/supabase/marathon'
+
+interface PaceDisciplineChartProps {
+  sessions: TrainingSessionRow[]
+}
+
+export function PaceDisciplineChart({ sessions }: PaceDisciplineChartProps) {
+  const data = sessions
+    .filter((s) => s.actual_avg_pace && s.planned_pace_min)
+    .map((s) => ({
+      date: s.session_date.slice(5),  // MM-DD
+      actual: parsePaceToSeconds(s.actual_avg_pace!),
+      planned: parsePaceToSeconds(s.planned_pace_min!),
+      plannedMax: s.planned_pace_max ? parsePaceToSeconds(s.planned_pace_max) : parsePaceToSeconds(s.planned_pace_min!),
+      tooFast: s.went_too_fast,
+      type: s.planned_type,
+    }))
+    .reverse()
+
+  if (data.length === 0) {
+    return <p className="text-xs text-white/30 py-4 text-center">No sessions with pace data yet.</p>
+  }
+
+  const formatTick = (val: number) => formatPace(val)
+
+  return (
+    <ResponsiveContainer width="100%" height={220}>
+      <LineChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+        <XAxis
+          dataKey="date"
+          tick={{ fill: 'rgba(255,255,255,0.3)', fontSize: 10 }}
+          axisLine={false}
+          tickLine={false}
+        />
+        <YAxis
+          tickFormatter={formatTick}
+          tick={{ fill: 'rgba(255,255,255,0.3)', fontSize: 10 }}
+          axisLine={false}
+          tickLine={false}
+          width={42}
+          reversed
+        />
+        <Tooltip
+          contentStyle={{ background: '#1a1a1a', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 8 }}
+          labelStyle={{ color: 'rgba(255,255,255,0.6)', fontSize: 11 }}
+          formatter={(value: number, name: string) => [formatPace(value), name === 'actual' ? 'Actual pace' : 'Planned pace']}
+        />
+        {/* Planned pace line */}
+        <Line
+          dataKey="planned"
+          stroke="rgba(255,255,255,0.2)"
+          strokeWidth={1}
+          strokeDasharray="4 4"
+          dot={false}
+          name="planned"
+        />
+        {/* Actual pace line with colored dots */}
+        <Line
+          dataKey="actual"
+          stroke="#f97316"
+          strokeWidth={2}
+          dot={(props: { cx: number; cy: number; payload: { tooFast: boolean } }) => {
+            const { cx, cy, payload } = props
+            return (
+              <Dot
+                key={`dot-${cx}-${cy}`}
+                cx={cx}
+                cy={cy}
+                r={4}
+                fill={payload.tooFast ? '#ef4444' : '#22c55e'}
+                stroke="none"
+              />
+            )
+          }}
+          activeDot={{ r: 5, fill: '#f97316' }}
+          name="actual"
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/src/components/marathon/RaceCountdown.tsx
+++ b/src/components/marathon/RaceCountdown.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { daysUntil, RACE_DATE, LIMASSOL_DATE } from '@/lib/marathon/plan'
+
+interface RaceCountdownProps {
+  currentWeek: number
+}
+
+export function RaceCountdown({ currentWeek }: RaceCountdownProps) {
+  const daysToBelgrade = daysUntil(RACE_DATE)
+  const daysToLimassol = daysUntil(LIMASSOL_DATE)
+  const weekProgress = Math.round((currentWeek / 9) * 100)
+
+  return (
+    <div className="rounded-xl bg-white/5 border border-white/10 p-5 space-y-4">
+      {/* Belgrade */}
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-xs text-white/40 uppercase tracking-wider">Belgrade Marathon</p>
+          <p className="text-lg font-bold text-white mt-0.5">Apr 19 · Target 3:32:00</p>
+        </div>
+        <div className="text-right">
+          <p className="text-3xl font-mono font-bold text-white">{daysToBelgrade}</p>
+          <p className="text-xs text-white/40">days to go</p>
+        </div>
+      </div>
+
+      {/* Week progress bar */}
+      <div className="space-y-1.5">
+        <div className="flex justify-between text-xs text-white/40">
+          <span>Week {currentWeek} of 9</span>
+          <span>{weekProgress}%</span>
+        </div>
+        <div className="h-1.5 rounded-full bg-white/10 overflow-hidden">
+          <div
+            className="h-full rounded-full bg-orange-500 transition-all"
+            style={{ width: `${weekProgress}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Limassol */}
+      {daysToLimassol > 0 && (
+        <div className="flex items-center justify-between border-t border-white/10 pt-3">
+          <div>
+            <p className="text-xs text-white/40 uppercase tracking-wider">Limassol Half</p>
+            <p className="text-sm font-medium text-white/70">Mar 22 · Target 1:44-1:45</p>
+          </div>
+          <div className="text-right">
+            <p className="text-xl font-mono font-bold text-yellow-400">{daysToLimassol}</p>
+            <p className="text-xs text-white/40">days</p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/marathon/SessionCard.tsx
+++ b/src/components/marathon/SessionCard.tsx
@@ -1,0 +1,154 @@
+import Link from 'next/link'
+import { CheckCircle2, Clock, XCircle, AlertTriangle, Minus } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { PlannedSession } from '@/lib/marathon/plan'
+import { SESSION_TYPE_LABELS, SESSION_TYPE_COLORS } from '@/lib/marathon/plan'
+import type { TrainingSessionRow } from '@/lib/supabase/marathon'
+
+interface SessionCardProps {
+  planned: PlannedSession
+  actual: TrainingSessionRow | null
+  date: string           // ISO date
+  isToday?: boolean
+  compact?: boolean      // for week overview
+}
+
+function StatusIcon({ status, wentTooFast }: { status: string; wentTooFast: boolean }) {
+  if (wentTooFast) return <AlertTriangle className="h-4 w-4 text-amber-400 shrink-0" />
+  switch (status) {
+    case 'completed': return <CheckCircle2 className="h-4 w-4 text-emerald-400 shrink-0" />
+    case 'skipped':   return <XCircle className="h-4 w-4 text-red-400 shrink-0" />
+    case 'modified':  return <CheckCircle2 className="h-4 w-4 text-blue-400 shrink-0" />
+    default:          return <Clock className="h-4 w-4 text-white/20 shrink-0" />
+  }
+}
+
+export function SessionCard({ planned, actual, date, isToday, compact }: SessionCardProps) {
+  const isRest = planned.type === 'REST'
+  const status = actual?.status ?? 'pending'
+  const wentTooFast = actual?.went_too_fast ?? false
+  const typeColor = SESSION_TYPE_COLORS[planned.type]
+
+  if (compact) {
+    return (
+      <div className={cn(
+        'flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm',
+        isToday ? 'bg-white/8 border border-white/20' : 'bg-white/[0.03] border border-white/[0.06]',
+      )}>
+        <span className={cn('text-xs font-semibold px-1.5 py-0.5 rounded font-mono', typeColor)}>
+          {planned.dayOfWeek}
+        </span>
+        <span className={cn('text-xs font-medium px-1.5 py-0.5 rounded', typeColor)}>
+          {SESSION_TYPE_LABELS[planned.type]}
+        </span>
+        <div className="flex-1 min-w-0">
+          {actual?.actual_avg_pace && (
+            <span className="text-xs text-white/50 font-mono">
+              {actual.actual_km}km @ {actual.actual_avg_pace}/km
+            </span>
+          )}
+          {!actual?.actual_avg_pace && planned.plannedKm && !isRest && (
+            <span className="text-xs text-white/30">
+              {planned.plannedKm}km planned
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-1.5">
+          {wentTooFast && (
+            <span className="text-xs text-amber-400 font-mono">+{actual?.pace_deviation_sec}s</span>
+          )}
+          {isToday && status === 'pending' && !isRest ? (
+            <Link
+              href={`/marathon/session/${date}`}
+              className="text-xs px-2 py-0.5 rounded bg-orange-500/20 text-orange-400 hover:bg-orange-500/30 transition-colors"
+            >
+              Log
+            </Link>
+          ) : (
+            <StatusIcon status={status} wentTooFast={wentTooFast} />
+          )}
+          {isRest && <Minus className="h-3.5 w-3.5 text-white/20" />}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={cn(
+      'rounded-xl border p-5 space-y-3',
+      isToday
+        ? 'bg-white/8 border-orange-500/30 ring-1 ring-orange-500/20'
+        : 'bg-white/5 border-white/10',
+      wentTooFast && 'border-amber-400/30',
+    )}>
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2 flex-wrap">
+          {isToday && (
+            <span className="text-xs font-semibold text-orange-400 uppercase tracking-wider">Today</span>
+          )}
+          <span className={cn('text-xs font-semibold px-2 py-0.5 rounded', typeColor)}>
+            {SESSION_TYPE_LABELS[planned.type]}
+          </span>
+          {planned.hasStrength && (
+            <span className="text-xs text-white/40 bg-white/5 px-2 py-0.5 rounded">
+              + Strength {planned.strengthWorkout}
+            </span>
+          )}
+        </div>
+        <StatusIcon status={status} wentTooFast={wentTooFast} />
+      </div>
+
+      {/* Description */}
+      {!isRest && (
+        <p className="text-sm text-white/70 leading-relaxed">{planned.description}</p>
+      )}
+
+      {/* Planned paces */}
+      {planned.paceMin && (
+        <div className="flex gap-4 text-xs text-white/40 font-mono">
+          <span>Target: {planned.paceMin}{planned.paceMax && planned.paceMax !== planned.paceMin ? `–${planned.paceMax}` : ''}/km</span>
+          {planned.plannedKm && <span>{planned.plannedKm}km</span>}
+        </div>
+      )}
+
+      {/* Actual results */}
+      {actual && status !== 'pending' && (
+        <div className={cn(
+          'rounded-lg p-3 space-y-1 text-sm',
+          wentTooFast ? 'bg-amber-400/10 border border-amber-400/20' : 'bg-white/5',
+        )}>
+          <div className="flex gap-4 font-mono text-xs flex-wrap">
+            {actual.actual_km && <span className="text-white/80">{actual.actual_km}km</span>}
+            {actual.actual_avg_pace && (
+              <span className={wentTooFast ? 'text-amber-400' : 'text-white/80'}>
+                @ {actual.actual_avg_pace}/km
+                {wentTooFast && ` (+${actual.pace_deviation_sec}s/km too fast)`}
+              </span>
+            )}
+            {actual.actual_avg_hr && <span className="text-white/50">HR {actual.actual_avg_hr}</span>}
+          </div>
+          {actual.notes && <p className="text-xs text-white/40">{actual.notes}</p>}
+        </div>
+      )}
+
+      {/* CTA */}
+      {isToday && status === 'pending' && !isRest && (
+        <Link
+          href={`/marathon/session/${date}`}
+          className="block w-full text-center text-sm font-semibold py-2.5 rounded-lg bg-orange-500 hover:bg-orange-400 text-white transition-colors"
+        >
+          Log This Session
+        </Link>
+      )}
+      {!isToday && status === 'pending' && !isRest && (
+        <Link
+          href={`/marathon/session/${date}`}
+          className="block w-full text-center text-xs text-white/30 hover:text-white/60 py-1 transition-colors"
+        >
+          Log early →
+        </Link>
+      )}
+    </div>
+  )
+}

--- a/src/components/marathon/SessionLogForm.tsx
+++ b/src/components/marathon/SessionLogForm.tsx
@@ -1,0 +1,396 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
+import { z } from 'zod'
+import { CheckCircle2, Loader2 } from 'lucide-react'
+import { PaceDisciplineAlert } from './PaceDisciplineAlert'
+import { checkWentTooFast, SESSION_TYPE_LABELS } from '@/lib/marathon/plan'
+import type { PlannedSession } from '@/lib/marathon/plan'
+
+const schema = z.object({
+  status: z.enum(['completed', 'skipped', 'modified']),
+  actual_km: z.number().min(0).max(100).optional(),
+  actual_avg_pace: z.string().regex(/^\d+:\d{2}$/).optional(),
+  actual_avg_hr: z.number().int().min(40).max(220).optional(),
+  actual_duration_min: z.number().int().min(0).max(600).optional(),
+  perceived_effort: z.number().int().min(1).max(10).optional(),
+  warmup_done: z.boolean().optional(),
+  post_fuel_done: z.boolean().optional(),
+  resting_hr: z.number().int().min(30).max(120).optional(),
+  notes: z.string().max(1000).optional(),
+})
+
+interface SessionLogFormProps {
+  date: string
+  planned: PlannedSession
+  weekNumber: number
+  existingActual?: {
+    status: string
+    actual_km?: number | null
+    actual_avg_pace?: string | null
+    actual_avg_hr?: number | null
+    actual_duration_min?: number | null
+    perceived_effort?: number | null
+    warmup_done?: boolean | null
+    post_fuel_done?: boolean | null
+    resting_hr?: number | null
+    notes?: string | null
+  } | null
+}
+
+export function SessionLogForm({ date, planned, weekNumber, existingActual }: SessionLogFormProps) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [showAlert, setShowAlert] = useState(false)
+  const [alertData, setAlertData] = useState<{ actual: string; deviation: number } | null>(null)
+  const [acknowledged, setAcknowledged] = useState(false)
+
+  const isRest = planned.type === 'REST'
+  const needsWarmup = ['TEMPO', 'VO2_MAX'].includes(planned.type)
+
+  const [form, setForm] = useState({
+    status: (existingActual?.status as 'completed' | 'skipped' | 'modified') ?? 'completed',
+    actual_km: existingActual?.actual_km?.toString() ?? planned.plannedKm?.toString() ?? '',
+    actual_avg_pace: existingActual?.actual_avg_pace ?? planned.paceMin ?? '',
+    actual_avg_hr: existingActual?.actual_avg_hr?.toString() ?? '',
+    actual_duration_min: existingActual?.actual_duration_min?.toString() ?? '',
+    perceived_effort: existingActual?.perceived_effort?.toString() ?? '',
+    warmup_done: existingActual?.warmup_done ?? (needsWarmup ? false : true),
+    post_fuel_done: existingActual?.post_fuel_done ?? false,
+    resting_hr: existingActual?.resting_hr?.toString() ?? '',
+    notes: existingActual?.notes ?? '',
+  })
+
+  const set = (key: keyof typeof form, value: unknown) =>
+    setForm((f) => ({ ...f, [key]: value }))
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+
+    const payload: Record<string, unknown> = {
+      status: form.status,
+      actual_km: form.actual_km ? parseFloat(form.actual_km) : undefined,
+      actual_avg_pace: form.actual_avg_pace || undefined,
+      actual_avg_hr: form.actual_avg_hr ? parseInt(form.actual_avg_hr) : undefined,
+      actual_duration_min: form.actual_duration_min ? parseInt(form.actual_duration_min) : undefined,
+      perceived_effort: form.perceived_effort ? parseInt(form.perceived_effort) : undefined,
+      warmup_done: form.warmup_done,
+      post_fuel_done: form.post_fuel_done,
+      resting_hr: form.resting_hr ? parseInt(form.resting_hr) : undefined,
+      notes: form.notes || undefined,
+    }
+
+    // Pace discipline check
+    let wentTooFast = false
+    let paceDeviationSec = 0
+    let paceTargetMet = true
+
+    if (form.actual_avg_pace && planned.paceMin && form.status !== 'skipped') {
+      const check = checkWentTooFast(form.actual_avg_pace, planned.paceMin)
+      wentTooFast = check.went
+      paceDeviationSec = check.deviationSec
+      paceTargetMet = !wentTooFast
+    }
+
+    // Warmup check
+    const skippedWarmup = needsWarmup && form.warmup_done === false
+
+    // RHR spike check (>49 bpm is above baseline max)
+    const rhrSpike = form.resting_hr ? parseInt(form.resting_hr) > 49 : false
+
+    try {
+      const res = await fetch(`/api/marathon/session/${date}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...payload,
+          week_number: weekNumber,
+          day_of_week: planned.dayOfWeek,
+          planned_type: planned.type,
+          planned_description: planned.description,
+          planned_km: planned.plannedKm,
+          planned_pace_min: planned.paceMin,
+          planned_pace_max: planned.paceMax,
+          has_strength: planned.hasStrength,
+          strength_workout: planned.strengthWorkout,
+          went_too_fast: wentTooFast,
+          skipped_warmup: skippedWarmup,
+          pace_target_met: paceTargetMet,
+          pace_deviation_sec: paceDeviationSec,
+        }),
+      })
+
+      if (!res.ok) throw new Error(await res.text())
+
+      if (wentTooFast && !acknowledged) {
+        setAlertData({ actual: form.actual_avg_pace, deviation: paceDeviationSec })
+        setShowAlert(true)
+        return
+      }
+
+      if (rhrSpike) {
+        // just show a note — don't block
+      }
+
+      setSaved(true)
+      startTransition(() => {
+        router.refresh()
+        setTimeout(() => router.push('/marathon'), 1500)
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save session')
+    }
+  }
+
+  if (saved) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+        <CheckCircle2 className="h-10 w-10 text-emerald-400" />
+        <p className="text-lg font-semibold text-white">Session logged</p>
+        <p className="text-sm text-white/40">Redirecting to training hub…</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {showAlert && alertData && planned.paceMin && (
+        <PaceDisciplineAlert
+          plannedPace={planned.paceMin}
+          actualPace={alertData.actual}
+          deviationSec={alertData.deviation}
+          sessionType={planned.type}
+          onAcknowledge={() => {
+            setAcknowledged(true)
+            setShowAlert(false)
+            setSaved(true)
+            startTransition(() => {
+              router.refresh()
+              setTimeout(() => router.push('/marathon'), 1500)
+            })
+          }}
+        />
+      )}
+
+      {!showAlert && (
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {/* Session type badge */}
+          <div className="flex items-center gap-3">
+            <span className="text-xs font-semibold text-white/40 uppercase tracking-wider">
+              {planned.dayOfWeek} · {SESSION_TYPE_LABELS[planned.type]}
+            </span>
+          </div>
+
+          {/* Status */}
+          <div className="space-y-2">
+            <label className="text-xs font-medium text-white/50 uppercase tracking-wider">Status</label>
+            <div className="flex gap-2">
+              {(['completed', 'modified', 'skipped'] as const).map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => set('status', s)}
+                  className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors capitalize ${
+                    form.status === s
+                      ? s === 'skipped'
+                        ? 'bg-red-500/20 text-red-300 border border-red-500/30'
+                        : 'bg-emerald-500/20 text-emerald-300 border border-emerald-500/30'
+                      : 'bg-white/5 text-white/40 border border-white/10 hover:bg-white/10'
+                  }`}
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {form.status !== 'skipped' && !isRest && (
+            <>
+              {/* Morning RHR */}
+              <div className="space-y-2">
+                <label className="text-xs font-medium text-white/50 uppercase tracking-wider">
+                  Morning RHR (bpm) <span className="text-white/25 normal-case">— log before getting up</span>
+                </label>
+                <input
+                  type="number"
+                  value={form.resting_hr}
+                  onChange={(e) => set('resting_hr', e.target.value)}
+                  placeholder="42–49 normal"
+                  className="input-field w-32"
+                  min={30}
+                  max={120}
+                />
+                {form.resting_hr && parseInt(form.resting_hr) > 49 && (
+                  <p className="text-xs text-amber-400">
+                    RHR above baseline (42-49 bpm). Monitor fatigue today.
+                  </p>
+                )}
+              </div>
+
+              {/* Actual km */}
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+                <div className="space-y-2">
+                  <label className="text-xs font-medium text-white/50 uppercase tracking-wider">Distance (km)</label>
+                  <input
+                    type="number"
+                    value={form.actual_km}
+                    onChange={(e) => set('actual_km', e.target.value)}
+                    step="0.1"
+                    placeholder={planned.plannedKm?.toString() ?? '0'}
+                    className="input-field"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-xs font-medium text-white/50 uppercase tracking-wider">Avg Pace</label>
+                  <input
+                    type="text"
+                    value={form.actual_avg_pace}
+                    onChange={(e) => set('actual_avg_pace', e.target.value)}
+                    placeholder={planned.paceMin ?? '6:20'}
+                    className="input-field font-mono"
+                  />
+                  {planned.paceMin && form.actual_avg_pace && form.actual_avg_pace.match(/^\d+:\d{2}$/) && (
+                    <p className={`text-xs font-mono ${
+                      checkWentTooFast(form.actual_avg_pace, planned.paceMin).went
+                        ? 'text-red-400'
+                        : 'text-emerald-400'
+                    }`}>
+                      Target: {planned.paceMin}/km
+                    </p>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-xs font-medium text-white/50 uppercase tracking-wider">Avg HR</label>
+                  <input
+                    type="number"
+                    value={form.actual_avg_hr}
+                    onChange={(e) => set('actual_avg_hr', e.target.value)}
+                    placeholder="145"
+                    className="input-field"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-xs font-medium text-white/50 uppercase tracking-wider">Duration (min)</label>
+                  <input
+                    type="number"
+                    value={form.actual_duration_min}
+                    onChange={(e) => set('actual_duration_min', e.target.value)}
+                    placeholder="60"
+                    className="input-field"
+                  />
+                </div>
+              </div>
+
+              {/* RPE */}
+              <div className="space-y-2">
+                <label className="text-xs font-medium text-white/50 uppercase tracking-wider">
+                  Perceived Effort (RPE 1-10)
+                </label>
+                <div className="flex gap-2 flex-wrap">
+                  {Array.from({ length: 10 }, (_, i) => i + 1).map((n) => (
+                    <button
+                      key={n}
+                      type="button"
+                      onClick={() => set('perceived_effort', n.toString())}
+                      className={`h-9 w-9 rounded-lg text-sm font-mono font-medium transition-colors ${
+                        form.perceived_effort === n.toString()
+                          ? n <= 3 ? 'bg-emerald-500/30 text-emerald-300 border border-emerald-500/40'
+                            : n <= 6 ? 'bg-yellow-500/30 text-yellow-300 border border-yellow-500/40'
+                            : 'bg-red-500/30 text-red-300 border border-red-500/40'
+                          : 'bg-white/5 text-white/40 border border-white/10 hover:bg-white/10'
+                      }`}
+                    >
+                      {n}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Checkboxes */}
+              <div className="space-y-3">
+                {needsWarmup && (
+                  <label className="flex items-center gap-3 cursor-pointer group">
+                    <input
+                      type="checkbox"
+                      checked={form.warmup_done === true}
+                      onChange={(e) => set('warmup_done', e.target.checked)}
+                      className="h-4 w-4 rounded border-white/20 bg-white/5 accent-orange-500"
+                    />
+                    <span className="text-sm text-white/70 group-hover:text-white/90 transition-colors">
+                      Warm-up completed
+                      {planned.type === 'TEMPO' && <span className="text-white/30 text-xs ml-2">(2km @ 5:30/km)</span>}
+                      {planned.type === 'VO2_MAX' && <span className="text-white/30 text-xs ml-2">(15min easy + strides)</span>}
+                    </span>
+                  </label>
+                )}
+
+                <label className="flex items-center gap-3 cursor-pointer group">
+                  <input
+                    type="checkbox"
+                    checked={form.post_fuel_done === true}
+                    onChange={(e) => set('post_fuel_done', e.target.checked)}
+                    className="h-4 w-4 rounded border-white/20 bg-white/5 accent-orange-500"
+                  />
+                  <span className="text-sm text-white/70 group-hover:text-white/90 transition-colors">
+                    Post-run fuel within 30min
+                  </span>
+                </label>
+              </div>
+            </>
+          )}
+
+          {/* Notes */}
+          <div className="space-y-2">
+            <label className="text-xs font-medium text-white/50 uppercase tracking-wider">Notes</label>
+            <textarea
+              value={form.notes}
+              onChange={(e) => set('notes', e.target.value)}
+              placeholder="How did it feel? Anything unusual?"
+              rows={3}
+              className="input-field resize-none"
+            />
+          </div>
+
+          {error && (
+            <p className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-3">{error}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isPending}
+            className="w-full py-3 rounded-xl text-sm font-semibold bg-orange-500 hover:bg-orange-400 disabled:opacity-50 text-white transition-colors flex items-center justify-center gap-2"
+          >
+            {isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+            Save Session
+          </button>
+        </form>
+      )}
+
+      <style jsx>{`
+        .input-field {
+          width: 100%;
+          background: rgba(255,255,255,0.05);
+          border: 1px solid rgba(255,255,255,0.1);
+          border-radius: 0.5rem;
+          padding: 0.625rem 0.75rem;
+          font-size: 0.875rem;
+          color: white;
+          outline: none;
+          transition: border-color 0.15s;
+        }
+        .input-field:focus {
+          border-color: rgba(255,255,255,0.25);
+        }
+        .input-field::placeholder {
+          color: rgba(255,255,255,0.2);
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/src/components/marathon/WeeklyProgress.tsx
+++ b/src/components/marathon/WeeklyProgress.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts'
+import type { TrainingWeek } from '@/lib/marathon/plan'
+import type { TrainingWeekRow } from '@/lib/supabase/marathon'
+
+interface WeeklyProgressProps {
+  planWeeks: TrainingWeek[]
+  dbWeeks: TrainingWeekRow[]
+}
+
+export function WeeklyProgress({ planWeeks, dbWeeks }: WeeklyProgressProps) {
+  const data = planWeeks.map((w) => {
+    const db = dbWeeks.find((d) => d.week_number === w.weekNumber)
+    return {
+      week: `W${w.weekNumber}`,
+      planned: w.plannedKm,
+      actual: db?.actual_km ?? 0,
+      type: w.weekType,
+    }
+  })
+
+  return (
+    <div className="rounded-xl bg-white/5 border border-white/10 p-5 space-y-4">
+      <h2 className="text-sm font-semibold text-white">Weekly Volume</h2>
+      <ResponsiveContainer width="100%" height={160}>
+        <BarChart data={data} barGap={4} barCategoryGap="30%">
+          <XAxis
+            dataKey="week"
+            tick={{ fill: 'rgba(255,255,255,0.4)', fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+          />
+          <YAxis
+            tick={{ fill: 'rgba(255,255,255,0.3)', fontSize: 10 }}
+            axisLine={false}
+            tickLine={false}
+            width={28}
+          />
+          <Tooltip
+            contentStyle={{ background: '#1a1a1a', border: '1px solid rgba(255,255,255,0.1)', borderRadius: 8 }}
+            labelStyle={{ color: 'rgba(255,255,255,0.6)', fontSize: 12 }}
+            itemStyle={{ fontSize: 12 }}
+            formatter={(value: number, name: string) => [`${value}km`, name === 'planned' ? 'Planned' : 'Actual']}
+          />
+          <Bar dataKey="planned" fill="rgba(255,255,255,0.08)" radius={[3, 3, 0, 0]} name="planned" />
+          <Bar dataKey="actual" radius={[3, 3, 0, 0]} name="actual">
+            {data.map((entry, i) => (
+              <Cell
+                key={i}
+                fill={
+                  entry.actual === 0 ? 'rgba(255,255,255,0.08)' :
+                  entry.actual >= entry.planned ? '#22c55e' : '#f97316'
+                }
+              />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+      <div className="flex gap-4 text-xs text-white/40">
+        <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-sm bg-white/15 inline-block" />Planned</span>
+        <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-sm bg-orange-500 inline-block" />Actual</span>
+        <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-sm bg-emerald-500 inline-block" />Complete</span>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/marathon/plan.ts
+++ b/src/lib/marathon/plan.ts
@@ -1,0 +1,267 @@
+// Marathon training plan — hardcoded source of truth
+// Belgrade Marathon, April 19, 2026 — 9 weeks
+
+export const RACE_DATE = new Date('2026-04-19')
+export const LIMASSOL_DATE = new Date('2026-03-22')
+export const ATHLETE_NAME = 'Silviya'
+
+export type SessionType = 'EASY' | 'VO2_MAX' | 'TEMPO' | 'HILLS' | 'LONG_RUN' | 'REST' | 'RACE' | 'SHAKEOUT'
+export type WeekType = 'normal' | 'limassol' | 'post_limassol' | 'peak' | 'taper'
+
+export interface PlannedSession {
+  dayOfWeek: 'Mon' | 'Tue' | 'Wed' | 'Thu' | 'Fri' | 'Sat' | 'Sun'
+  type: SessionType
+  description: string
+  plannedKm: number | null
+  paceMin: string | null  // "6:10"
+  paceMax: string | null  // "6:30"
+  hasStrength: boolean
+  strengthWorkout: 'A' | 'B' | null
+}
+
+export interface TrainingWeek {
+  weekNumber: number
+  label: string
+  weekType: WeekType
+  plannedKm: number
+  dateRange: { start: string; end: string }  // ISO dates
+  bloodDonationRecovery: boolean
+  sessions: PlannedSession[]
+}
+
+export const TRAINING_PLAN: TrainingWeek[] = [
+  {
+    weekNumber: 1,
+    label: 'Week 1 (Feb 16-22)',
+    weekType: 'normal',
+    plannedKm: 71,
+    dateRange: { start: '2026-02-16', end: '2026-02-22' },
+    bloodDonationRecovery: false,
+    sessions: [
+      { dayOfWeek: 'Mon', type: 'REST', description: 'Recovery from testing week (10km easy optional)', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Tue', type: 'VO2_MAX', description: '6×1000m @ 4:40/km (2min jog recovery) — 15min WU + strides, 10min CD', plannedKm: 11, paceMin: '4:40', paceMax: '4:40', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Wed', type: 'REST', description: '', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Thu', type: 'TEMPO', description: '10km @ 4:55/km — 2km WU @ 5:30, 2km CD @ 6:15', plannedKm: 14, paceMin: '4:55', paceMax: '4:55', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Fri', type: 'REST', description: '', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Sat', type: 'EASY', description: '8km @ 6:20/km + Strength Workout A (glutes/hips)', plannedKm: 10, paceMin: '6:10', paceMax: '6:30', hasStrength: true, strengthWorkout: 'A' },
+      { dayOfWeek: 'Sun', type: 'LONG_RUN', description: '5km@6:20 + 8km@5:00 + 4km@6:20 + 6km@5:00 + 5km@6:20 = 28km. Practice fueling every 5km.', plannedKm: 28, paceMin: '5:00', paceMax: '6:20', hasStrength: false, strengthWorkout: null },
+    ],
+  },
+  {
+    weekNumber: 2,
+    label: 'Week 2 (Feb 23-Mar 1)',
+    weekType: 'normal',
+    plannedKm: 48,
+    dateRange: { start: '2026-02-23', end: '2026-03-01' },
+    bloodDonationRecovery: true,
+    sessions: [
+      { dayOfWeek: 'Mon', type: 'EASY', description: '9km @ 6:20/km', plannedKm: 9, paceMin: '6:10', paceMax: '6:30', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Tue', type: 'HILLS', description: '10×2min hard uphill, jog down recovery — 10min WU, 10min CD — Effort: 85-90%', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Wed', type: 'REST', description: '', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Thu', type: 'TEMPO', description: '12km @ 4:52/km — 2km WU @ 5:30, 2km CD', plannedKm: 16, paceMin: '4:52', paceMax: '4:52', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Fri', type: 'REST', description: '', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Sat', type: 'EASY', description: '7km @ 6:20/km + Strength Workout B (core/quads)', plannedKm: 7, paceMin: '6:10', paceMax: '6:30', hasStrength: true, strengthWorkout: 'B' },
+      { dayOfWeek: 'Sun', type: 'LONG_RUN', description: '16km @ 6:20/km — Fully easy, HR 130-145 bpm', plannedKm: 16, paceMin: '6:10', paceMax: '6:30', hasStrength: false, strengthWorkout: null },
+    ],
+  },
+  {
+    weekNumber: 3,
+    label: 'Week 3 (Mar 2-8)',
+    weekType: 'normal',
+    plannedKm: 61,
+    dateRange: { start: '2026-03-02', end: '2026-03-08' },
+    bloodDonationRecovery: false,
+    sessions: [
+      { dayOfWeek: 'Mon', type: 'EASY', description: '9km @ 6:20/km', plannedKm: 9, paceMin: '6:10', paceMax: '6:30', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Tue', type: 'VO2_MAX', description: '5×2km @ 4:45/km (2:30 recovery) — 15min WU + strides, 10min CD', plannedKm: null, paceMin: '4:45', paceMax: '4:45', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Wed', type: 'REST', description: '', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Thu', type: 'TEMPO', description: '13km @ 4:52/km — 2km WU @ 5:30, 2km CD', plannedKm: 17, paceMin: '4:52', paceMax: '4:52', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Fri', type: 'REST', description: '', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Sat', type: 'EASY', description: '8km @ 6:20/km + Strength Workout A', plannedKm: 8, paceMin: '6:10', paceMax: '6:30', hasStrength: true, strengthWorkout: 'A' },
+      { dayOfWeek: 'Sun', type: 'LONG_RUN', description: '3km@6:20 + 10km@5:00 + 4km@6:20 + 8km@5:00 + 3km@6:20 = 28km. Second 8km block harder (fatigued).', plannedKm: 28, paceMin: '5:00', paceMax: '6:20', hasStrength: false, strengthWorkout: null },
+    ],
+  },
+  {
+    weekNumber: 4,
+    label: 'Week 4 (Mar 9-15)',
+    weekType: 'normal',
+    plannedKm: 69,
+    dateRange: { start: '2026-03-09', end: '2026-03-15' },
+    bloodDonationRecovery: false,
+    sessions: [
+      { dayOfWeek: 'Mon', type: 'EASY', description: '9km @ 6:20/km', plannedKm: 9, paceMin: '6:10', paceMax: '6:30', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Tue', type: 'HILLS', description: '12×2min hard uphill, jog down — 10min WU, 10min CD — Effort: 90%', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Wed', type: 'EASY', description: '6km @ 6:20/km if feeling fresh (optional)', plannedKm: 6, paceMin: '6:10', paceMax: '6:30', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Thu', type: 'TEMPO', description: '15km @ 4:50/km (LONGEST TEMPO) — 2km WU @ 5:30, 2km CD', plannedKm: 19, paceMin: '4:50', paceMax: '4:50', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Fri', type: 'REST', description: '', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Sat', type: 'EASY', description: '7km @ 6:20/km + Strength Workout B', plannedKm: 7, paceMin: '6:10', paceMax: '6:30', hasStrength: true, strengthWorkout: 'B' },
+      { dayOfWeek: 'Sun', type: 'LONG_RUN', description: '30km @ 6:20/km — full recovery long run', plannedKm: 30, paceMin: '6:10', paceMax: '6:30', hasStrength: false, strengthWorkout: null },
+    ],
+  },
+  {
+    weekNumber: 5,
+    label: 'Week 5 (Mar 16-22) — LIMASSOL',
+    weekType: 'limassol',
+    plannedKm: 44,
+    dateRange: { start: '2026-03-16', end: '2026-03-22' },
+    bloodDonationRecovery: false,
+    sessions: [
+      { dayOfWeek: 'Mon', type: 'EASY', description: '8km @ 6:20/km', plannedKm: 8, paceMin: '6:10', paceMax: '6:30', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Tue', type: 'VO2_MAX', description: '6×1600m @ 4:35/km (90sec recovery) — 15min WU + strides, 10min CD — Sharpening for Limassol', plannedKm: null, paceMin: '4:35', paceMax: '4:35', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Wed', type: 'REST', description: '', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Thu', type: 'TEMPO', description: '10km @ 4:50/km (reduced volume) — 2km WU, 2km CD', plannedKm: 14, paceMin: '4:50', paceMax: '4:50', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Fri', type: 'REST', description: '', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Sat', type: 'RACE', description: 'LIMASSOL HALF MARATHON — Target: 1:44-1:45 (4:55-5:00/km). Strategy: 5:05 first 5km → 5:00 km 5-15 → 4:55 km 15-21.', plannedKm: 21.1, paceMin: '4:55', paceMax: '5:00', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Sun', type: 'REST', description: 'Post-race recovery', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+    ],
+  },
+  {
+    weekNumber: 6,
+    label: 'Week 6 (Mar 23-29) — Recovery',
+    weekType: 'post_limassol',
+    plannedKm: 35,
+    dateRange: { start: '2026-03-23', end: '2026-03-29' },
+    bloodDonationRecovery: false,
+    sessions: [
+      { dayOfWeek: 'Mon', type: 'REST', description: '', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Tue', type: 'EASY', description: '6km @ 6:30/km (very easy recovery)', plannedKm: 6, paceMin: '6:20', paceMax: '6:40', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Wed', type: 'REST', description: '', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Thu', type: 'EASY', description: '8km @ 6:20/km', plannedKm: 8, paceMin: '6:10', paceMax: '6:30', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Fri', type: 'REST', description: '', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Sat', type: 'EASY', description: '7km @ 6:20/km + Strength Workout A (back to training)', plannedKm: 7, paceMin: '6:10', paceMax: '6:30', hasStrength: true, strengthWorkout: 'A' },
+      { dayOfWeek: 'Sun', type: 'LONG_RUN', description: '14km @ 6:20/km — recovery long run', plannedKm: 14, paceMin: '6:10', paceMax: '6:30', hasStrength: false, strengthWorkout: null },
+    ],
+  },
+  {
+    weekNumber: 7,
+    label: 'Week 7 (Mar 30-Apr 5) — PEAK',
+    weekType: 'peak',
+    plannedKm: 77,
+    dateRange: { start: '2026-03-30', end: '2026-04-05' },
+    bloodDonationRecovery: false,
+    sessions: [
+      { dayOfWeek: 'Mon', type: 'EASY', description: '9km @ 6:20/km', plannedKm: 9, paceMin: '6:10', paceMax: '6:30', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Tue', type: 'HILLS', description: '10×2min hard uphill (LAST hard hill session) — 10min WU, 10min CD — Effort: 90%', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Wed', type: 'REST', description: '', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Thu', type: 'TEMPO', description: '17km @ 4:48/km (HARDEST SESSION) — 2km WU @ 5:30, 2km CD', plannedKm: 21, paceMin: '4:48', paceMax: '4:48', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Fri', type: 'REST', description: '', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Sat', type: 'EASY', description: '8km @ 6:20/km + Strength Workout B', plannedKm: 8, paceMin: '6:10', paceMax: '6:30', hasStrength: true, strengthWorkout: 'B' },
+      { dayOfWeek: 'Sun', type: 'LONG_RUN', description: '5km easy + 10km@5:00 + 5km easy + 10km@5:00 + 5km easy = 35km (PEAK). Third block hardest. Fuel every 5km.', plannedKm: 35, paceMin: '5:00', paceMax: '6:20', hasStrength: false, strengthWorkout: null },
+    ],
+  },
+  {
+    weekNumber: 8,
+    label: 'Week 8 (Apr 6-12) — Sharpening',
+    weekType: 'normal',
+    plannedKm: 62,
+    dateRange: { start: '2026-04-06', end: '2026-04-12' },
+    bloodDonationRecovery: false,
+    sessions: [
+      { dayOfWeek: 'Mon', type: 'EASY', description: '9km @ 6:20/km', plannedKm: 9, paceMin: '6:10', paceMax: '6:30', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Tue', type: 'VO2_MAX', description: '4×2km @ 4:40/km (2min recovery) — 15min WU + strides, 10min CD — Sharp but not crushing', plannedKm: null, paceMin: '4:40', paceMax: '4:40', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Wed', type: 'REST', description: '', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Thu', type: 'TEMPO', description: '12km @ 4:48/km — 2km WU @ 5:30, 2km CD', plannedKm: 16, paceMin: '4:48', paceMax: '4:48', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Fri', type: 'REST', description: '', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Sat', type: 'EASY', description: '7km @ 6:20/km + Strength Workout A (2 sets, light)', plannedKm: 7, paceMin: '6:10', paceMax: '6:30', hasStrength: true, strengthWorkout: 'A' },
+      { dayOfWeek: 'Sun', type: 'LONG_RUN', description: '10km@5:00 + 4km@6:20 + 8km@5:00 = 22km — Reduced volume, taper begins', plannedKm: 22, paceMin: '5:00', paceMax: '6:20', hasStrength: false, strengthWorkout: null },
+    ],
+  },
+  {
+    weekNumber: 9,
+    label: 'Week 9 (Apr 13-19) — TAPER + RACE',
+    weekType: 'taper',
+    plannedKm: 20,
+    dateRange: { start: '2026-04-13', end: '2026-04-19' },
+    bloodDonationRecovery: false,
+    sessions: [
+      { dayOfWeek: 'Mon', type: 'EASY', description: '6km @ 6:20/km', plannedKm: 6, paceMin: '6:10', paceMax: '6:30', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Tue', type: 'SHAKEOUT', description: '5km @ 5:00/km + 4×200m @ 4:20/km — 2km WU, full recovery, 1km CD — Maintenance pace, feel rhythm', plannedKm: 9, paceMin: '5:00', paceMax: '5:00', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Wed', type: 'REST', description: '', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Thu', type: 'EASY', description: '4km @ 6:20/km', plannedKm: 4, paceMin: '6:10', paceMax: '6:30', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Fri', type: 'REST', description: '', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Sat', type: 'RACE', description: 'BELGRADE MARATHON — Target: 3:32:00 (5:00/km average). Run the plan.', plannedKm: 42.2, paceMin: '5:00', paceMax: '5:00', hasStrength: false, strengthWorkout: null },
+      { dayOfWeek: 'Sun', type: 'REST', description: 'Post-marathon recovery', plannedKm: null, paceMin: null, paceMax: null, hasStrength: false, strengthWorkout: null },
+    ],
+  },
+]
+
+// ── Helpers ───────────────────────────────────────────────────
+
+/** Returns the week containing a given ISO date string */
+export function getWeekForDate(dateStr: string): TrainingWeek | undefined {
+  return TRAINING_PLAN.find(
+    (w) => dateStr >= w.dateRange.start && dateStr <= w.dateRange.end,
+  )
+}
+
+/** Returns the planned session for a given ISO date */
+export function getSessionForDate(dateStr: string): (PlannedSession & { weekNumber: number }) | undefined {
+  const week = getWeekForDate(dateStr)
+  if (!week) return undefined
+  const date = new Date(dateStr + 'T12:00:00')
+  const dayNames: PlannedSession['dayOfWeek'][] = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+  const dayOfWeek = dayNames[date.getDay()]
+  const session = week.sessions.find((s) => s.dayOfWeek === dayOfWeek)
+  if (!session) return undefined
+  return { ...session, weekNumber: week.weekNumber }
+}
+
+/** Returns current week based on today's date */
+export function getCurrentWeek(): TrainingWeek | undefined {
+  const today = new Date().toISOString().split('T')[0]
+  return getWeekForDate(today)
+}
+
+/** Returns days until a target date */
+export function daysUntil(target: Date): number {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const t = new Date(target)
+  t.setHours(0, 0, 0, 0)
+  return Math.ceil((t.getTime() - today.getTime()) / 86400000)
+}
+
+/** Parses "M:SS" pace string to total seconds */
+export function parsePaceToSeconds(pace: string): number {
+  const [m, s] = pace.split(':').map(Number)
+  return m * 60 + (s || 0)
+}
+
+/** Formats seconds to "M:SS" pace string */
+export function formatPace(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  const s = Math.round(seconds % 60)
+  return `${m}:${String(s).padStart(2, '0')}`
+}
+
+/** Checks if an actual pace is faster than the planned pace min by more than threshold */
+export function checkWentTooFast(actualPace: string, plannedPaceMin: string, thresholdSec = 5): { went: boolean; deviationSec: number } {
+  const actualSec = parsePaceToSeconds(actualPace)
+  const plannedSec = parsePaceToSeconds(plannedPaceMin)
+  const deviation = plannedSec - actualSec  // positive = actual is faster
+  return { went: deviation > thresholdSec, deviationSec: deviation }
+}
+
+/** Session type label */
+export const SESSION_TYPE_LABELS: Record<SessionType, string> = {
+  EASY: 'Easy Run',
+  VO2_MAX: 'VO2 Max',
+  TEMPO: 'Tempo',
+  HILLS: 'Hills',
+  LONG_RUN: 'Long Run',
+  REST: 'Rest',
+  RACE: 'Race',
+  SHAKEOUT: 'Shakeout',
+}
+
+/** Session type colors for UI */
+export const SESSION_TYPE_COLORS: Record<SessionType, string> = {
+  EASY: 'text-emerald-400 bg-emerald-400/10',
+  VO2_MAX: 'text-blue-400 bg-blue-400/10',
+  TEMPO: 'text-orange-400 bg-orange-400/10',
+  HILLS: 'text-purple-400 bg-purple-400/10',
+  LONG_RUN: 'text-red-400 bg-red-400/10',
+  REST: 'text-white/30 bg-white/5',
+  RACE: 'text-yellow-400 bg-yellow-400/10',
+  SHAKEOUT: 'text-cyan-400 bg-cyan-400/10',
+}

--- a/src/lib/supabase/marathon.ts
+++ b/src/lib/supabase/marathon.ts
@@ -1,0 +1,251 @@
+// Supabase queries for marathon training module
+
+import { createClient } from './server'
+import { TRAINING_PLAN } from '@/lib/marathon/plan'
+
+// ── Types ─────────────────────────────────────────────────────
+
+export interface TrainingWeekRow {
+  id: string
+  user_id: string
+  week_number: number
+  week_label: string
+  week_type: string
+  planned_km: number | null
+  actual_km: number | null
+  status: 'upcoming' | 'in_progress' | 'completed'
+  blood_donation_recovery: boolean
+  notes: string | null
+  created_at: string
+}
+
+export interface TrainingSessionRow {
+  id: string
+  user_id: string
+  session_date: string
+  week_number: number
+  day_of_week: string
+  planned_type: string
+  planned_description: string | null
+  planned_km: number | null
+  planned_pace_min: string | null
+  planned_pace_max: string | null
+  has_strength: boolean
+  strength_workout: string | null
+  status: 'pending' | 'completed' | 'skipped' | 'modified'
+  actual_km: number | null
+  actual_avg_pace: string | null
+  actual_avg_hr: number | null
+  actual_duration_min: number | null
+  pace_target_met: boolean | null
+  pace_deviation_sec: number | null
+  warmup_done: boolean | null
+  post_fuel_done: boolean | null
+  perceived_effort: number | null
+  went_too_fast: boolean
+  skipped_warmup: boolean
+  notes: string | null
+  ai_feedback: string | null
+  resting_hr: number | null
+  created_at: string
+  updated_at: string
+}
+
+export interface RaceResultRow {
+  id: string
+  user_id: string
+  race_date: string
+  race_name: string
+  distance_km: number | null
+  finish_time: string | null
+  finish_time_seconds: number | null
+  avg_pace: string | null
+  official: boolean
+  notes: string | null
+  ai_debrief: string | null
+  created_at: string
+}
+
+// ── Training Weeks ────────────────────────────────────────────
+
+export async function getTrainingWeeks(): Promise<TrainingWeekRow[]> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('training_weeks')
+    .select('*')
+    .order('week_number', { ascending: true })
+  if (error) throw error
+  return data ?? []
+}
+
+export async function getTrainingWeek(weekNumber: number): Promise<TrainingWeekRow | null> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('training_weeks')
+    .select('*')
+    .eq('week_number', weekNumber)
+    .single()
+  if (error) return null
+  return data
+}
+
+export async function upsertTrainingWeek(
+  weekNumber: number,
+  updates: Partial<Pick<TrainingWeekRow, 'actual_km' | 'status' | 'notes'>>,
+): Promise<void> {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const plan = TRAINING_PLAN.find((w) => w.weekNumber === weekNumber)
+  if (!plan) throw new Error(`Week ${weekNumber} not in plan`)
+
+  const { error } = await supabase.from('training_weeks').upsert({
+    user_id: user.id,
+    week_number: weekNumber,
+    week_label: plan.label,
+    week_type: plan.weekType,
+    planned_km: plan.plannedKm,
+    blood_donation_recovery: plan.bloodDonationRecovery,
+    ...updates,
+  }, { onConflict: 'user_id,week_number' })
+  if (error) throw error
+}
+
+// ── Training Sessions ─────────────────────────────────────────
+
+export async function getSessionsForWeek(weekNumber: number): Promise<TrainingSessionRow[]> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('training_sessions')
+    .select('*')
+    .eq('week_number', weekNumber)
+    .order('session_date', { ascending: true })
+  if (error) throw error
+  return data ?? []
+}
+
+export async function getSessionForDate(dateStr: string): Promise<TrainingSessionRow | null> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('training_sessions')
+    .select('*')
+    .eq('session_date', dateStr)
+    .single()
+  if (error) return null
+  return data
+}
+
+export async function getRecentSessions(limit = 10): Promise<TrainingSessionRow[]> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('training_sessions')
+    .select('*')
+    .neq('status', 'pending')
+    .order('session_date', { ascending: false })
+    .limit(limit)
+  if (error) throw error
+  return data ?? []
+}
+
+export async function upsertSession(
+  sessionDate: string,
+  payload: Omit<TrainingSessionRow, 'id' | 'user_id' | 'created_at' | 'updated_at'>,
+): Promise<TrainingSessionRow> {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const { data, error } = await supabase
+    .from('training_sessions')
+    .upsert({ ...payload, user_id: user.id, session_date: sessionDate }, { onConflict: 'user_id,session_date' })
+    .select()
+    .single()
+  if (error) throw error
+  return data
+}
+
+export async function updateSession(
+  sessionDate: string,
+  updates: Partial<Omit<TrainingSessionRow, 'id' | 'user_id' | 'created_at' | 'updated_at'>>,
+): Promise<void> {
+  const supabase = createClient()
+  const { error } = await supabase
+    .from('training_sessions')
+    .update(updates)
+    .eq('session_date', sessionDate)
+  if (error) throw error
+}
+
+// ── Race Results ──────────────────────────────────────────────
+
+export async function getRaceResults(): Promise<RaceResultRow[]> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('race_results')
+    .select('*')
+    .order('race_date', { ascending: false })
+  if (error) throw error
+  return data ?? []
+}
+
+export async function getRaceResult(raceName: string): Promise<RaceResultRow | null> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('race_results')
+    .select('*')
+    .eq('race_name', raceName)
+    .single()
+  if (error) return null
+  return data
+}
+
+export async function upsertRaceResult(payload: Omit<RaceResultRow, 'id' | 'user_id' | 'created_at'>): Promise<RaceResultRow> {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const { data, error } = await supabase
+    .from('race_results')
+    .upsert({ ...payload, user_id: user.id }, { onConflict: 'user_id,race_date' })
+    .select()
+    .single()
+  if (error) throw error
+  return data
+}
+
+// ── Dashboard summary ─────────────────────────────────────────
+
+export async function getMarathonDashboardData() {
+  const supabase = createClient()
+
+  const today = new Date().toISOString().split('T')[0]
+
+  const [weeksRes, sessionsRes, todaySessionRes, flaggedRes] = await Promise.all([
+    supabase.from('training_weeks').select('*').order('week_number'),
+    supabase
+      .from('training_sessions')
+      .select('*')
+      .gte('session_date', today.slice(0, 8) + '01')  // this month
+      .order('session_date', { ascending: false })
+      .limit(20),
+    supabase
+      .from('training_sessions')
+      .select('*')
+      .eq('session_date', today)
+      .single(),
+    supabase
+      .from('training_sessions')
+      .select('session_date, went_too_fast, pace_deviation_sec, planned_type')
+      .eq('went_too_fast', true)
+      .order('session_date', { ascending: false })
+      .limit(1),
+  ])
+
+  return {
+    weeks: weeksRes.data ?? [],
+    sessions: sessionsRes.data ?? [],
+    todaySession: todaySessionRes.data ?? null,
+    lastFlag: flaggedRes.data?.[0] ?? null,
+  }
+}

--- a/supabase/migrations/20240111000000_marathon_schema.sql
+++ b/supabase/migrations/20240111000000_marathon_schema.sql
@@ -90,7 +90,9 @@ CREATE TABLE race_results (
   official              boolean NOT NULL DEFAULT true,
   notes                 text,
   ai_debrief            text,
-  created_at            timestamptz NOT NULL DEFAULT now()
+  created_at            timestamptz NOT NULL DEFAULT now(),
+
+  UNIQUE (user_id, race_date)
 );
 
 -- ── Indexes ───────────────────────────────────────────────────


### PR DESCRIPTION
Full 9-week Belgrade Marathon training hub for Silviya:

- /marathon — Training hub with today's session, week progress, countdown
- /marathon/session/[date] — Session log form with pace discipline auto-flags
- /marathon/week/[n] — Full week view with planned vs actual for all 7 days
- /marathon/race/limassol — Pre/post race page with Belgrade goal adjuster
- /marathon/race/belgrade — Race day pacing plan, fueling, strategy
- /marathon/history — Pace discipline chart, session calendar, stats

Components: RaceCountdown, SessionCard, SessionLogForm, PaceDisciplineAlert, PaceDisciplineChart, WeeklyProgress, AICoach, LimassolResultForm

API routes: /api/marathon/session/[date], /api/marathon/race-result, /api/ai/marathon-coach (Gemini streaming with full athlete context)

Data: Hardcoded 9-week plan in src/lib/marathon/plan.ts (source of truth), Supabase queries in src/lib/supabase/marathon.ts, DB migration with RLS

Sidebar: Added Marathon nav item with Timer icon

https://claude.ai/code/session_01313VEkRdS4qJPapUWn7r88