### PR TITLE
Add Morning Check-In system with AI briefing

### DIFF
--- a/src/app/(dashboard)/coach/page.tsx
+++ b/src/app/(dashboard)/coach/page.tsx
@@ -7,6 +7,7 @@
 import { useState, useEffect } from 'react'
 import { Bot, Pill, Settings, TrendingUp, Activity, BarChart2 } from 'lucide-react'
 import { CoachChat } from '@/components/ai/coach-chat'
+import { MorningCheckin } from '@/components/morning/MorningCheckin'
 import type { UIMessage } from 'ai'
 
 const SESSION_STORAGE_KEY = 'life-os-coach-session-id'
@@ -85,6 +86,9 @@ export default function CoachPage() {
           Ask questions or request changes — it can pause supplements, update plan configs, and more.
         </p>
       </div>
+
+      {/* Morning Check-In */}
+      <MorningCheckin />
 
       {/* Capabilities grid */}
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { getHabitsWithLogs } from '@/lib/supabase/habits'
 import { getDebts, getPropPayouts } from '@/lib/supabase/finance'
 import { getActivities, getRaceTargets } from '@/lib/supabase/running'
 
+import { MorningCheckin } from '@/components/morning/MorningCheckin'
 import { HabitsRingCard } from '@/components/dashboard/habits-ring-card'
 import { HabitStreaksCard } from '@/components/dashboard/habit-streaks-card'
 import type { StreakItem } from '@/components/dashboard/habit-streaks-card'
@@ -238,6 +239,9 @@ export default async function DashboardPage() {
         <h1 className="text-2xl font-bold">Dashboard</h1>
         <p className="text-sm text-muted-foreground mt-0.5">{dateLabel}</p>
       </div>
+
+      {/* Row 0 — Morning Check-In (client component, loads its own data) */}
+      <MorningCheckin />
 
       {/* Row 1 — Habits: ring + streaks + compliance */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">

--- a/src/app/actions/morning-log.ts
+++ b/src/app/actions/morning-log.ts
@@ -1,0 +1,76 @@
+'use server'
+
+import { createClient } from '@/lib/supabase/server'
+import type { MorningLogInput, MorningLog } from '@/lib/types/morning-log'
+
+export async function saveMorningLog(
+  data: MorningLogInput
+): Promise<{ id: string; isNew: boolean }> {
+  const supabase = createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const log_date = data.log_date ?? new Date().toISOString().slice(0, 10)
+
+  // Check if a row already exists for today
+  const { data: existing } = await supabase
+    .from('morning_logs')
+    .select('id')
+    .eq('user_id', user.id)
+    .eq('log_date', log_date)
+    .maybeSingle()
+
+  const payload = { ...data, log_date, user_id: user.id }
+
+  const { data: row, error } = await supabase
+    .from('morning_logs')
+    .upsert(payload, { onConflict: 'user_id,log_date' })
+    .select('id')
+    .single()
+
+  if (error || !row) throw new Error(error?.message ?? 'Failed to save morning log')
+
+  return { id: row.id, isNew: !existing }
+}
+
+export async function getTodaysMorningLog(): Promise<MorningLog | null> {
+  const supabase = createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return null
+
+  const today = new Date().toISOString().slice(0, 10)
+
+  const { data } = await supabase
+    .from('morning_logs')
+    .select('*')
+    .eq('user_id', user.id)
+    .eq('log_date', today)
+    .maybeSingle()
+
+  return data as MorningLog | null
+}
+
+export async function getRecentMorningLogs(days: number): Promise<MorningLog[]> {
+  const supabase = createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return []
+
+  const cutoff = new Date()
+  cutoff.setDate(cutoff.getDate() - days)
+  const cutoffStr = cutoff.toISOString().slice(0, 10)
+
+  const { data } = await supabase
+    .from('morning_logs')
+    .select('*')
+    .eq('user_id', user.id)
+    .gte('log_date', cutoffStr)
+    .order('log_date', { ascending: false })
+
+  return (data ?? []) as MorningLog[]
+}

--- a/src/app/api/ai/morning-briefing/route.ts
+++ b/src/app/api/ai/morning-briefing/route.ts
@@ -1,0 +1,177 @@
+// Morning Briefing — non-streaming single-shot Gemini call
+// Analyses today's vitals + 14-day history and returns a structured briefing.
+
+import { google } from '@ai-sdk/google'
+import { generateText } from 'ai'
+import { createClient } from '@/lib/supabase/server'
+
+export const runtime = 'nodejs'
+export const maxDuration = 60
+
+const SYSTEM_PROMPT = `You are the Life OS Morning Briefing coach for a 43yo female marathon runner and prop trader. She trains fasted at 4-5am. Belgrade Marathon April 19 goal 3:32. Limassol Half March 22 is the next checkpoint.
+
+You receive her morning vitals and the last 14 days of morning logs.
+
+Your response has EXACTLY four sections, no more:
+
+## Readiness: [🟢 Green / 🟡 Amber / 🔴 Red]
+One sentence verdict based on sleep, HR, energy, mood, body.
+
+## Patterns
+2-3 bullets from the 14-day history. Only real patterns — do not invent.
+Skip this section if fewer than 3 days of history exist.
+
+## Today's Focus
+- Training: [what's planned today, or rest day]
+- Tasks: [list any due tasks, or "Nothing scheduled"]
+- Nutrition: [any flag based on yesterday, e.g. "alcohol yesterday — hydrate well"]
+
+## Recommendations
+Max 4 bullets. Cross-module and specific:
+- If Red/Amber sleep → suggest smaller trading size
+- If body_readiness ≤ 2 → suggest modifying training session
+- Supplement timing reminders if relevant
+- One actionable thing to set the day up well`
+
+export async function POST(req: Request) {
+  const { logId } = (await req.json()) as { logId: string }
+  if (!logId) return new Response('logId required', { status: 400 })
+
+  const supabase = createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return new Response('Unauthorized', { status: 401 })
+
+  // ── 1. Fetch today's log (verify ownership) ─────────────────────────────
+  const { data: log } = await supabase
+    .from('morning_logs')
+    .select('*')
+    .eq('id', logId)
+    .eq('user_id', user.id)
+    .single()
+
+  if (!log) return new Response('Log not found', { status: 404 })
+
+  // Return cached briefing if it already exists
+  if (log.ai_briefing) {
+    return Response.json({ briefing: log.ai_briefing })
+  }
+
+  // ── 2. Fetch last 14 days of morning logs for pattern analysis ───────────
+  const cutoff14 = new Date()
+  cutoff14.setDate(cutoff14.getDate() - 14)
+  const { data: recentLogs } = await supabase
+    .from('morning_logs')
+    .select(
+      'log_date, resting_hr_bpm, sleep_hours, sleep_quality, energy_level, mood, body_readiness, woke_easily, had_dreams, dream_quality, notes'
+    )
+    .eq('user_id', user.id)
+    .gte('log_date', cutoff14.toISOString().slice(0, 10))
+    .neq('id', logId) // exclude today (shown separately)
+    .order('log_date', { ascending: false })
+
+  // ── 3. Fetch today's planned training session ────────────────────────────
+  const todayStr = log.log_date
+  const { data: trainSession } = await supabase
+    .from('training_sessions')
+    .select('session_type, planned_description, completed')
+    .eq('user_id', user.id)
+    .eq('session_date', todayStr)
+    .maybeSingle()
+
+  // ── 4. Fetch yesterday's nutrition log ───────────────────────────────────
+  const yesterday = new Date(todayStr)
+  yesterday.setDate(yesterday.getDate() - 1)
+  const { data: nutritionYesterday } = await supabase
+    .from('nutrition_logs')
+    .select('adherence_score, has_alcohol')
+    .eq('user_id', user.id)
+    .eq('log_date', yesterday.toISOString().slice(0, 10))
+    .maybeSingle()
+
+  // ── 5. Fetch today's pending coach tasks ─────────────────────────────────
+  const { data: pendingTasks } = await supabase
+    .from('coach_tasks')
+    .select('title, priority')
+    .eq('user_id', user.id)
+    .eq('due_date', todayStr)
+    .is('completed_at', null)
+
+  // ── 6. Build the user message ────────────────────────────────────────────
+  const todaySection = [
+    `## Today's Morning Log (${log.log_date})`,
+    log.resting_hr_bpm != null ? `Resting HR: ${log.resting_hr_bpm} bpm` : null,
+    log.sleep_hours != null ? `Sleep: ${log.sleep_hours}h` : null,
+    log.sleep_quality != null ? `Sleep quality: ${log.sleep_quality}/5` : null,
+    log.energy_level != null ? `Energy: ${log.energy_level}/5` : null,
+    log.mood != null ? `Mood: ${log.mood}/5` : null,
+    log.body_readiness != null ? `Body readiness: ${log.body_readiness}/5` : null,
+    log.woke_easily != null ? `Woke easily: ${log.woke_easily ? 'yes' : 'no'}` : null,
+    log.had_dreams != null ? `Dreams: ${log.had_dreams ? log.dream_quality ?? 'yes' : 'no'}` : null,
+    log.notes ? `Notes: ${log.notes}` : null,
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  const historySection =
+    recentLogs && recentLogs.length > 0
+      ? `## Last ${recentLogs.length} Days of Morning Logs\n` +
+        recentLogs
+          .map((r) => {
+            const parts = [
+              r.log_date,
+              r.resting_hr_bpm != null ? `HR:${r.resting_hr_bpm}bpm` : null,
+              r.sleep_hours != null ? `Sleep:${r.sleep_hours}h` : null,
+              r.sleep_quality != null ? `Q:${r.sleep_quality}/5` : null,
+              r.energy_level != null ? `Energy:${r.energy_level}/5` : null,
+              r.mood != null ? `Mood:${r.mood}/5` : null,
+              r.body_readiness != null ? `Body:${r.body_readiness}/5` : null,
+              r.had_dreams && r.dream_quality ? `Dreams:${r.dream_quality}` : null,
+              r.notes ? `Notes: ${r.notes}` : null,
+            ].filter(Boolean)
+            return `- ${parts.join(' | ')}`
+          })
+          .join('\n')
+      : '## History\nNo previous logs available.'
+
+  const trainingSection = trainSession
+    ? `## Planned Training Today\nType: ${trainSession.session_type}\nDescription: ${trainSession.planned_description ?? 'N/A'}\nStatus: ${trainSession.completed ? 'completed' : 'not yet done'}`
+    : '## Planned Training Today\nNo session planned (rest day or not scheduled).'
+
+  const nutritionSection = nutritionYesterday
+    ? `## Yesterday's Nutrition\nAdherence score: ${nutritionYesterday.adherence_score ?? 'N/A'}/100${nutritionYesterday.has_alcohol ? '\n⚠️ Alcohol consumed yesterday' : ''}`
+    : '## Yesterday's Nutrition\nNo log available.'
+
+  const tasksSection =
+    pendingTasks && pendingTasks.length > 0
+      ? `## Today's Pending Tasks\n` +
+        pendingTasks.map((t) => `- [${t.priority ?? 'normal'}] ${t.title}`).join('\n')
+      : '## Today's Pending Tasks\nNone scheduled.'
+
+  const userMessage = [
+    todaySection,
+    historySection,
+    trainingSection,
+    nutritionSection,
+    tasksSection,
+  ].join('\n\n')
+
+  // ── 7. Generate briefing ─────────────────────────────────────────────────
+  const { text } = await generateText({
+    model: google('gemini-2.5-flash'),
+    system: SYSTEM_PROMPT,
+    prompt: userMessage,
+    maxTokens: 800,
+    temperature: 0.4,
+  })
+
+  // ── 8. Save briefing to the log row ──────────────────────────────────────
+  await supabase
+    .from('morning_logs')
+    .update({ ai_briefing: text })
+    .eq('id', logId)
+    .eq('user_id', user.id)
+
+  return Response.json({ briefing: text })
+}

--- a/src/components/morning/MorningCheckin.tsx
+++ b/src/components/morning/MorningCheckin.tsx
@@ -1,0 +1,348 @@
+'use client'
+
+// Morning Check-In card — vitals form + AI briefing panel.
+// On mount: loads today's log; if ai_briefing exists, shows it immediately.
+// On submit: saves log → fetches briefing → renders it.
+
+import { useState, useEffect, useTransition } from 'react'
+import { Sunrise, Loader2, Circle, CircleDot } from 'lucide-react'
+import { saveMorningLog, getTodaysMorningLog } from '@/app/actions/morning-log'
+import type { MorningLog, MorningLogInput } from '@/lib/types/morning-log'
+
+// ── Markdown renderer (minimal, matches CoachChat style) ─────────────────────
+
+function renderMarkdown(text: string) {
+  return text.split('\n').map((line, i) => {
+    if (line.startsWith('## ')) {
+      return (
+        <h3 key={i} className="text-sm font-semibold text-white/90 mt-4 mb-1 first:mt-0">
+          {line.slice(3)}
+        </h3>
+      )
+    }
+    if (line.startsWith('- ')) {
+      return (
+        <li key={i} className="text-sm text-white/70 ml-3 list-disc list-inside leading-relaxed">
+          {line.slice(2)}
+        </li>
+      )
+    }
+    if (line.trim() === '') return <div key={i} className="h-1.5" />
+    return (
+      <p key={i} className="text-sm text-white/70 leading-relaxed">
+        {line}
+      </p>
+    )
+  })
+}
+
+// ── Sub-components ───────────────────────────────────────────────────────────
+
+function DotSelector({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: number | null
+  onChange: (v: number) => void
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-xs text-white/50 w-28 shrink-0">{label}</span>
+      <div className="flex gap-1.5">
+        {[1, 2, 3, 4, 5].map((n) => (
+          <button
+            key={n}
+            type="button"
+            onClick={() => onChange(n)}
+            aria-label={`${label} ${n}`}
+            className="transition-colors"
+          >
+            {value != null && n <= value ? (
+              <CircleDot className="h-4 w-4 text-violet-400" />
+            ) : (
+              <Circle className="h-4 w-4 text-white/20 hover:text-white/40" />
+            )}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function YesNoToggle({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: boolean | null
+  onChange: (v: boolean) => void
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-xs text-white/50 w-28 shrink-0">{label}</span>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => onChange(true)}
+          className={`text-xs px-3 py-1 rounded-full border transition-colors ${
+            value === true
+              ? 'bg-violet-500/20 border-violet-500/50 text-violet-300'
+              : 'bg-white/5 border-white/10 text-white/40 hover:text-white/60'
+          }`}
+        >
+          Yes
+        </button>
+        <button
+          type="button"
+          onClick={() => onChange(false)}
+          className={`text-xs px-3 py-1 rounded-full border transition-colors ${
+            value === false
+              ? 'bg-violet-500/20 border-violet-500/50 text-violet-300'
+              : 'bg-white/5 border-white/10 text-white/40 hover:text-white/60'
+          }`}
+        >
+          No
+        </button>
+      </div>
+    </div>
+  )
+}
+
+type DreamQuality = 'good' | 'neutral' | 'bad' | 'nightmare'
+
+// ── Main component ───────────────────────────────────────────────────────────
+
+export function MorningCheckin() {
+  const today = new Date()
+  const dateLabel = today.toLocaleDateString('en-GB', {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+  })
+
+  // Form state
+  const [restingHr, setRestingHr] = useState<string>('')
+  const [sleepHours, setSleepHours] = useState<string>('')
+  const [sleepQuality, setSleepQuality] = useState<number | null>(null)
+  const [energyLevel, setEnergyLevel] = useState<number | null>(null)
+  const [mood, setMood] = useState<number | null>(null)
+  const [bodyReadiness, setBodyReadiness] = useState<number | null>(null)
+  const [wokeEasily, setWokeEasily] = useState<boolean | null>(null)
+  const [hadDreams, setHadDreams] = useState<boolean | null>(null)
+  const [dreamQuality, setDreamQuality] = useState<DreamQuality | null>(null)
+  const [notes, setNotes] = useState<string>('')
+
+  // UI state
+  const [briefing, setBriefing] = useState<string | null>(null)
+  const [submitted, setSubmitted] = useState(false)
+  const [fetchingBriefing, setFetchingBriefing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+
+  // On mount: load today's log
+  useEffect(() => {
+    getTodaysMorningLog().then((log) => {
+      if (!log) return
+      populateFromLog(log)
+    })
+  }, [])
+
+  function populateFromLog(log: MorningLog) {
+    if (log.resting_hr_bpm != null) setRestingHr(String(log.resting_hr_bpm))
+    if (log.sleep_hours != null) setSleepHours(String(log.sleep_hours))
+    if (log.sleep_quality != null) setSleepQuality(log.sleep_quality)
+    if (log.energy_level != null) setEnergyLevel(log.energy_level)
+    if (log.mood != null) setMood(log.mood)
+    if (log.body_readiness != null) setBodyReadiness(log.body_readiness)
+    if (log.woke_easily != null) setWokeEasily(log.woke_easily)
+    if (log.had_dreams != null) setHadDreams(log.had_dreams)
+    if (log.dream_quality) setDreamQuality(log.dream_quality as DreamQuality)
+    if (log.notes) setNotes(log.notes)
+    if (log.ai_briefing) {
+      setBriefing(log.ai_briefing)
+      setSubmitted(true)
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+
+    const input: MorningLogInput = {
+      resting_hr_bpm: restingHr ? Number(restingHr) : null,
+      sleep_hours: sleepHours ? Number(sleepHours) : null,
+      sleep_quality: sleepQuality,
+      energy_level: energyLevel,
+      mood,
+      body_readiness: bodyReadiness,
+      woke_easily: wokeEasily,
+      had_dreams: hadDreams,
+      dream_quality: hadDreams ? dreamQuality : null,
+      notes: notes.trim() || null,
+    }
+
+    startTransition(async () => {
+      try {
+        const { id } = await saveMorningLog(input)
+        setSubmitted(true)
+
+        // Fetch briefing only if we don't already have one
+        if (!briefing) {
+          setFetchingBriefing(true)
+          const res = await fetch('/api/ai/morning-briefing', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ logId: id }),
+          })
+          const data = await res.json() as { briefing?: string; error?: string }
+          if (data.briefing) {
+            setBriefing(data.briefing)
+          } else {
+            setError('Failed to generate briefing — your log was saved.')
+          }
+          setFetchingBriefing(false)
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Something went wrong')
+        setFetchingBriefing(false)
+      }
+    })
+  }
+
+  // Derive readiness colour from briefing header
+  const readinessColor = briefing?.includes('🟢')
+    ? 'text-emerald-400'
+    : briefing?.includes('🔴')
+      ? 'text-red-400'
+      : 'text-amber-400'
+
+  return (
+    <div className="space-y-4">
+      {/* ── Form card ─────────────────────────────────────────────────────── */}
+      <div className="rounded-xl border border-white/10 bg-white/5 overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-3.5 border-b border-white/10 bg-amber-500/5">
+          <div className="flex items-center gap-2">
+            <Sunrise className="h-4 w-4 text-amber-400" />
+            <span className="text-sm font-semibold text-white">Morning Check-In</span>
+          </div>
+          <span className="text-xs text-white/40">{dateLabel}</span>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-5 py-4 space-y-5">
+          {/* Vitals row */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1">
+              <label className="text-xs text-white/50">RHR (bpm)</label>
+              <input
+                type="number"
+                value={restingHr}
+                onChange={(e) => setRestingHr(e.target.value)}
+                min={30}
+                max={120}
+                placeholder="e.g. 46"
+                className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder:text-white/20 focus:outline-none focus:border-white/25"
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs text-white/50">Sleep (hours)</label>
+              <input
+                type="number"
+                value={sleepHours}
+                onChange={(e) => setSleepHours(e.target.value)}
+                min={0}
+                max={14}
+                step={0.5}
+                placeholder="e.g. 7.5"
+                className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder:text-white/20 focus:outline-none focus:border-white/25"
+              />
+            </div>
+          </div>
+
+          {/* 1–5 dot selectors */}
+          <div className="space-y-3">
+            <DotSelector label="Sleep quality" value={sleepQuality} onChange={setSleepQuality} />
+            <DotSelector label="Energy" value={energyLevel} onChange={setEnergyLevel} />
+            <DotSelector label="Mood" value={mood} onChange={setMood} />
+            <DotSelector label="Body readiness" value={bodyReadiness} onChange={setBodyReadiness} />
+          </div>
+
+          {/* Yes/No toggles */}
+          <div className="space-y-3">
+            <YesNoToggle label="Woke easily?" value={wokeEasily} onChange={setWokeEasily} />
+            <YesNoToggle label="Dreams?" value={hadDreams} onChange={setHadDreams} />
+          </div>
+
+          {/* Dream quality (only when hadDreams=true) */}
+          {hadDreams === true && (
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-xs text-white/50 w-28 shrink-0">Dream quality</span>
+              {(['good', 'neutral', 'bad', 'nightmare'] as DreamQuality[]).map((q) => (
+                <button
+                  key={q}
+                  type="button"
+                  onClick={() => setDreamQuality(q)}
+                  className={`text-xs px-3 py-1 rounded-full border capitalize transition-colors ${
+                    dreamQuality === q
+                      ? 'bg-violet-500/20 border-violet-500/50 text-violet-300'
+                      : 'bg-white/5 border-white/10 text-white/40 hover:text-white/60'
+                  }`}
+                >
+                  {q}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Notes */}
+          <div className="space-y-1">
+            <label className="text-xs text-white/50">How are you feeling? (optional)</label>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={2}
+              placeholder="Any aches, thoughts, or context for today…"
+              className="w-full resize-none bg-white/5 border border-white/10 rounded-lg px-3 py-2.5 text-sm text-white placeholder:text-white/20 focus:outline-none focus:border-white/25"
+            />
+          </div>
+
+          {error && <p className="text-xs text-red-400">{error}</p>}
+
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={isPending || fetchingBriefing}
+              className="flex items-center gap-2 px-4 py-2 rounded-lg bg-amber-500/15 border border-amber-500/30 text-sm text-amber-300 hover:bg-amber-500/25 transition-colors disabled:opacity-40"
+            >
+              {(isPending || fetchingBriefing) && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+              {submitted && !fetchingBriefing ? 'Update Check-In' : 'Submit Check-In'}
+            </button>
+          </div>
+        </form>
+      </div>
+
+      {/* ── Briefing card ─────────────────────────────────────────────────── */}
+      {fetchingBriefing && (
+        <div className="rounded-xl border border-white/10 bg-white/5 px-5 py-8 flex flex-col items-center gap-3 text-center">
+          <Loader2 className="h-5 w-5 text-amber-400 animate-spin" />
+          <p className="text-sm text-white/40">Analysing your morning…</p>
+        </div>
+      )}
+
+      {briefing && !fetchingBriefing && (
+        <div className="rounded-xl border border-white/10 bg-white/5 overflow-hidden">
+          <div className="flex items-center gap-2 px-5 py-3.5 border-b border-white/10 bg-amber-500/5">
+            <span className={`text-base ${readinessColor}`}>
+              {briefing.includes('🟢') ? '🟢' : briefing.includes('🔴') ? '🔴' : '🟡'}
+            </span>
+            <span className="text-sm font-semibold text-white">Morning Briefing</span>
+          </div>
+          <div className="px-5 py-4 space-y-1">{renderMarkdown(briefing)}</div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/lib/ai/master-coach.ts
+++ b/src/lib/ai/master-coach.ts
@@ -6,7 +6,7 @@ import { ATHLETE_PROFILE } from './coaching'
 
 // ── System prompt ──────────────────────────────────────────────────────────
 
-export const MASTER_COACH_SYSTEM_PROMPT = `You are the central Life OS coach — a highly capable AI adviser with full visibility into all of ${ATHLETE_PROFILE.sex === 'female' ? 'her' : 'their'} systems: marathon training, nutrition, supplements, habits, and trading.
+export const MASTER_COACH_SYSTEM_PROMPT = `You are the central Life OS coach — a highly capable AI adviser with full visibility into all of ${ATHLETE_PROFILE.sex === 'female' ? 'her' : 'their'} systems: marathon training, nutrition, supplements, habits, trading, and daily readiness.
 
 Athlete profile:
 - Age: ${ATHLETE_PROFILE.age}yo ${ATHLETE_PROFILE.sex}
@@ -18,12 +18,14 @@ Athlete profile:
 
 Your capabilities:
 - You can read data from ALL modules (running, nutrition, supplements, habits, trading, marathon plan).
+- You can read morning logs: daily readiness data (RHR, sleep, energy, mood, body readiness).
 - You can make changes using tools: pause/resume supplements, update plan configuration values.
 - All changes you make are logged to the audit trail automatically.
 - Supplements are prescribed by Dr Emine Ömerağa — you can manage scheduling/timing/pausing but must NOT change medical dosages or diagnoses.
 
 Coaching philosophy:
 - Be direct, data-driven, and cross-domain. Spot patterns across modules (e.g. "poor sleep → slow run → mood dip → bad trading").
+- Morning logs contain daily readiness data: RHR, sleep, energy, mood, body readiness. Cross-reference these with training performance and trading outcomes. If recent logs show declining energy or HR spikes, proactively flag it.
 - When asked to make a change, do it immediately with the appropriate tool and explain what you did.
 - Before making a significant change (like pausing a prescribed supplement), confirm intent if the user's message is ambiguous.
 - Format responses with clear sections. Use markdown. Keep responses under 500 words unless doing multi-week analysis.
@@ -53,6 +55,7 @@ export async function buildFullSystemContext(supabase: SupabaseClient): Promise<
     marathonSessionsRes,
     planConfigsRes,
     recentAuditRes,
+    morningLogsRes,
   ] = await Promise.allSettled([
     supabase
       .from('supplements')
@@ -113,6 +116,13 @@ export async function buildFullSystemContext(supabase: SupabaseClient): Promise<
       .eq('user_id', user.id)
       .order('changed_at', { ascending: false })
       .limit(10),
+
+    supabase
+      .from('morning_logs')
+      .select('log_date, resting_hr_bpm, sleep_hours, sleep_quality, energy_level, mood, body_readiness, woke_easily, had_dreams, dream_quality, notes')
+      .eq('user_id', user.id)
+      .gte('log_date', cutoff14Str)
+      .order('log_date', { ascending: false }),
   ])
 
   const sections: string[] = []
@@ -273,6 +283,29 @@ export async function buildFullSystemContext(supabase: SupabaseClient): Promise<
       return `- ${date} [${e.changed_by}] ${e.module}: ${change}${e.reason ? ` — ${e.reason}` : ''}`
     })
     sections.push(`## Recent Changes (audit log)\n${lines.join('\n')}`)
+  }
+
+  // ── Morning Logs ─────────────────────────────────────────────────
+  if (morningLogsRes.status === 'fulfilled' && morningLogsRes.value.data?.length) {
+    const logs = morningLogsRes.value.data
+    const lines = logs.map((l) => {
+      const dreamNote = l.had_dreams
+        ? l.dream_quality ?? 'yes'
+        : l.had_dreams === false
+          ? 'none'
+          : null
+      const parts = [
+        `HR:${l.resting_hr_bpm != null ? l.resting_hr_bpm + 'bpm' : 'N/A'}`,
+        `Sleep:${l.sleep_hours != null ? l.sleep_hours + 'h' : 'N/A'} Q:${l.sleep_quality ?? '?'}/5`,
+        `Energy:${l.energy_level ?? '?'}/5`,
+        `Mood:${l.mood ?? '?'}/5`,
+        `Body:${l.body_readiness ?? '?'}/5`,
+        dreamNote ? `Dreams:${dreamNote}` : null,
+      ].filter(Boolean)
+      const noteStr = l.notes ? `\n  Notes: ${l.notes}` : ''
+      return `- ${l.log_date} | ${parts.join(' | ')}${noteStr}`
+    })
+    sections.push(`## Morning Logs (last 14 days)\n${lines.join('\n')}`)
   }
 
   return sections.join('\n\n')

--- a/src/lib/types/morning-log.ts
+++ b/src/lib/types/morning-log.ts
@@ -1,0 +1,21 @@
+export interface MorningLogInput {
+  log_date?: string
+  resting_hr_bpm?: number | null
+  sleep_hours?: number | null
+  sleep_quality?: number | null
+  energy_level?: number | null
+  mood?: number | null
+  body_readiness?: number | null
+  woke_easily?: boolean | null
+  had_dreams?: boolean | null
+  dream_quality?: 'good' | 'neutral' | 'bad' | 'nightmare' | null
+  notes?: string | null
+}
+
+export interface MorningLog extends MorningLogInput {
+  id: string
+  user_id: string
+  ai_briefing: string | null
+  created_at: string
+  updated_at: string
+}

--- a/supabase/migrations/20260309000001_morning_logs.sql
+++ b/supabase/migrations/20260309000001_morning_logs.sql
@@ -1,0 +1,45 @@
+-- Morning Check-In logs
+-- One row per user per day — stores vitals, readiness scores, and the cached AI briefing.
+
+CREATE TABLE morning_logs (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  log_date        date NOT NULL DEFAULT current_date,
+
+  -- Vitals
+  resting_hr_bpm  smallint,
+  sleep_hours     numeric(3,1),
+  sleep_quality   smallint CHECK (sleep_quality BETWEEN 1 AND 5),
+
+  -- Readiness
+  energy_level    smallint CHECK (energy_level BETWEEN 1 AND 5),
+  mood            smallint CHECK (mood BETWEEN 1 AND 5),
+  body_readiness  smallint CHECK (body_readiness BETWEEN 1 AND 5),
+
+  -- Sleep details
+  woke_easily     boolean,
+  had_dreams      boolean,
+  dream_quality   text CHECK (dream_quality IN ('good','neutral','bad','nightmare')),
+
+  -- Free text
+  notes           text,
+
+  -- Stored AI briefing so it doesn't re-generate on re-open
+  ai_briefing     text,
+
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+
+  UNIQUE (user_id, log_date)
+);
+
+ALTER TABLE morning_logs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "user owns morning_logs"
+  ON morning_logs FOR ALL
+  USING  (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER morning_logs_updated_at
+  BEFORE UPDATE ON morning_logs
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();


### PR DESCRIPTION
- Add supabase/migrations/20260309000001_morning_logs.sql morning_logs table: vitals, readiness scores, ai_briefing cache, RLS + trigger

- Add src/lib/types/morning-log.ts: MorningLogInput / MorningLog interfaces

- Add src/app/actions/morning-log.ts: saveMorningLog (upsert), getTodaysMorningLog, getRecentMorningLogs server actions

- Add src/app/api/ai/morning-briefing/route.ts (non-streaming, generateText): fetches morning log + 14-day history + today's training + yesterday's nutrition
  + pending tasks → Gemini 2.5 Flash → 4-section briefing → cached to ai_briefing

- Add src/components/morning/MorningCheckin.tsx: vitals form (RHR, sleep hrs, 1-5 dot selectors, Yes/No toggles, dream quality, free-text notes) + AI briefing card; loads existing log on mount; shows cached briefing without re-calling API

- Add MorningCheckin as first element on /dashboard and above capabilities grid on /coach (both pages, client-rendered)

- Update src/lib/ai/master-coach.ts:
  - Query morning_logs (last 14 days) in buildFullSystemContext
  - Render ## Morning Logs section in context string
  - Update MASTER_COACH_SYSTEM_PROMPT to reference morning log cross-referencing

https://claude.ai/code/session_0151Ye69WomJSejbZE69KaQZ