### PR TITLE
fix: Coach data blindness — LIVE_OS_DATA_SNAPSHOT + new tools

### DIFF
--- a/src/app/api/ai/life-coach/route.ts
+++ b/src/app/api/ai/life-coach/route.ts
@@ -7,7 +7,7 @@ import { streamText, convertToModelMessages } from 'ai'
 import { z } from 'zod'
 import { createClient } from '@/lib/supabase/server'
 import { ATHLETE_PROFILE } from '@/lib/ai/coaching'
-import { getSystemSnapshot } from '@/lib/ai/get-system-snapshot'
+import { getCoachContext, formatCoachContext } from '@/lib/ai/get-coach-context'
 
 export const runtime = 'nodejs'
 export const maxDuration = 90
@@ -66,24 +66,24 @@ export async function POST(req: Request) {
   } = await supabase.auth.getUser()
   if (!user) return new Response('Unauthorized', { status: 401 })
 
-  // ── Real-time system snapshot ────────────────────────────────────────────
-  let snapshotBlock = 'CURRENT_USER_STATE: {"error": "snapshot unavailable"}'
+  // ── Live context — fetched fresh on every request ────────────────────────
+  let liveDataBlock = '### LIVE_OS_DATA_SNAPSHOT\n> ERROR: context unavailable — do NOT tell the user you lack their data. Ask them to refresh.'
   try {
-    const snapshot = await getSystemSnapshot(supabase)
-    snapshotBlock = `CURRENT_USER_STATE:\n\`\`\`json\n${JSON.stringify(snapshot, null, 2)}\n\`\`\``
+    const ctx = await getCoachContext(supabase)
+    liveDataBlock = formatCoachContext(ctx)
   } catch (err) {
-    console.error('[life-coach] snapshot failed:', err)
+    console.error('[life-coach] context fetch failed:', err)
   }
 
   const moduleFocus = MODULE_FOCUS[focusModule] ?? MODULE_FOCUS.general
   const systemWithContext = `${COMMAND_CENTER_SYSTEM_PROMPT}
 
-## MODULE FOCUS
+## MODULE FOCUS FOR THIS SESSION
 ${moduleFocus}
 
 ---
 
-${snapshotBlock}`
+${liveDataBlock}`
 
   // ── Audit helper — called by every tool on execution ────────────────────
   async function logAudit(opts: {
@@ -473,6 +473,149 @@ ${snapshotBlock}`
             reason,
           })
           return p
