### PR TITLE
feat: Editable Nutrition Plans + Global Coach Tooling

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,4 +1,5 @@
 import { Sidebar } from "@/components/layout/sidebar";
+import { GlobalCoachPanel } from "@/components/layout/GlobalCoachPanel";
 
 export default function DashboardLayout({
   children,
@@ -12,6 +13,8 @@ export default function DashboardLayout({
       <main className="flex-1 overflow-y-auto p-4 pt-18 sm:p-6 lg:pt-6">
         {children}
       </main>
+      {/* Persistent floating Life Coach — accessible from any page */}
+      <GlobalCoachPanel />
     </div>
   );
 }

--- a/src/app/(dashboard)/nutrition/page.tsx
+++ b/src/app/(dashboard)/nutrition/page.tsx
@@ -1,4 +1,4 @@
-// Nutrition Hub — Today's meal checklist
+// Nutrition Hub — Today's meal checklist (meals from DB)
 
 import type { Metadata } from 'next'
 import Link from 'next/link'
@@ -7,6 +7,7 @@ import {
   getServerNutritionLog,
   getServerSupplementLog,
 } from '@/lib/supabase/nutrition'
+import { getServerMealsForDayType, seedMealsServer } from '@/lib/supabase/meals'
 import { DailyMealChecklist } from '@/components/nutrition/DailyMealChecklist'
 import { Activity, BarChart2, Pill, CalendarDays } from 'lucide-react'
 
@@ -20,14 +21,19 @@ export default async function NutritionPage() {
   const supabase = createClient()
   const today = new Date().toISOString().slice(0, 10)
 
-  const [nutritionLog, supplementLog] = await Promise.all([
-    getServerNutritionLog(supabase, today),
-    getServerSupplementLog(supabase, today),
-  ])
-
-  // Determine if today is a run day (weekday = Mon-Fri assumed run days)
+  // Determine day type
   const dayOfWeek = new Date().getDay()
   const isRunDay = dayOfWeek >= 1 && dayOfWeek <= 5
+  const dayType: 'training' | 'rest' = isRunDay ? 'training' : 'rest'
+
+  // Seed meals on first visit (idempotent)
+  await seedMealsServer()
+
+  const [nutritionLog, supplementLog, meals] = await Promise.all([
+    getServerNutritionLog(supabase, today),
+    getServerSupplementLog(supabase, today),
+    getServerMealsForDayType(supabase, dayType),
+  ])
 
   const dateLabel = new Date().toLocaleDateString('en-GB', {
     weekday: 'long',
@@ -98,6 +104,7 @@ export default async function NutritionPage() {
         dateLabel={dateLabel}
         initialLog={nutritionLog}
         isRunDay={isRunDay}
+        meals={meals}
       />
     </div>
   )

--- a/src/app/api/ai/life-coach/confirm/route.ts
+++ b/src/app/api/ai/life-coach/confirm/route.ts
@@ -35,9 +35,28 @@ const manageSupplementSchema = z.object({
   reason: z.string(),
 })
 
+const updateMealSchema = z.object({
+  action: z.literal('update_meal'),
+  params: z.object({
+    meal_id: z.string(),
+    meal_name: z.string(),
+    meal_label: z.string(),
+    updates: z.object({
+      label: z.string().optional(),
+      description: z.string().optional(),
+      calories: z.number().int().nonnegative().optional(),
+      protein: z.number().nonnegative().optional(),
+      carbs: z.number().nonnegative().optional(),
+      fats: z.number().nonnegative().optional(),
+    }),
+  }),
+  reason: z.string(),
+})
+
 const confirmBodySchema = z.discriminatedUnion('action', [
   updatePlanConfigSchema,
   manageSupplementSchema,
+  updateMealSchema,
 ])
 
 // ── Handler ────────────────────────────────────────────────────────────────
@@ -223,6 +242,67 @@ export async function POST(req: Request) {
       return Response.json({
         success: true,
         message: `${actionLabel[supplement_action] ?? supplement_action} ${supplement_name ?? supplement_id}.`,
+      })
+    }
+
+    // ── update_meal ───────────────────────────────────────────────
+    if (action === 'update_meal') {
+      const { meal_id, meal_label, updates } = params
+
+      // Fetch current for audit
+      const { data: current } = await supabase
+        .from('meals')
+        .select('*')
+        .eq('id', meal_id)
+        .eq('user_id', user.id)
+        .single()
+
+      if (!current) {
+        return Response.json({ success: false, message: 'Meal not found' }, { status: 404 })
+      }
+
+      const { data, error } = await supabase
+        .from('meals')
+        .update({ ...updates, updated_at: new Date().toISOString() })
+        .eq('id', meal_id)
+        .eq('user_id', user.id)
+        .select()
+        .single()
+
+      if (error) throw error
+
+      // meal_changes audit
+      await supabase.from('meal_changes').insert({
+        meal_id,
+        user_id: user.id,
+        changed_by: changedBy,
+        previous_value: current,
+        new_value: data,
+        reason,
+      })
+
+      // plan_audit_log
+      await supabase.from('plan_audit_log').insert({
+        user_id: user.id,
+        module: 'nutrition',
+        entity_type: 'meal',
+        entity_description: meal_label,
+        action: 'update',
+        field_changed: Object.keys(updates).join(', '),
+        previous_value: JSON.stringify(
+          Object.fromEntries(Object.keys(updates).map((k) => [k, (current as Record<string, unknown>)[k]]))
+        ),
+        new_value: JSON.stringify(updates),
+        reason,
+        changed_by: changedBy,
+      })
+
+      const changeDesc = Object.entries(updates)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join(', ')
+      return Response.json({
+        success: true,
+        message: `I've updated your ${meal_label} to include ${changeDesc}.`,
       })
     }
   } catch (e) {

--- a/src/app/api/ai/life-coach/route.ts
+++ b/src/app/api/ai/life-coach/route.ts
@@ -6,7 +6,13 @@ import { google } from '@ai-sdk/google'
 import { streamText, convertToModelMessages } from 'ai'
 import { z } from 'zod'
 import { createClient } from '@/lib/supabase/server'
-import { ATHLETE_PROFILE, getGlobalLifeContext, buildGlobalContextBlock } from '@/lib/ai/coaching'
+import {
+  ATHLETE_PROFILE,
+  getGlobalLifeContext,
+  buildGlobalContextBlock,
+  getGlobalContext,
+  buildNutritionContextBlock,
+} from '@/lib/ai/coaching'
 import { buildFullSystemContext } from '@/lib/ai/master-coach'
 
 export const runtime = 'nodejs'
@@ -72,15 +78,17 @@ export async function POST(req: Request) {
   } = await supabase.auth.getUser()
   if (!user) return new Response('Unauthorized', { status: 401 })
 
-  // Build context: fast cross-module summary + full detail block
+  // Build context: fast cross-module summary + nutrition plan + full detail block
   let contextBlock = ''
   try {
-    const [globalCtx, fullCtx] = await Promise.all([
+    const [globalCtx, fullCtx, nutritionCtx] = await Promise.all([
       getGlobalLifeContext(supabase),
       buildFullSystemContext(supabase),
+      getGlobalContext(supabase),
     ])
     const signals = buildGlobalContextBlock(globalCtx)
-    contextBlock = `## Cross-Module Signal Summary\n${signals}\n\n---\n\n${fullCtx}`
+    const nutritionBlock = buildNutritionContextBlock(nutritionCtx)
+    contextBlock = `## Cross-Module Signal Summary\n${signals}\n\n---\n\n${nutritionBlock}\n\n---\n\n${fullCtx}`
   } catch (err) {
     console.error('[life-coach] context build failed:', err)
     contextBlock = '(Context unavailable — answering from conversation only.)'
@@ -312,6 +320,114 @@ ${contextBlock}`
             return { success: true, message: 'Coaching note logged to audit trail.' }
           } catch (e) {
             return { success: false, message: `Failed to log note: ${String(e)}` }
+          }
+        },
+      },
+
+      // ── updateMeal ───────────────────────────────────────────────
+      updateMeal: {
+        description:
+          'Propose an update to a meal definition (description, macros, label). Returns a ' +
+          'proposal the user must confirm before the database is updated. Use this when the user ' +
+          'asks to change what a meal contains, its calories, protein, carbs, or fats.',
+        parameters: z.object({
+          meal_name: z
+            .string()
+            .describe(
+              'The meal_name key, e.g. "meal_breakfast", "meal_lunch", "meal_snack1"'
+            ),
+          updates: z
+            .object({
+              label: z.string().optional().describe('New display label'),
+              description: z.string().optional().describe('New description of the meal contents'),
+              calories: z.number().int().nonnegative().optional().describe('New calorie target'),
+              protein: z.number().nonnegative().optional().describe('Protein in grams'),
+              carbs: z.number().nonnegative().optional().describe('Carbohydrates in grams'),
+              fats: z.number().nonnegative().optional().describe('Fats in grams'),
+            })
+            .describe('Fields to update — only include fields being changed'),
+          reason: z
+            .string()
+            .describe('Why this meal change is proposed (include any relevant context)'),
+        }),
+        execute: async ({ meal_name, updates, reason }) => {
+          try {
+            const { data: meal } = await supabase
+              .from('meals')
+              .select('id, label, description, calories, protein, carbs, fats')
+              .eq('user_id', user.id)
+              .eq('meal_name', meal_name)
+              .limit(1)
+              .single()
+
+            if (!meal) {
+              return {
+                type: 'error' as const,
+                message: `Meal "${meal_name}" not found in your plan. Valid keys: meal_post_run, meal_breakfast, meal_lunch, meal_snack1-4.`,
+              }
+            }
+
+            const changeLines = Object.entries(updates)
+              .map(([k, v]) => `**${k}**: ${(meal as Record<string, unknown>)[k] ?? 'unset'} → ${v}`)
+              .join('\n')
+
+            return {
+              type: 'proposal' as const,
+              action: 'update_meal',
+              displayTitle: `Update ${meal.label}`,
+              displayBody: changeLines,
+              reason,
+              params: {
+                meal_id: meal.id,
+                meal_name,
+                meal_label: meal.label,
+                updates,
+              },
+            }
+          } catch (e) {
+            return { type: 'error' as const, message: `Failed to build proposal: ${String(e)}` }
+          }
+        },
+      },
+
+      // ── addSupplement ────────────────────────────────────────────
+      addSupplement: {
+        description:
+          'Propose adding a new supplement to the user\'s protocol. Returns a proposal the user ' +
+          'must confirm before the supplement is inserted. Use when the user explicitly asks to ' +
+          'add a new supplement.',
+        parameters: z.object({
+          name: z.string().describe('Supplement name, e.g. "Creatine Monohydrate"'),
+          frequency: z
+            .string()
+            .describe('Dosing and frequency, e.g. "5g daily" or "1000mg twice daily"'),
+          timing: z
+            .string()
+            .optional()
+            .describe('When to take it, e.g. "post-workout with food"'),
+          prescribed_for: z
+            .string()
+            .optional()
+            .describe('Goal or condition addressed, e.g. "muscle recovery, strength"'),
+          reason: z.string().describe('Why this supplement is being proposed'),
+        }),
+        execute: async ({ name, frequency, timing, prescribed_for, reason }) => {
+          return {
+            type: 'proposal' as const,
+            action: 'manage_supplement',
+            displayTitle: `Add Supplement: ${name}`,
+            displayBody:
+              `Add **${name}** — ${frequency}` +
+              (timing ? `, take ${timing}` : '') +
+              (prescribed_for ? ` *(for: ${prescribed_for})*` : ''),
+            reason,
+            params: {
+              supplement_action: 'add',
+              name,
+              frequency,
+              timing: timing ?? null,
+              prescribed_for: prescribed_for ?? null,
+            },
           }
         },
       },

--- a/src/app/api/nutrition/meals/[id]/route.ts
+++ b/src/app/api/nutrition/meals/[id]/route.ts
@@ -1,0 +1,102 @@
+// PATCH /api/nutrition/meals/[id]
+// Updates a meal definition. Called by MealEditDialog (manual edits)
+// and by the life-coach confirm endpoint (AI-proposed edits).
+// All changes are logged to plan_audit_log with the appropriate changed_by value.
+
+import { createClient } from '@/lib/supabase/server'
+import { z } from 'zod'
+
+export const runtime = 'nodejs'
+
+const patchBodySchema = z.object({
+  updates: z.object({
+    label: z.string().min(1).optional(),
+    description: z.string().nullable().optional(),
+    calories: z.number().int().nonnegative().nullable().optional(),
+    protein: z.number().nonnegative().nullable().optional(),
+    carbs: z.number().nonnegative().nullable().optional(),
+    fats: z.number().nonnegative().nullable().optional(),
+    icon: z.string().optional(),
+  }),
+  reason: z.string().optional(),
+  changed_by: z.enum(['user', 'ai_life_coach']).default('user'),
+})
+
+export async function PATCH(req: Request, { params }: { params: { id: string } }) {
+  const supabase = createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return new Response('Unauthorized', { status: 401 })
+
+  let rawBody: unknown
+  try {
+    rawBody = await req.json()
+  } catch {
+    return Response.json({ success: false, message: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const parsed = patchBodySchema.safeParse(rawBody)
+  if (!parsed.success) {
+    return Response.json(
+      { success: false, message: 'Invalid request', errors: parsed.error.flatten() },
+      { status: 400 }
+    )
+  }
+
+  const { updates, reason, changed_by } = parsed.data
+  const mealId = params.id
+
+  // Fetch current for audit
+  const { data: current, error: fetchError } = await supabase
+    .from('meals')
+    .select('*')
+    .eq('id', mealId)
+    .eq('user_id', user.id)
+    .single()
+
+  if (fetchError || !current) {
+    return Response.json({ success: false, message: 'Meal not found' }, { status: 404 })
+  }
+
+  const { data, error } = await supabase
+    .from('meals')
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq('id', mealId)
+    .eq('user_id', user.id)
+    .select()
+    .single()
+
+  if (error) {
+    return Response.json({ success: false, message: error.message }, { status: 500 })
+  }
+
+  // Audit: meal_changes
+  await supabase.from('meal_changes').insert({
+    meal_id: mealId,
+    user_id: user.id,
+    changed_by,
+    previous_value: current,
+    new_value: data,
+    reason: reason ?? null,
+  })
+
+  // Audit: plan_audit_log
+  const previousSnippet = JSON.stringify(
+    Object.fromEntries(Object.keys(updates).map((k) => [k, (current as Record<string, unknown>)[k]]))
+  )
+  await supabase.from('plan_audit_log').insert({
+    user_id: user.id,
+    module: 'nutrition',
+    entity_type: 'meal',
+    entity_description: current.label as string,
+    action: 'update',
+    field_changed: Object.keys(updates).join(', '),
+    previous_value: previousSnippet,
+    new_value: JSON.stringify(updates),
+    reason: reason ?? null,
+    changed_by,
+  })
+
+  return Response.json({ success: true, meal: data })
+}

--- a/src/components/layout/GlobalCoachPanel.tsx
+++ b/src/components/layout/GlobalCoachPanel.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+// GlobalCoachPanel — persistent floating Life Coach accessible from any page.
+// A floating button (bottom-right) opens a collapsible side panel containing
+// the full LifeCoach component with module focus + proposal cards.
+
+import { useState, useEffect } from 'react'
+import { Brain, X, ChevronRight } from 'lucide-react'
+import { LifeCoach } from '@/components/ai/life-coach'
+
+export function GlobalCoachPanel() {
+  const [open, setOpen] = useState(false)
+
+  // Close on Escape
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [])
+
+  return (
+    <>
+      {/* Floating trigger button */}
+      <button
+        onClick={() => setOpen(true)}
+        aria-label="Open Life Coach"
+        className={`
+          fixed bottom-6 right-6 z-40
+          flex items-center gap-2
+          rounded-full border border-violet-500/30 bg-[#0a0a0a] px-4 py-3
+          text-sm font-medium text-violet-300
+          shadow-lg shadow-violet-900/20
+          transition-all duration-200
+          hover:bg-violet-500/10 hover:border-violet-500/50 hover:shadow-violet-900/40
+          ${open ? 'opacity-0 pointer-events-none' : 'opacity-100'}
+        `}
+      >
+        <Brain className="h-4 w-4 text-violet-400" />
+        <span className="hidden sm:inline">Life Coach</span>
+      </button>
+
+      {/* Backdrop (mobile only) */}
+      {open && (
+        <div
+          className="fixed inset-0 z-40 bg-black/50 sm:hidden"
+          onClick={() => setOpen(false)}
+        />
+      )}
+
+      {/* Side panel */}
+      <div
+        className={`
+          fixed top-0 right-0 z-50 h-screen w-full sm:w-[480px]
+          flex flex-col
+          border-l border-white/8 bg-[#0a0a0a]
+          shadow-2xl
+          transition-transform duration-300 ease-in-out
+          ${open ? 'translate-x-0' : 'translate-x-full'}
+        `}
+      >
+        {/* Panel header */}
+        <div className="flex shrink-0 items-center justify-between border-b border-white/8 px-4 py-3">
+          <div className="flex items-center gap-2">
+            <Brain className="h-4 w-4 text-violet-400" />
+            <span className="text-sm font-semibold text-white">Global Life Coach</span>
+            <span className="text-xs text-white/30">· all modules</span>
+          </div>
+          <button
+            onClick={() => setOpen(false)}
+            className="text-white/30 hover:text-white/70 transition-colors"
+            aria-label="Close coach panel"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Panel body — scrollable */}
+        <div className="flex-1 overflow-y-auto p-4">
+          {open && <LifeCoach />}
+        </div>
+
+        {/* Collapse handle */}
+        <button
+          onClick={() => setOpen(false)}
+          className="shrink-0 flex items-center justify-center gap-1.5 border-t border-white/8 py-3 text-xs text-white/30 hover:text-white/60 transition-colors"
+        >
+          <ChevronRight className="h-3.5 w-3.5" />
+          Close panel
+        </button>
+      </div>
+    </>
+  )
+}

--- a/src/components/nutrition/DailyMealChecklist.tsx
+++ b/src/components/nutrition/DailyMealChecklist.tsx
@@ -17,6 +17,7 @@ import type {
   FruitChoice,
 } from '@/lib/types/nutrition'
 import { MEAL_ICONS, MEAL_LABELS } from '@/lib/types/nutrition'
+import type { Meal } from '@/lib/supabase/meals'
 
 const MEAL_KEYS = [
   'meal_post_run',
@@ -33,6 +34,7 @@ interface DailyMealChecklistProps {
   dateLabel: string
   initialLog: NutritionLog | null
   isRunDay?: boolean
+  meals?: Meal[]  // DB meal definitions; falls back to static constants if empty
 }
 
 type LogState = {
@@ -82,7 +84,12 @@ export function DailyMealChecklist({
   dateLabel,
   initialLog,
   isRunDay,
+  meals = [],
 }: DailyMealChecklistProps) {
+  // Build meal lookup by meal_name for quick access in render
+  const [mealMap, setMealMap] = useState<Record<string, Meal>>(() =>
+    Object.fromEntries(meals.map((m) => [m.meal_name, m]))
+  )
   const [log, setLog] = useState<LogState>(initState(initialLog))
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
@@ -186,25 +193,33 @@ export function DailyMealChecklist({
       {/* Adherence score bar */}
       <AdherenceScore score={score} />
 
-      {/* Meal cards */}
+      {/* Meal cards — use DB-derived meal list if available, else fall back to static keys */}
       <div className="space-y-2">
-        {MEAL_KEYS.map((mealKey) => (
-          <MealCard
-            key={mealKey}
-            mealKey={mealKey}
-            icon={MEAL_ICONS[mealKey]}
-            label={MEAL_LABELS[mealKey]}
-            status={log[mealKey] as MealStatus}
-            note={log.meal_notes[mealKey] ?? ''}
-            lunchCarbChoice={mealKey === 'meal_lunch' ? log.meal_lunch_carb_choice : undefined}
-            fruitChoice={mealKey === 'meal_snack4' ? log.meal_snack4_fruit : undefined}
-            onStatusChange={(s) => updateMealStatus(mealKey, s)}
-            onNoteChange={(n) => updateMealNote(mealKey, n)}
-            onLunchCarbChange={mealKey === 'meal_lunch' ? updateLunchCarb : undefined}
-            onFruitChange={mealKey === 'meal_snack4' ? updateFruitChoice : undefined}
-            disabled={saving}
-          />
-        ))}
+        {(meals.length > 0 ? meals.map((m) => m.meal_name) : MEAL_KEYS).map((mealKey) => {
+          const dbMeal = mealMap[mealKey] ?? null
+          return (
+            <MealCard
+              key={mealKey}
+              mealKey={mealKey}
+              icon={dbMeal?.icon ?? MEAL_ICONS[mealKey]}
+              label={dbMeal?.label ?? MEAL_LABELS[mealKey]}
+              description={dbMeal?.description}
+              dbMeal={dbMeal}
+              status={log[mealKey as keyof typeof log] as MealStatus}
+              note={log.meal_notes[mealKey] ?? ''}
+              lunchCarbChoice={mealKey === 'meal_lunch' ? log.meal_lunch_carb_choice : undefined}
+              fruitChoice={mealKey === 'meal_snack4' ? log.meal_snack4_fruit : undefined}
+              onStatusChange={(s) => updateMealStatus(mealKey as (typeof MEAL_KEYS)[number], s)}
+              onNoteChange={(n) => updateMealNote(mealKey, n)}
+              onLunchCarbChange={mealKey === 'meal_lunch' ? updateLunchCarb : undefined}
+              onFruitChange={mealKey === 'meal_snack4' ? updateFruitChoice : undefined}
+              onMealUpdated={(updated) =>
+                setMealMap((prev) => ({ ...prev, [mealKey]: updated }))
+              }
+              disabled={saving}
+            />
+          )
+        })}
       </div>
 
       {/* Water tracker */}

--- a/src/components/nutrition/MealCard.tsx
+++ b/src/components/nutrition/MealCard.tsx
@@ -1,9 +1,11 @@
 'use client'
 
-import { ChevronDown, ChevronUp } from 'lucide-react'
+import { ChevronDown, ChevronUp, Pencil } from 'lucide-react'
 import { useState } from 'react'
 import type { MealStatus, LunchCarbChoice, FruitChoice } from '@/lib/types/nutrition'
 import { LUNCH_CARB_LABELS, FRUIT_LABELS, MEAL_DETAILS } from '@/lib/types/nutrition'
+import type { Meal } from '@/lib/supabase/meals'
+import { MealEditDialog } from './MealEditDialog'
 
 const STATUS_CYCLE: MealStatus[] = ['pending', 'complete', 'partial', 'skipped', 'modified']
 
@@ -19,6 +21,8 @@ interface MealCardProps {
   mealKey: string
   icon: string
   label: string
+  description?: string | null  // from DB meals table (overrides MEAL_DETAILS fallback)
+  dbMeal?: Meal | null         // full DB row — enables edit dialog
   status: MealStatus
   note: string
   lunchCarbChoice?: LunchCarbChoice | null
@@ -27,6 +31,7 @@ interface MealCardProps {
   onNoteChange: (note: string) => void
   onLunchCarbChange?: (choice: LunchCarbChoice) => void
   onFruitChange?: (choice: FruitChoice) => void
+  onMealUpdated?: (updated: Meal) => void
   disabled?: boolean
 }
 
@@ -34,6 +39,8 @@ export function MealCard({
   mealKey,
   icon,
   label,
+  description,
+  dbMeal,
   status,
   note,
   lunchCarbChoice,
@@ -42,13 +49,23 @@ export function MealCard({
   onNoteChange,
   onLunchCarbChange,
   onFruitChange,
+  onMealUpdated,
   disabled,
 }: MealCardProps) {
   const [expanded, setExpanded] = useState(false)
+  const [editOpen, setEditOpen] = useState(false)
+  const [currentMeal, setCurrentMeal] = useState<Meal | null>(dbMeal ?? null)
   const display = STATUS_DISPLAY[status]
   const showNoteField = status === 'partial' || status === 'skipped' || status === 'modified'
   const isLunch = mealKey === 'meal_lunch'
   const isSnack4 = mealKey === 'meal_snack4'
+
+  // Use DB description if available, fall back to static MEAL_DETAILS
+  const mealDescription = currentMeal?.description ?? description ?? MEAL_DETAILS[mealKey]
+  // Macro summary line
+  const macroLine = currentMeal && (currentMeal.calories || currentMeal.protein)
+    ? `${currentMeal.calories ?? '?'} kcal · ${currentMeal.protein ?? '?'}g P · ${currentMeal.carbs ?? '?'}g C · ${currentMeal.fats ?? '?'}g F`
+    : null
 
   function cycleStatus() {
     const idx = STATUS_CYCLE.indexOf(status)
@@ -58,7 +75,20 @@ export function MealCard({
     else if (next !== 'pending') setExpanded(true)
   }
 
+  function handleMealSaved(updated: Meal) {
+    setCurrentMeal(updated)
+    onMealUpdated?.(updated)
+  }
+
   return (
+    <>
+      {editOpen && currentMeal && (
+        <MealEditDialog
+          meal={currentMeal}
+          onClose={() => setEditOpen(false)}
+          onSaved={handleMealSaved}
+        />
+      )}
     <div className={`rounded-lg border border-white/8 ${display.bg} transition-colors`}>
       <div className="flex items-center gap-3 px-3 py-2.5">
         <span className="text-base shrink-0">{icon}</span>
@@ -68,9 +98,26 @@ export function MealCard({
           className="flex-1 text-left min-w-0"
           disabled={disabled}
         >
-          <span className="text-sm font-medium text-white/80 truncate block">{label}</span>
-          <span className="text-xs text-white/35">{MEAL_DETAILS[mealKey]}</span>
+          <span className="text-sm font-medium text-white/80 truncate block">
+            {currentMeal?.label ?? label}
+          </span>
+          <span className="text-xs text-white/35 truncate block">{mealDescription}</span>
+          {macroLine && (
+            <span className="text-xs text-white/25 truncate block">{macroLine}</span>
+          )}
         </button>
+
+        {/* Manual edit button */}
+        {currentMeal && (
+          <button
+            onClick={() => setEditOpen(true)}
+            disabled={disabled}
+            title="Edit meal"
+            className="shrink-0 rounded-md p-1.5 text-white/25 hover:text-white/60 hover:bg-white/5 transition-colors"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </button>
+        )}
 
         <button
           onClick={cycleStatus}
@@ -161,5 +208,6 @@ export function MealCard({
         </div>
       )}
     </div>
+    </>
   )
 }

--- a/src/components/nutrition/MealEditDialog.tsx
+++ b/src/components/nutrition/MealEditDialog.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+// MealEditDialog — Manual edit overlay for a single meal definition.
+// Opens as a modal with fields for description and macros.
+// Saves via PATCH /api/nutrition/meals/[id] with changed_by='user'.
+
+import { useState } from 'react'
+import { Loader2, X } from 'lucide-react'
+import type { Meal, MealUpdate } from '@/lib/supabase/meals'
+
+interface MealEditDialogProps {
+  meal: Meal
+  onClose: () => void
+  onSaved: (updated: Meal) => void
+}
+
+export function MealEditDialog({ meal, onClose, onSaved }: MealEditDialogProps) {
+  const [form, setForm] = useState<{
+    label: string
+    description: string
+    calories: string
+    protein: string
+    carbs: string
+    fats: string
+  }>({
+    label: meal.label,
+    description: meal.description ?? '',
+    calories: meal.calories != null ? String(meal.calories) : '',
+    protein: meal.protein != null ? String(meal.protein) : '',
+    carbs: meal.carbs != null ? String(meal.carbs) : '',
+    fats: meal.fats != null ? String(meal.fats) : '',
+  })
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  function num(val: string): number | null {
+    const n = parseFloat(val)
+    return isNaN(n) ? null : n
+  }
+
+  async function handleSave() {
+    setSaving(true)
+    setError('')
+    try {
+      const updates: MealUpdate = {}
+      if (form.label !== meal.label) updates.label = form.label
+      if (form.description !== (meal.description ?? '')) updates.description = form.description || null
+      const cal = num(form.calories)
+      if (cal !== meal.calories) updates.calories = cal ?? undefined
+      const prot = num(form.protein)
+      if (prot !== meal.protein) updates.protein = prot ?? undefined
+      const carb = num(form.carbs)
+      if (carb !== meal.carbs) updates.carbs = carb ?? undefined
+      const fat = num(form.fats)
+      if (fat !== meal.fats) updates.fats = fat ?? undefined
+
+      const res = await fetch(`/api/nutrition/meals/${meal.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ updates, reason: 'Manual edit via nutrition page', changed_by: 'user' }),
+      })
+      const json = await res.json()
+      if (!res.ok || !json.success) throw new Error(json.message ?? 'Save failed')
+      onSaved(json.meal as Meal)
+      onClose()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Save failed')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    /* Backdrop */
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      {/* Panel */}
+      <div className="relative w-full max-w-md mx-4 rounded-xl border border-white/10 bg-[#111] shadow-2xl">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-white/8">
+          <div>
+            <h2 className="text-sm font-semibold text-white">{meal.icon} {meal.label}</h2>
+            <p className="text-xs text-white/40 mt-0.5">Manual edit — logged to audit trail</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-white/40 hover:text-white/70 transition-colors"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Form */}
+        <div className="p-5 space-y-4">
+          {error && (
+            <div className="rounded-lg bg-red-500/10 border border-red-500/25 px-3 py-2 text-xs text-red-400">
+              {error}
+            </div>
+          )}
+
+          {/* Label */}
+          <div>
+            <label className="text-xs text-white/50 block mb-1">Meal label</label>
+            <input
+              type="text"
+              value={form.label}
+              onChange={(e) => setForm({ ...form, label: e.target.value })}
+              className="w-full rounded-md bg-white/5 border border-white/10 px-3 py-2 text-sm text-white focus:outline-none focus:border-white/30"
+            />
+          </div>
+
+          {/* Description */}
+          <div>
+            <label className="text-xs text-white/50 block mb-1">Description / contents</label>
+            <textarea
+              value={form.description}
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+              rows={3}
+              className="w-full rounded-md bg-white/5 border border-white/10 px-3 py-2 text-sm text-white placeholder:text-white/20 focus:outline-none focus:border-white/30 resize-none"
+              placeholder="What does this meal contain?"
+            />
+          </div>
+
+          {/* Macros */}
+          <div>
+            <label className="text-xs text-white/50 block mb-2">Macros</label>
+            <div className="grid grid-cols-4 gap-2">
+              {[
+                { key: 'calories', label: 'kcal', field: 'calories' },
+                { key: 'protein', label: 'P (g)', field: 'protein' },
+                { key: 'carbs', label: 'C (g)', field: 'carbs' },
+                { key: 'fats', label: 'F (g)', field: 'fats' },
+              ].map(({ key, label, field }) => (
+                <div key={key}>
+                  <label className="text-xs text-white/35 block mb-1 text-center">{label}</label>
+                  <input
+                    type="number"
+                    min="0"
+                    step={field === 'calories' ? '1' : '0.1'}
+                    value={form[field as keyof typeof form]}
+                    onChange={(e) => setForm({ ...form, [field]: e.target.value })}
+                    className="w-full rounded-md bg-white/5 border border-white/10 px-2 py-1.5 text-sm text-white text-center focus:outline-none focus:border-white/30"
+                    placeholder="—"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 px-5 py-4 border-t border-white/8">
+          <button
+            onClick={onClose}
+            disabled={saving}
+            className="rounded-lg border border-white/10 px-4 py-2 text-xs text-white/50 hover:text-white/70 hover:border-white/20 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="flex items-center gap-1.5 rounded-lg bg-white/10 border border-white/15 px-4 py-2 text-xs text-white hover:bg-white/15 transition-colors disabled:opacity-50"
+          >
+            {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            Save changes
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/ai/coaching.ts
+++ b/src/lib/ai/coaching.ts
@@ -521,3 +521,91 @@ export function buildGlobalContextBlock(ctx: GlobalLifeContext): string {
 
   return sections.join('\n\n')
 }
+
+// ── Nutrition + Plan Config context for Life Coach ────────────────────────────
+
+export interface GlobalNutritionContext {
+  meals: Array<{
+    meal_name: string
+    label: string
+    description: string | null
+    calories: number | null
+    protein: number | null
+    carbs: number | null
+    fats: number | null
+    day_type: string
+  }>
+  nutritionConfigs: Array<{
+    config_key: string
+    config_label: string
+    config_value: string
+    config_unit: string | null
+  }>
+  todayDayType: 'training' | 'rest'
+}
+
+export async function getGlobalContext(
+  supabase: SupabaseClient
+): Promise<GlobalNutritionContext> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return { meals: [], nutritionConfigs: [], todayDayType: 'training' }
+  }
+
+  // Determine today's day type (weekday = training, weekend = rest)
+  const dow = new Date().getDay()
+  const todayDayType: 'training' | 'rest' = dow >= 1 && dow <= 5 ? 'training' : 'rest'
+
+  const [mealsResult, configsResult] = await Promise.allSettled([
+    supabase
+      .from('meals')
+      .select('meal_name, label, description, calories, protein, carbs, fats, day_type')
+      .eq('user_id', user.id)
+      .eq('day_type', todayDayType)
+      .order('order_index'),
+    supabase
+      .from('plan_configs')
+      .select('config_key, config_label, config_value, config_unit')
+      .eq('user_id', user.id)
+      .eq('module', 'nutrition'),
+  ])
+
+  const meals =
+    mealsResult.status === 'fulfilled' ? (mealsResult.value.data ?? []) : []
+  const nutritionConfigs =
+    configsResult.status === 'fulfilled' ? (configsResult.value.data ?? []) : []
+
+  return { meals, nutritionConfigs, todayDayType }
+}
+
+export function buildNutritionContextBlock(ctx: GlobalNutritionContext): string {
+  const dayLabel = ctx.todayDayType === 'training' ? 'Training day' : 'Rest day'
+
+  const totalCals = ctx.meals.reduce((s, m) => s + (m.calories ?? 0), 0)
+  const totalProtein = ctx.meals.reduce((s, m) => s + (m.protein ?? 0), 0)
+  const totalCarbs = ctx.meals.reduce((s, m) => s + (m.carbs ?? 0), 0)
+  const totalFats = ctx.meals.reduce((s, m) => s + (m.fats ?? 0), 0)
+
+  const mealLines = ctx.meals
+    .map(
+      (m) =>
+        `  - [${m.meal_name}] ${m.label}: ${m.description ?? 'no description'} ` +
+        `(${m.calories ?? '?'} kcal | ${m.protein ?? '?'}g P | ${m.carbs ?? '?'}g C | ${m.fats ?? '?'}g F)`
+    )
+    .join('\n')
+
+  const configLines = ctx.nutritionConfigs
+    .map((c) => `  - ${c.config_label}: ${c.config_value}${c.config_unit ? ' ' + c.config_unit : ''}`)
+    .join('\n')
+
+  return (
+    `## Nutrition Plan (${dayLabel})\n` +
+    `Daily totals: ~${totalCals} kcal | ${totalProtein.toFixed(0)}g protein | ${totalCarbs.toFixed(0)}g carbs | ${totalFats.toFixed(0)}g fat\n` +
+    (mealLines ? `Meals:\n${mealLines}` : 'No meals loaded.') +
+    '\n\n' +
+    `## Nutrition Config Targets\n` +
+    (configLines || '  (no nutrition configs seeded)')
+  )
+}

--- a/src/lib/supabase/meals.ts
+++ b/src/lib/supabase/meals.ts
@@ -1,0 +1,326 @@
+// Meals — Supabase query functions
+// Meals table stores editable meal *definitions* (description, macros).
+// Meal *status* (complete/partial/skipped) continues to live in nutrition_logs.
+
+import { createClient } from './client'
+import { createClient as createServerClient } from './server'
+
+export interface Meal {
+  id: string
+  user_id: string
+  day_type: 'training' | 'rest'
+  meal_name: string   // matches nutrition_logs column: 'meal_breakfast', etc.
+  label: string
+  icon: string
+  description: string | null
+  calories: number | null
+  protein: number | null
+  carbs: number | null
+  fats: number | null
+  order_index: number
+  created_at: string
+  updated_at: string
+}
+
+export type MealUpdate = Partial<Pick<Meal, 'label' | 'description' | 'calories' | 'protein' | 'carbs' | 'fats' | 'icon'>>
+
+// Hardcoded seed data — mirrors MEAL_DETAILS / MEAL_LABELS from nutrition types
+const SEED_MEALS: Omit<Meal, 'id' | 'user_id' | 'created_at' | 'updated_at'>[] = [
+  // ── Training days ────────────────────────────────────────────────────────
+  {
+    day_type: 'training',
+    meal_name: 'meal_post_run',
+    label: 'Post-Run Recovery',
+    icon: '🏃',
+    description: '500ml water + 1 scoop BCAA (300ml)',
+    calories: 30,
+    protein: 7,
+    carbs: 2,
+    fats: 0,
+    order_index: 0,
+  },
+  {
+    day_type: 'training',
+    meal_name: 'meal_breakfast',
+    label: 'Breakfast 07:30',
+    icon: '🌅',
+    description: '50g red lentils + 40g oats + turmeric/BP/onion/OO + 25g soy mince',
+    calories: 380,
+    protein: 28,
+    carbs: 52,
+    fats: 8,
+    order_index: 1,
+  },
+  {
+    day_type: 'training',
+    meal_name: 'meal_lunch',
+    label: 'Lunch 12:00',
+    icon: '☀️',
+    description: 'Carb choice + 50g soy mince + 6-8 tbsp veggies/salad',
+    calories: 450,
+    protein: 30,
+    carbs: 55,
+    fats: 8,
+    order_index: 2,
+  },
+  {
+    day_type: 'training',
+    meal_name: 'meal_snack1',
+    label: 'Snack 1 · 16:30',
+    icon: '🍎',
+    description: 'Muesli (30g carb) + 25g vegan protein in plant milk',
+    calories: 320,
+    protein: 30,
+    carbs: 35,
+    fats: 6,
+    order_index: 3,
+  },
+  {
+    day_type: 'training',
+    meal_name: 'meal_snack2',
+    label: 'Snack 2 · 18:30',
+    icon: '🫒',
+    description: '7 olives + 20g bread + 1 cucumber',
+    calories: 120,
+    protein: 3,
+    carbs: 15,
+    fats: 7,
+    order_index: 4,
+  },
+  {
+    day_type: 'training',
+    meal_name: 'meal_snack3',
+    label: 'Snack 3 · 19:30',
+    icon: '🥤',
+    description: 'Shake: 250ml almond/coconut milk + 30g vegan protein',
+    calories: 180,
+    protein: 30,
+    carbs: 5,
+    fats: 5,
+    order_index: 5,
+  },
+  {
+    day_type: 'training',
+    meal_name: 'meal_snack4',
+    label: 'Snack 4 · 21:30',
+    icon: '🌙',
+    description: '1 fruit portion + 15g raw nuts',
+    calories: 180,
+    protein: 4,
+    carbs: 20,
+    fats: 9,
+    order_index: 6,
+  },
+  // ── Rest days ────────────────────────────────────────────────────────────
+  {
+    day_type: 'rest',
+    meal_name: 'meal_breakfast',
+    label: 'Breakfast 08:00',
+    icon: '🌅',
+    description: '50g red lentils + 40g oats + turmeric/BP/onion/OO + 25g soy mince',
+    calories: 380,
+    protein: 28,
+    carbs: 52,
+    fats: 8,
+    order_index: 0,
+  },
+  {
+    day_type: 'rest',
+    meal_name: 'meal_lunch',
+    label: 'Lunch 13:00',
+    icon: '☀️',
+    description: 'Smaller carb choice + 50g soy mince + 8-10 tbsp veggies/salad',
+    calories: 400,
+    protein: 30,
+    carbs: 45,
+    fats: 8,
+    order_index: 1,
+  },
+  {
+    day_type: 'rest',
+    meal_name: 'meal_snack1',
+    label: 'Snack 1 · 16:00',
+    icon: '🍎',
+    description: 'Muesli (25g carb) + 25g vegan protein in plant milk',
+    calories: 290,
+    protein: 30,
+    carbs: 28,
+    fats: 6,
+    order_index: 2,
+  },
+  {
+    day_type: 'rest',
+    meal_name: 'meal_snack2',
+    label: 'Snack 2 · 18:30',
+    icon: '🫒',
+    description: '7 olives + 20g bread + 1 cucumber',
+    calories: 120,
+    protein: 3,
+    carbs: 15,
+    fats: 7,
+    order_index: 3,
+  },
+  {
+    day_type: 'rest',
+    meal_name: 'meal_snack3',
+    label: 'Snack 3 · 19:30',
+    icon: '🥤',
+    description: 'Shake: 250ml almond/coconut milk + 25g vegan protein',
+    calories: 155,
+    protein: 25,
+    carbs: 5,
+    fats: 5,
+    order_index: 4,
+  },
+  {
+    day_type: 'rest',
+    meal_name: 'meal_snack4',
+    label: 'Snack 4 · 21:00',
+    icon: '🌙',
+    description: '1 fruit portion + 15g raw nuts',
+    calories: 180,
+    protein: 4,
+    carbs: 20,
+    fats: 9,
+    order_index: 5,
+  },
+]
+
+// ── Seed (idempotent) ─────────────────────────────────────────────────────────
+
+export async function seedMeals(): Promise<void> {
+  const supabase = createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return
+
+  const { count } = await supabase
+    .from('meals')
+    .select('*', { count: 'exact', head: true })
+    .eq('user_id', user.id)
+
+  if ((count ?? 0) > 0) return
+
+  await supabase
+    .from('meals')
+    .insert(SEED_MEALS.map((m) => ({ ...m, user_id: user.id })))
+}
+
+export async function seedMealsServer(): Promise<void> {
+  const supabase = createServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return
+
+  const { count } = await supabase
+    .from('meals')
+    .select('*', { count: 'exact', head: true })
+    .eq('user_id', user.id)
+
+  if ((count ?? 0) > 0) return
+
+  await supabase
+    .from('meals')
+    .insert(SEED_MEALS.map((m) => ({ ...m, user_id: user.id })))
+}
+
+// ── Queries ───────────────────────────────────────────────────────────────────
+
+export async function getMealsForDayType(dayType: 'training' | 'rest'): Promise<Meal[]> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('meals')
+    .select('*')
+    .eq('day_type', dayType)
+    .order('order_index')
+  if (error) throw error
+  return data ?? []
+}
+
+export async function getServerMealsForDayType(
+  supabase: ReturnType<typeof createServerClient>,
+  dayType: 'training' | 'rest'
+): Promise<Meal[]> {
+  const { data, error } = await supabase
+    .from('meals')
+    .select('*')
+    .eq('day_type', dayType)
+    .order('order_index')
+  if (error) return []
+  return data ?? []
+}
+
+export async function getMealById(id: string): Promise<Meal | null> {
+  const supabase = createClient()
+  const { data, error } = await supabase
+    .from('meals')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle()
+  if (error) throw error
+  return data
+}
+
+// ── Update (client-side — for manual edit dialog) ─────────────────────────────
+
+export async function updateMealClient(
+  mealId: string,
+  updates: MealUpdate,
+  reason?: string,
+  changedBy: 'user' | 'ai_life_coach' = 'user'
+): Promise<Meal> {
+  const supabase = createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  // Fetch current for audit
+  const { data: current } = await supabase
+    .from('meals')
+    .select('*')
+    .eq('id', mealId)
+    .eq('user_id', user.id)
+    .single()
+
+  if (!current) throw new Error('Meal not found')
+
+  const { data, error } = await supabase
+    .from('meals')
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq('id', mealId)
+    .eq('user_id', user.id)
+    .select()
+    .single()
+  if (error) throw error
+
+  // Audit trail
+  await supabase.from('meal_changes').insert({
+    meal_id: mealId,
+    user_id: user.id,
+    changed_by: changedBy,
+    previous_value: current,
+    new_value: data,
+    reason: reason ?? null,
+  })
+
+  // plan_audit_log entry
+  await supabase.from('plan_audit_log').insert({
+    user_id: user.id,
+    module: 'nutrition',
+    entity_type: 'meal',
+    entity_description: current.label,
+    action: 'update',
+    field_changed: Object.keys(updates).join(', '),
+    previous_value: JSON.stringify(
+      Object.fromEntries(Object.keys(updates).map((k) => [k, (current as Record<string, unknown>)[k]]))
+    ),
+    new_value: JSON.stringify(updates),
+    reason: reason ?? null,
+    changed_by: changedBy,
+  })
+
+  return data
+}

--- a/supabase/migrations/20240115000000_meals_table.sql
+++ b/supabase/migrations/20240115000000_meals_table.sql
@@ -1,0 +1,50 @@
+-- Meals table: stores editable meal plan definitions per day type
+-- Meal *status* (complete/partial/skipped) stays in nutrition_logs as-is.
+
+CREATE TABLE public.meals (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  day_type      TEXT        NOT NULL CHECK (day_type IN ('training', 'rest')),
+  meal_name     TEXT        NOT NULL, -- e.g. 'meal_breakfast' — matches nutrition_logs column
+  label         TEXT        NOT NULL, -- Display label e.g. 'Breakfast 07:30'
+  icon          TEXT        NOT NULL DEFAULT '🍽️',
+  description   TEXT,
+  calories      INT,
+  protein       DECIMAL(5,1),
+  carbs         DECIMAL(5,1),
+  fats          DECIMAL(5,1),
+  order_index   INT         NOT NULL DEFAULT 0,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.meals ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage their own meals"
+  ON public.meals FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX meals_user_day_type ON public.meals (user_id, day_type, order_index);
+
+-- Add meal_changes audit table for tracking AI/manual edits
+CREATE TABLE public.meal_changes (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  meal_id         UUID        NOT NULL REFERENCES public.meals(id) ON DELETE CASCADE,
+  user_id         UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  changed_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  changed_by      TEXT        NOT NULL DEFAULT 'user',
+  previous_value  JSONB,
+  new_value       JSONB,
+  reason          TEXT
+);
+
+ALTER TABLE public.meal_changes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage their own meal changes"
+  ON public.meal_changes FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- Add extra nutrition_targets to plan_configs (seeded via application, not SQL)
+-- Columns already exist in plan_configs table; no schema change needed.


### PR DESCRIPTION
Step 1 — Database:
- Add `meals` table (id, user_id, day_type, meal_name, label, icon, description, calories, protein, carbs, fats, order_index) with RLS
- Add `meal_changes` audit table tracking every edit with previous/new JSONB
- Migration: supabase/migrations/20240115000000_meals_table.sql

Step 2 — Nutrition UI refactor:
- src/lib/supabase/meals.ts: seed helpers (idempotent), server/client queries, updateMealClient() with dual audit trail (meal_changes + plan_audit_log)
- Nutrition page now seeds meals on first visit then fetches from DB
- DailyMealChecklist accepts `meals` prop; falls back to static constants if DB rows absent (zero-breakage for existing callers)
- MealCard: shows DB description + macro summary line; pencil icon button opens MealEditDialog with live optimistic update on save
- MealEditDialog: shadcn-style modal (dark #111) with label, description textarea, and 4-field macro grid; saves via PATCH with audit logging

Step 3 — Global Coach Integration:
- GlobalCoachPanel: floating violet Brain button (bottom-right); slides in a 480px panel containing the full LifeCoach component; Escape closes it
- DashboardLayout now renders <GlobalCoachPanel /> — persistent on every page
- coaching.ts: getGlobalContext() fetches today's DB meals + nutrition plan_configs; buildNutritionContextBlock() injects into Life Coach system prompt

Step 4 — Tool Calling:
- life-coach/route.ts: two new tools · updateMeal — looks up meal by meal_name, returns proposal card with field-by-field before→after diff; user must Confirm before DB write · addSupplement — simplified wrapper returning manage_supplement/add proposal
- life-coach/confirm/route.ts: new `update_meal` branch updates meals table, writes meal_changes + plan_audit_log with changed_by='ai_life_coach'
- Confirmation message: "I've updated your Breakfast to include 30g of oats..."
- PATCH /api/nutrition/meals/[id]: standalone endpoint for manual dialog saves

Every AI change attributed to 'ai_life_coach' in audit trail.

https://claude.ai/code/session_0192wVy8TxcxvvrftPX9SBQr