### PR TITLE
feat: add master AI coach with full-system context and tool-calling

### DIFF
--- a/src/app/(dashboard)/coach/page.tsx
+++ b/src/app/(dashboard)/coach/page.tsx
@@ -1,0 +1,49 @@
+// Life OS — Master Coach page
+// Full-system AI coach with cross-module context and tool-calling
+
+import { MasterCoach } from '@/components/ai/master-coach'
+import { Bot, Pill, Settings, TrendingUp, Activity, BarChart2 } from 'lucide-react'
+
+const CAPABILITIES = [
+  { icon: Activity, label: 'Running', desc: 'Pace analysis, HR trends, race prep' },
+  { icon: Pill, label: 'Supplements', desc: 'Pause, resume, timing guidance' },
+  { icon: TrendingUp, label: 'Marathon', desc: 'Training sessions, week reviews' },
+  { icon: Settings, label: 'Plan Configs', desc: 'Adjust paces, targets, thresholds' },
+  { icon: BarChart2, label: 'Nutrition', desc: 'Adherence scores, hydration, violations' },
+  { icon: Bot, label: 'Habits', desc: 'Streak tracking, completion rates' },
+]
+
+export default function CoachPage() {
+  return (
+    <div className="space-y-6 p-6">
+      {/* Page header */}
+      <div>
+        <div className="flex items-center gap-2 mb-1">
+          <Bot className="h-5 w-5 text-violet-400" />
+          <h1 className="text-xl font-semibold text-white">Life OS Coach</h1>
+        </div>
+        <p className="text-sm text-white/40">
+          Full-system AI coach with visibility across all modules.
+          Ask questions or request changes — it can pause supplements, update plan configs, and more.
+        </p>
+      </div>
+
+      {/* Capabilities grid */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+        {CAPABILITIES.map(({ icon: Icon, label, desc }) => (
+          <div
+            key={label}
+            className="flex flex-col gap-1.5 px-3 py-3 rounded-lg bg-white/5 border border-white/10"
+          >
+            <Icon className="h-4 w-4 text-violet-400/70" />
+            <p className="text-xs font-medium text-white/70">{label}</p>
+            <p className="text-[11px] text-white/30 leading-snug">{desc}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Coach chat — full width */}
+      <MasterCoach />
+    </div>
+  )
+}

--- a/src/app/api/ai/coach/route.ts
+++ b/src/app/api/ai/coach/route.ts
@@ -1,0 +1,248 @@
+// Master AI Coach — streaming API with cross-module tool-calling
+// Reads all modules for context, can modify supplements and plan configs
+
+import { google } from '@ai-sdk/google'
+import { streamText, convertToModelMessages } from 'ai'
+import { z } from 'zod'
+import { createClient } from '@/lib/supabase/server'
+import { MASTER_COACH_SYSTEM_PROMPT, buildFullSystemContext } from '@/lib/ai/master-coach'
+
+export const runtime = 'nodejs'
+export const maxDuration = 90
+
+export async function POST(req: Request) {
+  const { messages } = await req.json()
+
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return new Response('Unauthorized', { status: 401 })
+  }
+
+  let contextBlock = ''
+  try {
+    contextBlock = await buildFullSystemContext(supabase)
+  } catch (err) {
+    console.error('[coach] context build failed:', err)
+    contextBlock = '(Context unavailable — answering from conversation only.)'
+  }
+
+  const systemWithContext = `${MASTER_COACH_SYSTEM_PROMPT}\n\n---\n\n${contextBlock}`
+  const modelMessages = await convertToModelMessages(messages)
+
+  const result = streamText({
+    model: google('gemini-2.5-flash'),
+    system: systemWithContext,
+    messages: modelMessages,
+    maxOutputTokens: 2048,
+    temperature: 0.7,
+    maxSteps: 3, // allow tool call → result → follow-up
+
+    tools: {
+      // ── Supplement tools ────────────────────────────────────────
+
+      pause_supplement: {
+        description:
+          'Pause a supplement so it no longer appears in the daily checklist. ' +
+          'Use when the user asks to skip, stop, or pause a specific supplement.',
+        parameters: z.object({
+          supplement_id: z.string().describe('UUID of the supplement (shown in brackets in the context)'),
+          reason: z.string().describe('Why the supplement is being paused'),
+        }),
+        execute: async ({ supplement_id, reason }) => {
+          try {
+            const { error } = await supabase
+              .from('supplements')
+              .update({
+                is_paused: true,
+                pause_reason: reason,
+                paused_at: new Date().toISOString().slice(0, 10),
+                updated_at: new Date().toISOString(),
+              })
+              .eq('id', supplement_id)
+              .eq('user_id', user.id)
+
+            if (error) throw error
+
+            await supabase.from('supplement_changes').insert({
+              supplement_id,
+              user_id: user.id,
+              change_type: 'paused',
+              previous_value: { is_paused: false },
+              new_value: { is_paused: true, pause_reason: reason },
+              reason,
+              changed_by: 'ai_coach',
+            })
+
+            await supabase.from('plan_audit_log').insert({
+              user_id: user.id,
+              module: 'nutrition',
+              entity_type: 'supplement',
+              entity_description: supplement_id,
+              action: 'pause',
+              new_value: 'paused',
+              reason,
+              changed_by: 'ai_coach',
+            })
+
+            return { success: true, message: `Supplement paused. Reason recorded: "${reason}"` }
+          } catch (e) {
+            return { success: false, message: `Failed to pause supplement: ${String(e)}` }
+          }
+        },
+      },
+
+      resume_supplement: {
+        description:
+          'Resume a paused supplement so it shows in the daily checklist again.',
+        parameters: z.object({
+          supplement_id: z.string().describe('UUID of the supplement to resume'),
+        }),
+        execute: async ({ supplement_id }) => {
+          try {
+            const { data: sup } = await supabase
+              .from('supplements')
+              .select('name')
+              .eq('id', supplement_id)
+              .eq('user_id', user.id)
+              .single()
+
+            const { error } = await supabase
+              .from('supplements')
+              .update({
+                is_paused: false,
+                pause_reason: null,
+                paused_at: null,
+                resume_at: null,
+                updated_at: new Date().toISOString(),
+              })
+              .eq('id', supplement_id)
+              .eq('user_id', user.id)
+
+            if (error) throw error
+
+            await supabase.from('plan_audit_log').insert({
+              user_id: user.id,
+              module: 'nutrition',
+              entity_type: 'supplement',
+              entity_description: sup?.name ?? supplement_id,
+              action: 'resume',
+              new_value: 'active',
+              changed_by: 'ai_coach',
+            })
+
+            return { success: true, message: `${sup?.name ?? 'Supplement'} resumed.` }
+          } catch (e) {
+            return { success: false, message: `Failed to resume supplement: ${String(e)}` }
+          }
+        },
+      },
+
+      // ── Plan config tools ───────────────────────────────────────
+
+      update_plan_config: {
+        description:
+          'Update a plan configuration value. Use to adjust training paces, nutrition targets, ' +
+          'daily calorie or water goals, trading parameters, or any other plan setting. ' +
+          'Only update configs that are relevant to the user\'s request.',
+        parameters: z.object({
+          module: z.string().describe(
+            'Module name: running | nutrition | trading | marathon | habits'
+          ),
+          config_key: z.string().describe(
+            'Exact config_key from the Plan Configurations section, e.g. "easy_pace_min"'
+          ),
+          new_value: z.string().describe('New value as a string'),
+          reason: z.string().describe('Why this change is being made'),
+        }),
+        execute: async ({ module, config_key, new_value, reason }) => {
+          try {
+            const { data: current } = await supabase
+              .from('plan_configs')
+              .select('config_value, config_label')
+              .eq('user_id', user.id)
+              .eq('module', module)
+              .eq('config_key', config_key)
+              .single()
+
+            if (!current) {
+              return { success: false, message: `Config "${module}.${config_key}" not found.` }
+            }
+
+            const { error } = await supabase
+              .from('plan_configs')
+              .update({
+                config_value: new_value,
+                last_changed_at: new Date().toISOString(),
+                last_changed_by: 'ai_coach',
+                change_reason: reason,
+              })
+              .eq('user_id', user.id)
+              .eq('module', module)
+              .eq('config_key', config_key)
+
+            if (error) throw error
+
+            await supabase.from('plan_audit_log').insert({
+              user_id: user.id,
+              module,
+              entity_type: 'plan_config',
+              entity_description: current.config_label,
+              action: 'update',
+              field_changed: config_key,
+              previous_value: current.config_value,
+              new_value,
+              reason,
+              changed_by: 'ai_coach',
+            })
+
+            return {
+              success: true,
+              message: `Updated "${current.config_label}" from "${current.config_value}" to "${new_value}". Reason: ${reason}`,
+            }
+          } catch (e) {
+            return { success: false, message: `Failed to update config: ${String(e)}` }
+          }
+        },
+      },
+
+      // ── Audit log read tool ─────────────────────────────────────
+
+      get_recent_changes: {
+        description:
+          'Fetch the most recent changes across all modules from the audit log. ' +
+          'Useful when the user asks "what did you change?" or "show me recent updates".',
+        parameters: z.object({
+          limit: z.number().default(10).describe('Number of entries to return (max 20)'),
+        }),
+        execute: async ({ limit }) => {
+          try {
+            const { data } = await supabase
+              .from('plan_audit_log')
+              .select('changed_at, module, entity_description, action, field_changed, previous_value, new_value, reason, changed_by')
+              .eq('user_id', user.id)
+              .order('changed_at', { ascending: false })
+              .limit(Math.min(limit, 20))
+
+            if (!data?.length) return { entries: [], message: 'No changes logged yet.' }
+
+            const formatted = data.map((e) => ({
+              date: new Date(e.changed_at).toLocaleString('en-GB'),
+              module: e.module,
+              what: e.entity_description ?? e.action,
+              change: e.field_changed ? `${e.field_changed}: ${e.previous_value} → ${e.new_value}` : e.action,
+              reason: e.reason,
+              by: e.changed_by,
+            }))
+
+            return { entries: formatted, message: `Found ${formatted.length} recent change(s).` }
+          } catch (e) {
+            return { entries: [], message: `Failed to fetch audit log: ${String(e)}` }
+          }
+        },
+      },
+    },
+  })
+
+  return result.toUIMessageStreamResponse()
+}

--- a/src/components/ai/master-coach.tsx
+++ b/src/components/ai/master-coach.tsx
@@ -1,0 +1,379 @@
+'use client'
+
+// Master AI Coach — full-system chat with tool-call result cards
+// Handles cross-module changes (supplement pause/resume, plan config updates)
+
+import { useState, useRef, useEffect } from 'react'
+import { useChat } from '@ai-sdk/react'
+import { DefaultChatTransport } from 'ai'
+import {
+  Bot,
+  SendHorizonal,
+  RefreshCw,
+  Loader2,
+  CheckCircle,
+  XCircle,
+  Settings,
+  Pill,
+  History,
+  Zap,
+} from 'lucide-react'
+import type { UIMessage } from 'ai'
+
+// ── Markdown helpers (shared pattern from coach-chat.tsx) ──────────────────
+
+function formatInline(text: string) {
+  const parts = text.split(/(\*\*[^*]+\*\*|`[^`]+`)/g)
+  return parts.map((part, i) => {
+    if (part.startsWith('**') && part.endsWith('**')) {
+      return (
+        <strong key={i} className="text-white font-semibold">
+          {part.slice(2, -2)}
+        </strong>
+      )
+    }
+    if (part.startsWith('`') && part.endsWith('`')) {
+      return (
+        <code
+          key={i}
+          className="bg-white/10 text-violet-300 px-1 py-0.5 rounded text-xs font-mono"
+        >
+          {part.slice(1, -1)}
+        </code>
+      )
+    }
+    return part
+  })
+}
+
+function renderMarkdown(text: string) {
+  return text.split('\n').map((line, i) => {
+    if (line.startsWith('## '))
+      return (
+        <h3 key={i} className="text-sm font-semibold text-white/90 mt-4 mb-1 first:mt-0">
+          {line.slice(3)}
+        </h3>
+      )
+    if (line.startsWith('### '))
+      return (
+        <h4 key={i} className="text-xs font-semibold text-white/80 mt-3 mb-1">
+          {line.slice(4)}
+        </h4>
+      )
+    if (line.startsWith('- ') || line.startsWith('* '))
+      return (
+        <li key={i} className="text-sm text-white/70 ml-3 list-disc list-inside leading-relaxed">
+          {formatInline(line.slice(2))}
+        </li>
+      )
+    if (line.match(/^\d+\. /))
+      return (
+        <li key={i} className="text-sm text-white/70 ml-3 list-decimal list-inside leading-relaxed">
+          {formatInline(line.replace(/^\d+\. /, ''))}
+        </li>
+      )
+    if (line === '---') return <hr key={i} className="border-white/10 my-3" />
+    if (line.trim() === '') return <div key={i} className="h-1.5" />
+    return (
+      <p key={i} className="text-sm text-white/70 leading-relaxed">
+        {formatInline(line)}
+      </p>
+    )
+  })
+}
+
+// ── Tool result card ───────────────────────────────────────────────────────
+
+const TOOL_META: Record<string, { label: string; Icon: React.ElementType; color: string }> = {
+  pause_supplement: { label: 'Paused supplement', Icon: Pill, color: 'text-amber-400' },
+  resume_supplement: { label: 'Resumed supplement', Icon: Pill, color: 'text-emerald-400' },
+  update_plan_config: { label: 'Updated plan config', Icon: Settings, color: 'text-violet-400' },
+  get_recent_changes: { label: 'Fetched audit log', Icon: History, color: 'text-sky-400' },
+}
+
+interface ToolResult {
+  success?: boolean
+  message?: string
+  entries?: Array<{ date: string; module: string; what: string; change: string; reason?: string; by: string }>
+}
+
+function ToolCard({
+  toolName,
+  state,
+  result,
+}: {
+  toolName: string
+  state: string
+  result?: ToolResult
+}) {
+  const meta = TOOL_META[toolName] ?? { label: toolName, Icon: Zap, color: 'text-white/40' }
+  const { label, Icon, color } = meta
+  const isPending = state === 'call' || state === 'partial-call'
+  const isSuccess = result?.success !== false
+
+  if (isPending) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-xs text-white/40">
+        <Loader2 className={`h-3.5 w-3.5 ${color} animate-spin`} />
+        <span>{label}…</span>
+      </div>
+    )
+  }
+
+  // get_recent_changes returns an entries list, not a simple message
+  if (toolName === 'get_recent_changes' && result?.entries?.length) {
+    return (
+      <div className="rounded-lg border border-sky-500/20 bg-sky-500/5 overflow-hidden">
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-sky-500/15">
+          <History className="h-3.5 w-3.5 text-sky-400" />
+          <span className="text-xs font-medium text-sky-300">Recent Changes</span>
+        </div>
+        <div className="px-3 py-2 space-y-1">
+          {result.entries.map((e, i) => (
+            <div key={i} className="text-xs text-white/50">
+              <span className="text-white/30">{e.date}</span>
+              {' · '}
+              <span className="text-white/60">[{e.module}]</span>
+              {' '}
+              {e.change}
+              {e.reason ? <span className="text-white/30"> — {e.reason}</span> : null}
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={`flex items-start gap-2.5 px-3 py-2 rounded-lg border text-xs ${
+        isSuccess
+          ? 'bg-emerald-500/5 border-emerald-500/20'
+          : 'bg-red-500/5 border-red-500/20'
+      }`}
+    >
+      {isSuccess ? (
+        <CheckCircle className="h-3.5 w-3.5 text-emerald-400 mt-0.5 shrink-0" />
+      ) : (
+        <XCircle className="h-3.5 w-3.5 text-red-400 mt-0.5 shrink-0" />
+      )}
+      <div className="min-w-0">
+        <span className={`font-medium ${isSuccess ? 'text-emerald-300' : 'text-red-300'}`}>
+          {label}
+        </span>
+        {result?.message && (
+          <p className="text-white/40 mt-0.5 leading-relaxed">{result.message}</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Message renderer ────────────────────────────────────────────────────────
+
+function MessageContent({ msg }: { msg: UIMessage }) {
+  const textPart = msg.parts.find((p) => p.type === 'text')
+  const text = textPart && 'text' in textPart ? textPart.text : ''
+
+  const toolParts = msg.parts.filter((p) => p.type === 'tool-invocation') as Array<{
+    type: 'tool-invocation'
+    toolInvocationId: string
+    toolName: string
+    args: Record<string, unknown>
+    state: string
+    result?: ToolResult
+  }>
+
+  if (!text && toolParts.length === 0) return null
+
+  return (
+    <div className="space-y-2.5">
+      {toolParts.length > 0 && (
+        <div className="space-y-1.5">
+          {toolParts.map((tp) => (
+            <ToolCard
+              key={tp.toolInvocationId}
+              toolName={tp.toolName}
+              state={tp.state}
+              result={tp.result}
+            />
+          ))}
+        </div>
+      )}
+      {text && <div className="space-y-1">{renderMarkdown(text)}</div>}
+    </div>
+  )
+}
+
+// ── Main component ─────────────────────────────────────────────────────────
+
+export function MasterCoach() {
+  const [input, setInput] = useState('')
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  const { messages, sendMessage, status, setMessages } = useChat({
+    transport: new DefaultChatTransport({ api: '/api/ai/coach' }),
+  })
+
+  const isLoading = status === 'submitted' || status === 'streaming'
+  const hasMessages = messages.length > 0
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  const handleSend = async (e?: React.FormEvent) => {
+    e?.preventDefault()
+    const text = input.trim()
+    if (!text || isLoading) return
+    setInput('')
+    await sendMessage({ text })
+  }
+
+  return (
+    <div className="flex flex-col rounded-xl border border-white/10 bg-white/5 overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-5 py-4 border-b border-white/10 bg-violet-500/10">
+        <Bot className="h-4 w-4 shrink-0 text-violet-400" />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-white">Life OS Coach</p>
+          <p className="text-xs text-white/40 truncate">
+            Gemini · all modules · can make changes
+          </p>
+        </div>
+        {hasMessages && (
+          <button
+            onClick={() => setMessages([])}
+            className="text-xs text-white/30 hover:text-white/60 transition-colors flex items-center gap-1"
+          >
+            <RefreshCw className="h-3 w-3" />
+            Clear
+          </button>
+        )}
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto max-h-[520px] px-5 py-4 space-y-4 min-h-[140px]">
+        {!hasMessages && (
+          <div className="flex flex-col items-center justify-center h-28 gap-2 text-center">
+            <Bot className="h-9 w-9 text-violet-400 opacity-30" />
+            <p className="text-xs text-white/30 max-w-xs leading-relaxed">
+              Ask about any module — training, nutrition, supplements, habits, trading.
+              I can also make changes: pause a supplement, adjust a training pace, etc.
+            </p>
+          </div>
+        )}
+
+        {messages.map((msg) => {
+          if (msg.role === 'user') {
+            const textPart = msg.parts.find((p) => p.type === 'text')
+            const text = textPart && 'text' in textPart ? textPart.text : ''
+            if (!text) return null
+            return (
+              <div key={msg.id} className="flex gap-3 justify-end">
+                <div className="max-w-[85%] rounded-xl px-4 py-3 bg-white/10 border border-white/10">
+                  <p className="text-sm text-white/80">{text}</p>
+                </div>
+              </div>
+            )
+          }
+
+          const content = <MessageContent msg={msg} />
+          // Check if there's anything to render
+          const hasText = msg.parts.some((p) => p.type === 'text' && 'text' in p && (p as { text: string }).text)
+          const hasTools = msg.parts.some((p) => p.type === 'tool-invocation')
+          if (!hasText && !hasTools) return null
+
+          return (
+            <div key={msg.id} className="flex gap-3 justify-start">
+              <div className="shrink-0 h-6 w-6 rounded-full flex items-center justify-center mt-0.5 bg-violet-500/10 border border-violet-500/20">
+                <Bot className="h-3 w-3 text-violet-400" />
+              </div>
+              <div className="max-w-[90%] rounded-xl px-4 py-3 bg-white/5 border border-white/10">
+                {content}
+              </div>
+            </div>
+          )
+        })}
+
+        {isLoading &&
+          (messages.length === 0 ||
+            messages[messages.length - 1]?.role !== 'assistant') && (
+            <div className="flex gap-3 justify-start">
+              <div className="shrink-0 h-6 w-6 rounded-full flex items-center justify-center bg-violet-500/10 border border-violet-500/20">
+                <Loader2 className="h-3 w-3 text-violet-400 animate-spin" />
+              </div>
+              <div className="bg-white/5 border border-white/10 rounded-xl px-4 py-3">
+                <div className="flex gap-1 items-center">
+                  <span className="h-1.5 w-1.5 rounded-full bg-white/30 animate-bounce [animation-delay:0ms]" />
+                  <span className="h-1.5 w-1.5 rounded-full bg-white/30 animate-bounce [animation-delay:150ms]" />
+                  <span className="h-1.5 w-1.5 rounded-full bg-white/30 animate-bounce [animation-delay:300ms]" />
+                </div>
+              </div>
+            </div>
+          )}
+
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Suggestion chips */}
+      {!hasMessages && (
+        <div className="px-5 pb-3 flex flex-wrap gap-1.5">
+          {[
+            'How am I doing this week?',
+            'Pause my iron supplement',
+            'What changes were made recently?',
+            'Am I on track for Belgrade?',
+          ].map((prompt) => (
+            <button
+              key={prompt}
+              onClick={() => {
+                setInput(prompt)
+              }}
+              className="text-xs px-2.5 py-1 rounded-full bg-white/5 border border-white/10 text-white/40 hover:text-white/70 hover:bg-white/10 transition-colors"
+            >
+              {prompt}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Input */}
+      <form
+        onSubmit={handleSend}
+        className="flex items-end gap-3 px-5 py-4 border-t border-white/10 bg-white/[0.02]"
+      >
+        <textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Ask about any module, or request a change…"
+          rows={1}
+          disabled={isLoading}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault()
+              handleSend()
+            }
+          }}
+          className="flex-1 resize-none bg-white/5 border border-white/10 rounded-lg px-3 py-2.5 text-sm text-white placeholder:text-white/25 focus:outline-none focus:border-white/25 disabled:opacity-40 max-h-32 leading-relaxed"
+          style={{ minHeight: '38px' }}
+        />
+        <button
+          type="submit"
+          disabled={isLoading || !input.trim()}
+          className={`shrink-0 h-[38px] w-[38px] flex items-center justify-center rounded-lg transition-colors ${
+            isLoading || !input.trim()
+              ? 'opacity-30 cursor-not-allowed bg-white/5'
+              : 'bg-violet-500/10 hover:opacity-80'
+          }`}
+        >
+          {isLoading ? (
+            <Loader2 className="h-4 w-4 text-violet-400 animate-spin" />
+          ) : (
+            <SendHorizonal className="h-4 w-4 text-violet-400" />
+          )}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -18,6 +18,7 @@ import {
   Salad,
   Timer,
   RefreshCcw,
+  Bot,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { createClient } from "@/lib/supabase/client";
@@ -27,6 +28,7 @@ import { ThemeToggle } from "@/components/theme/theme-toggle";
 const navItems: Array<{ href: string; label: string; icon: React.ElementType; indent?: boolean }> = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { href: "/adapt", label: "Adapt", icon: RefreshCcw },
+  { href: "/coach", label: "Coach", icon: Bot },
   { href: "/habits", label: "Habits", icon: Activity },
   { href: "/trading", label: "Trading", icon: TrendingUp },
   { href: "/trading/accountability", label: "Accountability", icon: ShieldCheck, indent: true },

--- a/src/lib/ai/master-coach.ts
+++ b/src/lib/ai/master-coach.ts
@@ -1,0 +1,279 @@
+// Master AI Coach — full-system context builder and system prompt
+// Understands all modules and can make cross-module changes via tool-calling
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { ATHLETE_PROFILE } from './coaching'
+
+// ── System prompt ──────────────────────────────────────────────────────────
+
+export const MASTER_COACH_SYSTEM_PROMPT = `You are the central Life OS coach — a highly capable AI adviser with full visibility into all of ${ATHLETE_PROFILE.sex === 'female' ? 'her' : 'their'} systems: marathon training, nutrition, supplements, habits, and trading.
+
+Athlete profile:
+- Age: ${ATHLETE_PROFILE.age}yo ${ATHLETE_PROFILE.sex}
+- Goal race: ${ATHLETE_PROFILE.race} on ${ATHLETE_PROFILE.raceDate}
+- Target time: ${ATHLETE_PROFILE.targetTime} (${ATHLETE_PROFILE.targetPacePerKm} avg pace)
+- Training paces: Easy ${ATHLETE_PROFILE.trainingPaces.easy} | Tempo ${ATHLETE_PROFILE.trainingPaces.tempo} | VO2max ${ATHLETE_PROFILE.trainingPaces.vo2max} | Long ${ATHLETE_PROFILE.trainingPaces.longRun}
+- Key problem: ${ATHLETE_PROFILE.mainIssue}
+- Resting HR baseline: ${ATHLETE_PROFILE.restingHrBaseline}
+
+Your capabilities:
+- You can read data from ALL modules (running, nutrition, supplements, habits, trading, marathon plan).
+- You can make changes using tools: pause/resume supplements, update plan configuration values.
+- All changes you make are logged to the audit trail automatically.
+- Supplements are prescribed by Dr Emine Ömerağa — you can manage scheduling/timing/pausing but must NOT change medical dosages or diagnoses.
+
+Coaching philosophy:
+- Be direct, data-driven, and cross-domain. Spot patterns across modules (e.g. "poor sleep → slow run → mood dip → bad trading").
+- When asked to make a change, do it immediately with the appropriate tool and explain what you did.
+- Before making a significant change (like pausing a prescribed supplement), confirm intent if the user's message is ambiguous.
+- Format responses with clear sections. Use markdown. Keep responses under 500 words unless doing multi-week analysis.
+- When you use a tool, briefly acknowledge what you changed and why.`
+
+// ── Full-system context builder ────────────────────────────────────────────
+
+export async function buildFullSystemContext(supabase: SupabaseClient): Promise<string> {
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return '(Not authenticated — no context available.)'
+
+  const today = new Date().toISOString().slice(0, 10)
+  const cutoff14 = new Date()
+  cutoff14.setDate(cutoff14.getDate() - 14)
+  const cutoff7 = new Date()
+  cutoff7.setDate(cutoff7.getDate() - 7)
+  const cutoff14Str = cutoff14.toISOString().slice(0, 10)
+  const cutoff7Str = cutoff7.toISOString().slice(0, 10)
+
+  const [
+    supplementsRes,
+    nutritionRes,
+    habitsRes,
+    habitsLogsRes,
+    runningRes,
+    hrRes,
+    marathonSessionsRes,
+    planConfigsRes,
+    recentAuditRes,
+  ] = await Promise.allSettled([
+    supabase
+      .from('supplements')
+      .select('id, name, frequency, timing, is_active, is_paused, pause_reason, prescribed_for, duration_notes, blood_donation_override')
+      .eq('user_id', user.id)
+      .eq('is_active', true)
+      .order('created_at', { ascending: true }),
+
+    supabase
+      .from('nutrition_logs')
+      .select('log_date, adherence_score, water_ml, has_alcohol, has_fried_food, has_processed_snack')
+      .eq('user_id', user.id)
+      .gte('log_date', cutoff14Str)
+      .order('log_date', { ascending: false }),
+
+    supabase
+      .from('habits')
+      .select('id, name, streak')
+      .eq('user_id', user.id)
+      .eq('is_archived', false),
+
+    supabase
+      .from('habit_logs')
+      .select('habit_id, logged_at')
+      .eq('user_id', user.id)
+      .gte('logged_at', cutoff14.toISOString()),
+
+    supabase
+      .from('running_activities')
+      .select('workout_type, distance_meters, duration_seconds, avg_pace_sec_per_km, avg_hr, started_at, title')
+      .eq('user_id', user.id)
+      .order('started_at', { ascending: false })
+      .limit(7),
+
+    supabase
+      .from('resting_hr_logs')
+      .select('log_date, bpm')
+      .eq('user_id', user.id)
+      .gte('log_date', cutoff7Str)
+      .order('log_date', { ascending: false }),
+
+    supabase
+      .from('training_sessions')
+      .select('session_date, session_type, planned_description, completed, actual_distance_km, actual_duration_min, perceived_effort, coach_notes, flag')
+      .eq('user_id', user.id)
+      .gte('session_date', cutoff7Str)
+      .order('session_date', { ascending: false }),
+
+    supabase
+      .from('plan_configs')
+      .select('module, config_key, config_label, config_value, config_unit')
+      .eq('user_id', user.id)
+      .order('module', { ascending: true }),
+
+    supabase
+      .from('plan_audit_log')
+      .select('changed_at, module, entity_type, action, field_changed, previous_value, new_value, reason, changed_by')
+      .eq('user_id', user.id)
+      .order('changed_at', { ascending: false })
+      .limit(10),
+  ])
+
+  const sections: string[] = []
+
+  // ── Supplements ──────────────────────────────────────────────
+  if (supplementsRes.status === 'fulfilled' && supplementsRes.value.data) {
+    const sups = supplementsRes.value.data
+    const active = sups.filter((s) => !s.is_paused)
+    const paused = sups.filter((s) => s.is_paused)
+
+    const activeLines = active.map((s) => {
+      const timing = s.timing ? ` · ${s.timing}` : ''
+      const forNote = s.prescribed_for ? ` (${s.prescribed_for})` : ''
+      const override = s.blood_donation_override ? ' ⚡ override:daily in recovery' : ''
+      return `- [${s.id}] ${s.name} — ${s.frequency}${timing}${forNote}${override}`
+    })
+    const pausedLines = paused.map(
+      (s) => `- [${s.id}] ${s.name} — PAUSED (${s.pause_reason ?? 'no reason'})`
+    )
+
+    sections.push(
+      `## Supplements (${active.length} active${paused.length ? `, ${paused.length} paused` : ''})\n` +
+        (activeLines.join('\n') || 'None.') +
+        (pausedLines.length ? '\n\n**Paused:**\n' + pausedLines.join('\n') : '') +
+        '\n\n_Note: supplement IDs are shown in brackets — use them when calling tools._'
+    )
+  }
+
+  // ── Supplement log for today ──────────────────────────────────
+  if (supplementsRes.status === 'fulfilled' && supplementsRes.value.data) {
+    const { data: todayLogs } = await supabase
+      .from('supplement_log_entries')
+      .select('supplement_id, taken')
+      .eq('user_id', user.id)
+      .eq('log_date', today)
+    if (todayLogs && todayLogs.length > 0) {
+      const takenIds = new Set(todayLogs.filter((l) => l.taken).map((l) => l.supplement_id))
+      const notTaken = (supplementsRes.value.data ?? [])
+        .filter((s) => !s.is_paused && !takenIds.has(s.id))
+        .map((s) => s.name)
+      sections.push(
+        `## Supplement Adherence Today (${today})\n` +
+          `Taken: ${takenIds.size} of ${(supplementsRes.value.data ?? []).filter((s) => !s.is_paused).length}\n` +
+          (notTaken.length ? `Not yet taken: ${notTaken.join(', ')}` : 'All done!')
+      )
+    }
+  }
+
+  // ── Nutrition ──────────────────────────────────────────────────
+  if (nutritionRes.status === 'fulfilled' && nutritionRes.value.data?.length) {
+    const logs = nutritionRes.value.data
+    const avgScore =
+      logs.reduce((s, l) => s + (l.adherence_score ?? 0), 0) / logs.length
+    const alcoholDays = logs.filter((l) => l.has_alcohol).length
+    const lines = logs
+      .slice(0, 14)
+      .map((l) => {
+        const flags = [
+          l.has_alcohol ? '🍷' : '',
+          l.has_fried_food ? '🍟' : '',
+          l.has_processed_snack ? '🍪' : '',
+        ]
+          .filter(Boolean)
+          .join(' ')
+        const water = l.water_ml != null ? `${l.water_ml}ml` : ''
+        return `- ${l.log_date}: ${l.adherence_score ?? '?'}/100${water ? ` | ${water}` : ''}${flags ? ' ' + flags : ''}`
+      })
+    sections.push(
+      `## Nutrition (last 14 days)\nAvg score: ${avgScore.toFixed(0)}/100 | Alcohol days: ${alcoholDays}\n${lines.join('\n')}`
+    )
+  }
+
+  // ── Habits ─────────────────────────────────────────────────────
+  if (
+    habitsRes.status === 'fulfilled' &&
+    habitsLogsRes.status === 'fulfilled' &&
+    habitsRes.value.data?.length
+  ) {
+    const habits = habitsRes.value.data
+    const logs = habitsLogsRes.value.data ?? []
+    const lines = habits.map((h) => {
+      const completions = logs.filter((l) => l.habit_id === h.id).length
+      const rate = ((completions / 14) * 100).toFixed(0)
+      return `- ${h.name}: ${completions}/14 days (${rate}%) | streak: ${h.streak}`
+    })
+    sections.push(`## Habits (last 14 days)\n${lines.join('\n')}`)
+  }
+
+  // ── Running ─────────────────────────────────────────────────────
+  if (runningRes.status === 'fulfilled' && runningRes.value.data?.length) {
+    const formatPace = (s: number | null) => {
+      if (!s) return 'N/A'
+      const m = Math.floor(s / 60)
+      const sec = Math.round(s % 60)
+      return `${m}:${String(sec).padStart(2, '0')}/km`
+    }
+    const lines = runningRes.value.data.map((a) => {
+      const date = new Date(a.started_at).toLocaleDateString('en-GB', {
+        weekday: 'short',
+        day: 'numeric',
+        month: 'short',
+      })
+      const dist = (a.distance_meters / 1000).toFixed(2) + 'km'
+      const pace = formatPace(a.avg_pace_sec_per_km)
+      const hr = a.avg_hr ? ` HR:${a.avg_hr}` : ''
+      return `- ${date}: ${a.workout_type.toUpperCase()} ${dist} @ ${pace}${hr}`
+    })
+
+    const hrLines =
+      hrRes.status === 'fulfilled' && hrRes.value.data?.length
+        ? hrRes.value.data.map((h) => `- ${h.log_date}: ${h.bpm} bpm`).join('\n')
+        : 'No resting HR data.'
+
+    sections.push(`## Running (last 7 activities)\n${lines.join('\n')}\n\n**Resting HR (last 7 days):**\n${hrLines}`)
+  }
+
+  // ── Marathon Plan ───────────────────────────────────────────────
+  if (marathonSessionsRes.status === 'fulfilled' && marathonSessionsRes.value.data?.length) {
+    const sessions = marathonSessionsRes.value.data
+    const lines = sessions.map((s) => {
+      const done = s.completed ? '✅' : '⬜'
+      const dist = s.actual_distance_km ? ` ${s.actual_distance_km}km` : ''
+      const effort = s.perceived_effort ? ` RPE:${s.perceived_effort}` : ''
+      const flag = s.flag ? ` ⚠️ ${s.flag}` : ''
+      return `- ${s.session_date} ${done} ${s.session_type}${dist}${effort}${flag}`
+    })
+    sections.push(`## Marathon Training Sessions (last 7 days)\n${lines.join('\n')}`)
+  }
+
+  // ── Plan Configs ────────────────────────────────────────────────
+  if (planConfigsRes.status === 'fulfilled' && planConfigsRes.value.data?.length) {
+    const configs = planConfigsRes.value.data
+    const byModule: Record<string, string[]> = {}
+    for (const c of configs) {
+      if (!byModule[c.module]) byModule[c.module] = []
+      const unit = c.config_unit ? ` ${c.config_unit}` : ''
+      byModule[c.module].push(`- ${c.config_key}: ${c.config_value}${unit} (${c.config_label})`)
+    }
+    const moduleBlocks = Object.entries(byModule)
+      .map(([mod, lines]) => `**${mod}:**\n${lines.join('\n')}`)
+      .join('\n\n')
+    sections.push(`## Plan Configurations\n${moduleBlocks}`)
+  }
+
+  // ── Recent Changes ──────────────────────────────────────────────
+  if (recentAuditRes.status === 'fulfilled' && recentAuditRes.value.data?.length) {
+    const entries = recentAuditRes.value.data
+    const lines = entries.map((e) => {
+      const date = new Date(e.changed_at).toLocaleDateString('en-GB', {
+        day: 'numeric',
+        month: 'short',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+      const change = e.field_changed
+        ? `${e.field_changed}: ${e.previous_value} → ${e.new_value}`
+        : `${e.action} ${e.entity_type}`
+      return `- ${date} [${e.changed_by}] ${e.module}: ${change}${e.reason ? ` — ${e.reason}` : ''}`
+    })
+    sections.push(`## Recent Changes (audit log)\n${lines.join('\n')}`)
+  }
+
+  return sections.join('\n\n')
+}


### PR DESCRIPTION
- `src/lib/ai/master-coach.ts` — system prompt + `buildFullSystemContext()` that fetches supplements, nutrition, habits, running, marathon sessions, and plan configs in one parallel query block
- `src/app/api/ai/coach/route.ts` — streaming API with three tools: `pause_supplement`, `resume_supplement`, `update_plan_config`, `get_recent_changes`; all changes are audit-logged
- `src/components/ai/master-coach.tsx` — chat UI that renders tool-invocation parts as action cards (CheckCircle/XCircle) and `get_recent_changes` results as an inline history list; suggestion chips on empty state
- `src/app/(dashboard)/coach/page.tsx` — Coach page with capability grid
- Sidebar updated with Coach nav entry

https://claude.ai/code/session_01E8gFJcw2aVTW7AYfatAJsA