+        },
+      },
+
+      // ── logMealComplete ───────────────────────────────────────────
+      // Direct write — low-risk: just marks a meal status in today's log.
+      logMealComplete: {
+        description:
+          'Mark a meal as complete (or partial/skipped) in today\'s nutrition log. ' +
+          'Use when the user says they just ate a meal or want to log one. ' +
+          'This is a direct write — no confirmation required.',
+        parameters: z.object({
+          meal_name: z
+            .string()
+            .describe('Key of the meal: meal_post_run | meal_breakfast | meal_lunch | meal_snack1 | meal_snack2 | meal_snack3 | meal_snack4'),
+          status: z
+            .enum(['complete', 'partial', 'skipped'])
+            .describe('New status to set for the meal'),
+          note: z
+            .string()
+            .optional()
+            .describe('Optional note about what was eaten or why it was skipped/partial'),
+        }),
+        execute: async ({ meal_name, status, note }) => {
+          try {
+            const today = new Date().toISOString().split('T')[0]
+
+            // Upsert nutrition_log row with updated meal status
+            const updatePayload: Record<string, unknown> = {
+              user_id: user.id,
+              log_date: today,
+              [meal_name]: status,
+            }
+            if (note) {
+              // Merge note into meal_notes JSONB — fetch existing first
+              const { data: existing } = await supabase
+                .from('nutrition_logs')
+                .select('meal_notes')
+                .eq('user_id', user.id)
+                .eq('log_date', today)
+                .maybeSingle()
+              const existingNotes = (existing?.meal_notes as Record<string, string>) ?? {}
+              updatePayload.meal_notes = { ...existingNotes, [meal_name]: note }
+            }
+
+            const { error } = await supabase
+              .from('nutrition_logs')
+              .upsert(updatePayload, { onConflict: 'user_id,log_date' })
+
+            if (error) throw error
+
+            await logAudit({
+              module: 'nutrition',
+              action: 'meal_logged',
+              entity_type: 'meal_log',
+              entity_description: `${meal_name} marked ${status}`,
+              new_value: status,
+              reason: note,
+            })
+
+            return {
+              success: true,
+              message: `Logged **${meal_name.replace('meal_', '')}** as **${status}** for ${today}.${note ? ` Note: "${note}"` : ''}`,
+            }
+          } catch (e) {
+            return { success: false, message: `Failed to log meal: ${String(e)}` }
+          }
+        },
+      },
+
+      // ── updateSupplement ──────────────────────────────────────────
+      // Direct write for non-critical supplement field updates (timing, notes).
+      // Significant lifecycle changes (pause/expire) still go through manageSupplement proposals.
+      updateSupplement: {
+        description:
+          'Directly update non-critical fields of a supplement: timing, prescribed_for, or notes. ' +
+          'For pause / resume / expire actions use the manageSupplement tool instead (those require user confirmation). ' +
+          'Use this when the user wants to change when a supplement is taken or what it\'s for.',
+        parameters: z.object({
+          supplement_name: z
+            .string()
+            .describe('Name of the supplement to update (partial match is OK)'),
+          updates: z.object({
+            timing: z
+              .string()
+              .nullable()
+              .optional()
+              .describe('New timing, e.g. "post-workout with food" or "morning with breakfast"'),
+            prescribed_for: z
+              .string()
+              .nullable()
+              .optional()
+              .describe('Updated goal/condition this supplement addresses'),
+          }),
+          reason: z.string().describe('Why the update is being made'),
+        }),
+        execute: async ({ supplement_name, updates, reason }) => {
+          try {
+            // Find supplement by partial name match
+            const { data: matches } = await supabase
+              .from('supplements')
+              .select('id, name')
+              .eq('user_id', user.id)
+              .eq('is_active', true)
+              .ilike('name', `%${supplement_name}%`)
+              .limit(1)
+
+            const sup = matches?.[0]
+            if (!sup) {
+              return {
+                success: false,
+                message: `No active supplement matching "${supplement_name}" found. Check the supplement list.`,
+              }
+            }
+
+            const { error } = await supabase
+              .from('supplements')
+              .update(updates)
+              .eq('id', sup.id)
+              .eq('user_id', user.id)
+
+            if (error) throw error
+
+            await logAudit({
+              module: 'nutrition',
+              action: 'supplement_updated',
+              entity_type: 'supplement',
+              entity_description: `Updated ${sup.name}: ${Object.keys(updates).join(', ')}`,
+              new_value: JSON.stringify(updates),
+              reason,
+            })
+
+            const changeDesc = Object.entries(updates)
+              .filter(([, v]) => v !== undefined)
+              .map(([k, v]) => `${k}: "${v}"`)
+              .join(', ')
+
+            return {
+              success: true,
+              message: `Updated **${sup.name}** — ${changeDesc}. Recorded in audit trail.`,
+            }
+          } catch (e) {
+            return { success: false, message: `Failed to update supplement: ${String(e)}` }
+          }
         },
       },
     },

--- a/src/components/ai/coach-chat.tsx
+++ b/src/components/ai/coach-chat.tsx
@@ -266,7 +266,7 @@ function ToolInvocationRenderer({
     return (
       <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-xs text-white/40">
         <Loader2 className="h-3.5 w-3.5 text-violet-400 animate-spin" />
-        <span>Preparing proposal…</span>
+        <span>Running {part.toolName}…</span>
       </div>
     )
   }
@@ -297,12 +297,22 @@ function ToolInvocationRenderer({
     )
   }
 
-  // Render simple success (e.g. logManualAudit)
+  // Render direct-write success (logMealComplete, updateSupplement, logManualAudit)
   if (result && 'success' in result && result.success === true && 'message' in result) {
     return (
       <div className="flex items-start gap-2.5 px-3 py-2 rounded-lg border bg-emerald-500/5 border-emerald-500/20 text-xs">
         <CheckCircle className="h-3.5 w-3.5 text-emerald-400 mt-0.5 shrink-0" />
         <p className="text-emerald-300">{result.message as string}</p>
+      </div>
+    )
+  }
+
+  // Render direct-write failure
+  if (result && 'success' in result && result.success === false && 'message' in result) {
+    return (
+      <div className="flex items-start gap-2.5 px-3 py-2 rounded-lg border bg-red-500/5 border-red-500/20 text-xs">
+        <AlertCircle className="h-3.5 w-3.5 text-red-400 mt-0.5 shrink-0" />
+        <p className="text-red-300">{result.message as string}</p>
       </div>
     )
   }

--- a/src/lib/ai/get-coach-context.ts
+++ b/src/lib/ai/get-coach-context.ts
@@ -1,0 +1,344 @@
+// get-coach-context.ts
+// Targeted context loader that fetches raw, coach-ready data for the AI.
+// Designed to fix "data blindness" — each section is clearly labelled so the
+// model can unambiguously reference it. Called alongside getSystemSnapshot.
+
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+// ── Output types ─────────────────────────────────────────────────────────────
+
+export interface CoachTrade {
+  date: string
+  symbol: string
+  outcome: string
+  net_pnl: number | null
+  notes: string | null
+}
+
+export interface CoachActivity {
+  date: string
+  type: string
+  distance_km: number
+  pace_per_km: string
+  avg_hr: number | null
+  duration_min: number | null
+}
+
+export interface CoachMealEntry {
+  meal_name: string
+  label: string
+  status: string           // pending | complete | partial | skipped | modified
+  calories: number | null
+  protein_g: number | null
+}
+
+export interface CoachConfig {
+  module: string
+  key: string
+  label: string
+  value: string
+  unit: string | null
+}
+
+export interface CoachContext {
+  as_of: string            // ISO timestamp — tells the model when this was fetched
+  today: string            // YYYY-MM-DD
+  day_type: 'training' | 'rest'
+  trading: {
+    last_5_trades: CoachTrade[]
+    today_pnl: number
+    today_trade_count: number
+  }
+  athletics: {
+    last_3_activities: CoachActivity[]
+    today_scheduled: {
+      title: string
+      type: string
+      target_distance_km: number | null
+      target_pace: string | null
+    } | null
+  }
+  nutrition: {
+    meals: CoachMealEntry[]
+    meals_complete: number
+    meals_total: number
+    total_calories_consumed: number
+    total_protein_consumed_g: number
+    calorie_target: number | null
+    protein_target_g: number | null
+  }
+  plan_configs: CoachConfig[]
+}
+
+// ── Helper ───────────────────────────────────────────────────────────────────
+
+function secPerKmToPace(sec: number | null): string {
+  if (!sec) return '—'
+  const m = Math.floor(sec / 60)
+  const s = Math.round(sec % 60)
+  return `${m}:${String(s).padStart(2, '0')}/km`
+}
+
+// ── Main export ──────────────────────────────────────────────────────────────
+
+export async function getCoachContext(supabase: SupabaseClient): Promise<CoachContext> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  const now = new Date()
+  const today = now.toISOString().split('T')[0]
+  const todayStart = `${today}T00:00:00.000Z`
+  const todayEnd = `${today}T23:59:59.999Z`
+  const dow = now.getDay()
+  const dayType: 'training' | 'rest' = dow >= 1 && dow <= 5 ? 'training' : 'rest'
+
+  if (!user) {
+    return {
+      as_of: now.toISOString(),
+      today,
+      day_type: dayType,
+      trading: { last_5_trades: [], today_pnl: 0, today_trade_count: 0 },
+      athletics: { last_3_activities: [], today_scheduled: null },
+      nutrition: {
+        meals: [], meals_complete: 0, meals_total: 0,
+        total_calories_consumed: 0, total_protein_consumed_g: 0,
+        calorie_target: null, protein_target_g: null,
+      },
+      plan_configs: [],
+    }
+  }
+
+  const [
+    tradesRecent,
+    tradesToday,
+    activities,
+    scheduledToday,
+    nutritionLog,
+    mealDefs,
+    planConfigs,
+  ] = await Promise.allSettled([
+    // Last 5 trades (any date)
+    supabase
+      .from('trades')
+      .select('opened_at, symbol, outcome, net_pnl, notes')
+      .eq('user_id', user.id)
+      .order('opened_at', { ascending: false })
+      .limit(5),
+
+    // Today's trades for PnL total
+    supabase
+      .from('trades')
+      .select('net_pnl')
+      .eq('user_id', user.id)
+      .gte('opened_at', todayStart)
+      .lte('opened_at', todayEnd),
+
+    // Last 3 running activities
+    supabase
+      .from('running_activities')
+      .select('started_at, workout_type, distance_meters, avg_pace_sec_per_km, avg_hr, duration_seconds')
+      .eq('user_id', user.id)
+      .order('started_at', { ascending: false })
+      .limit(3),
+
+    // Today's scheduled training
+    supabase
+      .from('training_schedule')
+      .select('title, type, target_distance, target_pace')
+      .eq('user_id', user.id)
+      .eq('date', today)
+      .maybeSingle(),
+
+    // Today's nutrition log (meal statuses)
+    supabase
+      .from('nutrition_logs')
+      .select('*')
+      .eq('user_id', user.id)
+      .eq('log_date', today)
+      .maybeSingle(),
+
+    // Meal definitions for today's day type
+    supabase
+      .from('meals')
+      .select('meal_name, label, calories, protein, day_type')
+      .eq('user_id', user.id)
+      .eq('day_type', dayType)
+      .order('order_index'),
+
+    // All plan configs
+    supabase
+      .from('plan_configs')
+      .select('module, config_key, config_label, config_value, config_unit')
+      .eq('user_id', user.id)
+      .order('module')
+      .order('config_key'),
+  ])
+
+  // ── Trading ──────────────────────────────────────────────────────────────
+
+  const recentTrades = tradesRecent.status === 'fulfilled' ? (tradesRecent.value.data ?? []) : []
+  const todayTrades = tradesToday.status === 'fulfilled' ? (tradesToday.value.data ?? []) : []
+
+  const last5: CoachTrade[] = recentTrades.map((t: {
+    opened_at: string; symbol: string; outcome: string; net_pnl: number | null; notes: string | null
+  }) => ({
+    date: t.opened_at.split('T')[0],
+    symbol: t.symbol,
+    outcome: t.outcome,
+    net_pnl: t.net_pnl,
+    notes: t.notes,
+  }))
+
+  const todayPnl = todayTrades.reduce(
+    (sum: number, t: { net_pnl: number | null }) => sum + (t.net_pnl ?? 0), 0
+  )
+
+  // ── Athletics ────────────────────────────────────────────────────────────
+
+  const acts = activities.status === 'fulfilled' ? (activities.value.data ?? []) : []
+  const last3: CoachActivity[] = acts.map((a: {
+    started_at: string; workout_type: string; distance_meters: number | null;
+    avg_pace_sec_per_km: number | null; avg_hr: number | null; duration_seconds: number | null
+  }) => ({
+    date: a.started_at.split('T')[0],
+    type: a.workout_type,
+    distance_km: a.distance_meters ? Math.round((a.distance_meters / 1000) * 100) / 100 : 0,
+    pace_per_km: secPerKmToPace(a.avg_pace_sec_per_km),
+    avg_hr: a.avg_hr,
+    duration_min: a.duration_seconds ? Math.round(a.duration_seconds / 60) : null,
+  }))
+
+  const scheduled = scheduledToday.status === 'fulfilled' ? scheduledToday.value.data : null
+
+  // ── Nutrition ────────────────────────────────────────────────────────────
+
+  const log = nutritionLog.status === 'fulfilled' ? nutritionLog.value.data : null
+  const defs = mealDefs.status === 'fulfilled' ? (mealDefs.value.data ?? []) : []
+
+  const mealKeys = [
+    'meal_post_run', 'meal_breakfast', 'meal_lunch',
+    'meal_snack1', 'meal_snack2', 'meal_snack3', 'meal_snack4',
+  ]
+
+  const meals: CoachMealEntry[] = defs.map((m: {
+    meal_name: string; label: string; calories: number | null; protein: number | null
+  }) => {
+    const status = log
+      ? ((log as Record<string, unknown>)[m.meal_name] as string) ?? 'pending'
+      : 'pending'
+    return {
+      meal_name: m.meal_name,
+      label: m.label,
+      status,
+      calories: m.calories,
+      protein_g: m.protein,
+    }
+  })
+
+  // If no DB meals yet, fall back to nutrition_log keys
+  const effectiveMeals = meals.length > 0 ? meals : mealKeys.map((k) => ({
+    meal_name: k,
+    label: k.replace('meal_', '').replace(/_/g, ' '),
+    status: log ? ((log as Record<string, unknown>)[k] as string) ?? 'pending' : 'pending',
+    calories: null,
+    protein_g: null,
+  }))
+
+  const completedMeals = effectiveMeals.filter((m) => m.status === 'complete')
+  const totalCals = completedMeals.reduce((s, m) => s + (m.calories ?? 0), 0)
+  const totalProtein = completedMeals.reduce((s, m) => s + (m.protein_g ?? 0), 0)
+
+  // ── Plan configs ─────────────────────────────────────────────────────────
+
+  const configs = planConfigs.status === 'fulfilled' ? (planConfigs.value.data ?? []) : []
+  const configList: CoachConfig[] = configs.map((c: {
+    module: string; config_key: string; config_label: string; config_value: string; config_unit: string | null
+  }) => ({
+    module: c.module,
+    key: c.config_key,
+    label: c.config_label,
+    value: c.config_value,
+    unit: c.config_unit,
+  }))
+
+  const ncMap = Object.fromEntries(configs.map((c: { config_key: string; config_value: string }) => [c.config_key, c.config_value]))
+
+  return {
+    as_of: now.toISOString(),
+    today,
+    day_type: dayType,
+    trading: {
+      last_5_trades: last5,
+      today_pnl: Math.round(todayPnl * 100) / 100,
+      today_trade_count: todayTrades.length,
+    },
+    athletics: {
+      last_3_activities: last3,
+      today_scheduled: scheduled
+        ? {
+            title: scheduled.title,
+            type: scheduled.type,
+            target_distance_km: scheduled.target_distance ?? null,
+            target_pace: scheduled.target_pace ?? null,
+          }
+        : null,
+    },
+    nutrition: {
+      meals: effectiveMeals,
+      meals_complete: completedMeals.length,
+      meals_total: effectiveMeals.length,
+      total_calories_consumed: totalCals,
+      total_protein_consumed_g: totalProtein,
+      calorie_target: ncMap[dayType === 'training' ? 'calories_training' : 'calories_rest']
+        ? parseInt(ncMap[dayType === 'training' ? 'calories_training' : 'calories_rest'])
+        : null,
+      protein_target_g: ncMap['protein_target'] ? parseInt(ncMap['protein_target']) : null,
+    },
+    plan_configs: configList,
+  }
+}
+
+// ── Format as a compact, LLM-readable block ───────────────────────────────────
+
+export function formatCoachContext(ctx: CoachContext): string {
+  const lines: string[] = [
+    `### LIVE_OS_DATA_SNAPSHOT`,
+    `> Fetched: ${ctx.as_of} | Today: ${ctx.today} (${ctx.day_type} day)`,
+    `> **You MUST use this data to answer questions. Do NOT say you lack access to the user's data.**`,
+    '',
+    '#### TRADING',
+    `Today P&L: **$${ctx.trading.today_pnl >= 0 ? '+' : ''}${ctx.trading.today_pnl}** across ${ctx.trading.today_trade_count} trade(s)`,
+    'Last 5 trades:',
+    ...ctx.trading.last_5_trades.map((t) =>
+      `  - ${t.date} | ${t.symbol} | ${t.outcome} | P&L: ${t.net_pnl != null ? `$${t.net_pnl}` : 'n/a'}${t.notes ? ` | Note: ${t.notes.slice(0, 60)}` : ''}`
+    ),
+    ctx.trading.last_5_trades.length === 0 ? '  (no recent trades)' : '',
+    '',
+    '#### ATHLETICS',
+    ctx.athletics.today_scheduled
+      ? `Today's scheduled: **${ctx.athletics.today_scheduled.title}** (${ctx.athletics.today_scheduled.type}) — ${ctx.athletics.today_scheduled.target_distance_km ?? '?'}km @ ${ctx.athletics.today_scheduled.target_pace ?? 'open pace'}`
+      : 'Today\'s scheduled: none / rest day',
+    'Last 3 activities:',
+    ...ctx.athletics.last_3_activities.map((a) =>
+      `  - ${a.date} | ${a.type} | ${a.distance_km}km @ ${a.pace_per_km}${a.avg_hr ? ` | HR: ${a.avg_hr}bpm` : ''}${a.duration_min ? ` | ${a.duration_min}min` : ''}`
+    ),
+    ctx.athletics.last_3_activities.length === 0 ? '  (no recent activities)' : '',
+    '',
+    '#### NUTRITION',
+    `Meals: **${ctx.nutrition.meals_complete}/${ctx.nutrition.meals_total}** complete`,
+    `Consumed: **${ctx.nutrition.total_calories_consumed} kcal** / target ${ctx.nutrition.calorie_target ?? '?'} kcal | Protein: **${ctx.nutrition.total_protein_consumed_g}g** / target ${ctx.nutrition.protein_target_g ?? '?'}g`,
+    'Meal statuses:',
+    ...ctx.nutrition.meals.map((m) =>
+      `  - [${m.status.toUpperCase()}] ${m.label}${m.calories ? ` (${m.calories} kcal)` : ''}`
+    ),
+    '',
+    '#### PLAN CONFIGS',
+    ...ctx.plan_configs.map((c) =>
+      `  - [${c.module}] ${c.label}: **${c.value}${c.unit ? ' ' + c.unit : ''}**`
+    ),
+    ctx.plan_configs.length === 0 ? '  (no configs loaded)' : '',
+  ]
+
+  return lines.filter((l) => l !== undefined).join('\n')
+}


### PR DESCRIPTION
Root cause: AI was answering from model knowledge rather than live DB data. The previous system prompt used CURRENT_USER_STATE but the JSON block was hard to parse; tool descriptions didn't reference it; and direct-write tools for meal logging and supplement updates were missing.

Task 1 — src/lib/ai/get-coach-context.ts (new):
- getCoachContext(supabase): 7-way parallel query fan-out · Last 5 trades: date, symbol, outcome, net_pnl, notes · Today's trades: summed P&L, count · Last 3 activities: date, type, km, pace (M:SS/km), avg HR, duration · Today's training_schedule target: title, type, km, pace · Today's nutrition_log: per-meal status (pending/complete/partial/skipped) · Meal definitions for today's day_type: label, calories, protein · All plan_configs: module, key, label, value, unit
- formatCoachContext(): renders structured markdown ### LIVE_OS_DATA_SNAPSHOT block with clear section headers, bold values, and a hard instruction: "You MUST use this data. Do NOT say you lack access to the user's data."

Task 2 — life-coach/route.ts overhaul:
- Replace getSystemSnapshot import with getCoachContext + formatCoachContext
- snapshotBlock → liveDataBlock using formatCoachContext output
- System prompt section renamed to "## MODULE FOCUS FOR THIS SESSION"
- Error fallback updated to tell AI not to claim data blindness

Task 3 — New tools (direct writes, no confirmation required):
- logMealComplete(meal_name, status, note): upserts nutrition_logs row, sets meal status to complete/partial/skipped, merges note into meal_notes JSONB. Audit logged as 'meal_logged'. Returns success + confirmation string.
- updateSupplement(supplement_name, updates, reason): ilike name lookup on supplements table, updates timing/prescribed_for. Audit logged as 'supplement_updated'. Returns success + change description. Both return {success, message} rendered as green/red badge in UI.

Task 4 — coach-chat.tsx UI verification:
- extraBody: { module: focusModule } already wired via DefaultChatTransport ✓
- ToolInvocationRenderer pending spinner: "Preparing proposal…" → "Running {toolName}…" (accurate for direct-write tools)
- Added failure path for {success: false, message}: renders red AlertCircle badge (previously fell through to null)

https://claude.ai/code/session_0192wVy8TxcxvvrftPX9SBQr