### PR TITLE
Add Coach Tasks system — coach and user can create, list, and complet…

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { getDebts, getPropPayouts } from '@/lib/supabase/finance'
 import { getActivities, getRaceTargets } from '@/lib/supabase/running'
 
 import { MorningCheckin } from '@/components/morning/MorningCheckin'
+import { TodaysTasks } from '@/components/tasks/TodaysTasks'
 import { HabitsRingCard } from '@/components/dashboard/habits-ring-card'
 import { HabitStreaksCard } from '@/components/dashboard/habit-streaks-card'
 import type { StreakItem } from '@/components/dashboard/habit-streaks-card'
@@ -242,6 +243,9 @@ export default async function DashboardPage() {
 
       {/* Row 0 — Morning Check-In (client component, loads its own data) */}
       <MorningCheckin />
+
+      {/* Row 0b — Today's Tasks */}
+      <TodaysTasks />
 
       {/* Row 1 — Habits: ring + streaks + compliance */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">

--- a/src/app/actions/coach-tasks.ts
+++ b/src/app/actions/coach-tasks.ts
@@ -1,0 +1,138 @@
+'use server'
+
+import { createClient } from '@/lib/supabase/server'
+import type { CoachTaskInput, CoachTask } from '@/lib/types/coach-task'
+
+export async function createTask(data: CoachTaskInput): Promise<CoachTask> {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const { data: row, error } = await supabase
+    .from('coach_tasks')
+    .insert({
+      ...data,
+      user_id: user.id,
+      recurrence: data.recurrence ?? 'none',
+      source: data.source ?? 'user',
+    })
+    .select('*')
+    .single()
+
+  if (error || !row) throw new Error(error?.message ?? 'Failed to create task')
+  return row as CoachTask
+}
+
+export async function updateTask(
+  id: string,
+  data: Partial<CoachTaskInput>
+): Promise<CoachTask> {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const { data: row, error } = await supabase
+    .from('coach_tasks')
+    .update(data)
+    .eq('id', id)
+    .eq('user_id', user.id)
+    .select('*')
+    .single()
+
+  if (error || !row) throw new Error(error?.message ?? 'Failed to update task')
+  return row as CoachTask
+}
+
+export async function completeTask(id: string): Promise<void> {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const { error } = await supabase
+    .from('coach_tasks')
+    .update({ completed_at: new Date().toISOString() })
+    .eq('id', id)
+    .eq('user_id', user.id)
+
+  if (error) throw new Error(error.message)
+}
+
+export async function deleteTask(id: string): Promise<void> {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) throw new Error('Not authenticated')
+
+  const { error } = await supabase
+    .from('coach_tasks')
+    .delete()
+    .eq('id', id)
+    .eq('user_id', user.id)
+
+  if (error) throw new Error(error.message)
+}
+
+export async function getTodaysTasks(): Promise<CoachTask[]> {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return []
+
+  const todayStr = new Date().toISOString().slice(0, 10)
+  const todayDow = new Date().getDay() // 0=Sun, 1=Mon … 6=Sat
+  const isWeekday = todayDow >= 1 && todayDow <= 5
+
+  // Fetch candidates: tasks due today OR recurring tasks not yet filtered
+  // We fetch a wider set and filter recurrence logic in JS.
+  const { data } = await supabase
+    .from('coach_tasks')
+    .select('*')
+    .eq('user_id', user.id)
+    .is('completed_at', null)
+    .or(
+      [
+        `due_date.eq.${todayStr}`,
+        `recurrence.eq.daily`,
+        `recurrence.eq.weekdays`,
+        `recurrence.eq.weekly`,
+      ].join(',')
+    )
+    .order('due_date', { ascending: true, nullsFirst: false })
+
+  const rows = (data ?? []) as CoachTask[]
+
+  return rows.filter((task) => {
+    // Explicitly due today
+    if (task.due_date === todayStr) return true
+    // Daily: always show
+    if (task.recurrence === 'daily') return true
+    // Weekdays: Mon–Fri only
+    if (task.recurrence === 'weekdays') return isWeekday
+    // Weekly: show if today matches the weekday of the task's created_at
+    if (task.recurrence === 'weekly') {
+      const createdDow = new Date(task.created_at).getDay()
+      return createdDow === todayDow
+    }
+    return false
+  })
+}
+
+export async function getUpcomingTasks(days: number): Promise<CoachTask[]> {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return []
+
+  const todayStr = new Date().toISOString().slice(0, 10)
+  const futureDate = new Date()
+  futureDate.setDate(futureDate.getDate() + days)
+  const futureStr = futureDate.toISOString().slice(0, 10)
+
+  const { data } = await supabase
+    .from('coach_tasks')
+    .select('*')
+    .eq('user_id', user.id)
+    .is('completed_at', null)
+    .gte('due_date', todayStr)
+    .lte('due_date', futureStr)
+    .order('due_date', { ascending: true })
+
+  return (data ?? []) as CoachTask[]
+}

--- a/src/app/api/ai/coach/route.ts
+++ b/src/app/api/ai/coach/route.ts
@@ -306,6 +306,152 @@ export async function POST(req: Request) {
         },
       },
 
+      // ── Task tools ──────────────────────────────────────────────
+
+      create_task: {
+        description:
+          'Create a task or reminder for the user. Use when the user says ' +
+          '"remind me to X", "add a task to Y", "don\'t let me forget Z on [date]", ' +
+          'or asks the coach to track something for a specific date. ' +
+          'Always confirm after creating: "Added to your tasks: [title] for [date]."',
+        parameters: z.object({
+          title: z.string().describe('Clear, actionable task title'),
+          notes: z.string().optional().describe('Additional context or details'),
+          due_date: z.string().optional().describe('ISO date YYYY-MM-DD'),
+          due_time: z.string().optional().describe('HH:MM 24h format'),
+          recurrence: z.enum(['none', 'daily', 'weekly', 'weekdays']).default('none'),
+          module: z
+            .enum(['general', 'training', 'nutrition', 'trading', 'health', 'personal'])
+            .default('general'),
+          coach_context: z.string().describe('Why this task was created'),
+        }),
+        execute: async ({ title, notes, due_date, due_time, recurrence, module: taskModule, coach_context }) => {
+          try {
+            const { data: row, error } = await supabase
+              .from('coach_tasks')
+              .insert({
+                user_id: user.id,
+                title,
+                notes: notes ?? null,
+                due_date: due_date ?? null,
+                due_time: due_time ?? null,
+                recurrence,
+                module: taskModule,
+                source: 'ai_coach',
+                coach_context,
+              })
+              .select('id, title')
+              .single()
+
+            if (error) throw error
+
+            const dateStr = due_date ? ` for ${due_date}` : ''
+            const timeStr = due_time ? ` at ${due_time}` : ''
+            return {
+              success: true,
+              id: row?.id,
+              message: `Added to your tasks: "${title}"${dateStr}${timeStr}.`,
+            }
+          } catch (e) {
+            return { success: false, message: `Failed to create task: ${String(e)}` }
+          }
+        },
+      },
+
+      complete_task: {
+        description:
+          'Mark a task as complete. Use when user says "done", "completed", ' +
+          '"mark X as done", or similar. Provide either the task id or a partial title to match.',
+        parameters: z.object({
+          task_id: z.string().optional().describe('UUID of the task if known'),
+          title_hint: z.string().optional().describe('Partial title to match if no id available'),
+        }),
+        execute: async ({ task_id, title_hint }) => {
+          try {
+            let resolvedId = task_id
+
+            if (!resolvedId && title_hint) {
+              const { data: matches } = await supabase
+                .from('coach_tasks')
+                .select('id, title')
+                .eq('user_id', user.id)
+                .is('completed_at', null)
+                .ilike('title', `%${title_hint}%`)
+                .order('created_at', { ascending: false })
+                .limit(1)
+
+              resolvedId = matches?.[0]?.id
+              if (!resolvedId) {
+                return { success: false, message: `No pending task found matching "${title_hint}".` }
+              }
+            }
+
+            if (!resolvedId) {
+              return { success: false, message: 'Provide task_id or title_hint to complete a task.' }
+            }
+
+            const { data: task, error } = await supabase
+              .from('coach_tasks')
+              .update({ completed_at: new Date().toISOString() })
+              .eq('id', resolvedId)
+              .eq('user_id', user.id)
+              .select('title')
+              .single()
+
+            if (error) throw error
+            return { success: true, message: `Completed: "${task?.title ?? resolvedId}".` }
+          } catch (e) {
+            return { success: false, message: `Failed to complete task: ${String(e)}` }
+          }
+        },
+      },
+
+      get_tasks: {
+        description:
+          'Fetch the user\'s current tasks. Use when user asks "what do I have to do", ' +
+          '"what\'s on my list", "any reminders today", or similar.',
+        parameters: z.object({
+          scope: z
+            .enum(['today', 'upcoming', 'all_pending'])
+            .default('today')
+            .describe('today=due today | upcoming=next 7 days | all_pending=all incomplete'),
+        }),
+        execute: async ({ scope }) => {
+          try {
+            const todayStr = new Date().toISOString().slice(0, 10)
+            const futureStr = new Date(Date.now() + 7 * 86_400_000).toISOString().slice(0, 10)
+
+            let query = supabase
+              .from('coach_tasks')
+              .select('id, title, notes, due_date, due_time, module, source, recurrence')
+              .eq('user_id', user.id)
+              .is('completed_at', null)
+
+            if (scope === 'today') {
+              query = query.eq('due_date', todayStr)
+            } else if (scope === 'upcoming') {
+              query = query.gte('due_date', todayStr).lte('due_date', futureStr)
+            }
+
+            const { data } = await query.order('due_date', { ascending: true, nullsFirst: false })
+
+            const tasks = (data ?? []).map((t) => ({
+              id: t.id,
+              title: t.title,
+              due: t.due_date ? `${t.due_date}${t.due_time ? ' ' + t.due_time : ''}` : 'no date',
+              module: t.module ?? 'general',
+              source: t.source,
+              recurrence: t.recurrence,
+              notes: t.notes ?? undefined,
+            }))
+
+            return { tasks, count: tasks.length, message: `Found ${tasks.length} task(s).` }
+          } catch (e) {
+            return { tasks: [], count: 0, message: `Failed to fetch tasks: ${String(e)}` }
+          }
+        },
+      },
+
       // ── Audit log read tool ─────────────────────────────────────
 
       get_recent_changes: {

--- a/src/app/api/ai/morning-briefing/route.ts
+++ b/src/app/api/ai/morning-briefing/route.ts
@@ -93,7 +93,7 @@ export async function POST(req: Request) {
   // ── 5. Fetch today's pending coach tasks ─────────────────────────────────
   const { data: pendingTasks } = await supabase
     .from('coach_tasks')
-    .select('title, priority')
+    .select('title, module')
     .eq('user_id', user.id)
     .eq('due_date', todayStr)
     .is('completed_at', null)
@@ -146,7 +146,7 @@ export async function POST(req: Request) {
   const tasksSection =
     pendingTasks && pendingTasks.length > 0
       ? `## Today's Pending Tasks\n` +
-        pendingTasks.map((t) => `- [${t.priority ?? 'normal'}] ${t.title}`).join('\n')
+        pendingTasks.map((t) => `- [${t.module ?? 'general'}] ${t.title}`).join('\n')
       : `## Today's Pending Tasks\nNone scheduled.`
 
   const userMessage = [

--- a/src/components/tasks/TodaysTasks.tsx
+++ b/src/components/tasks/TodaysTasks.tsx
@@ -1,0 +1,270 @@
+'use client'
+
+// Today's Tasks widget — compact card showing today's tasks.
+// Users can complete tasks inline and add new ones via an inline form.
+// The AI coach can also create tasks; they surface here automatically.
+
+import { useState, useEffect, useTransition } from 'react'
+import { CheckSquare, Circle, CheckCircle2, Plus, X, Loader2, Clock } from 'lucide-react'
+import {
+  getTodaysTasks,
+  completeTask,
+  createTask,
+} from '@/app/actions/coach-tasks'
+import type { CoachTask } from '@/lib/types/coach-task'
+
+// ── Module badge colours ─────────────────────────────────────────────────────
+
+const MODULE_STYLES: Record<string, { bg: string; text: string; label: string }> = {
+  trading:   { bg: 'bg-blue-500/15',   text: 'text-blue-300',   label: 'trading'   },
+  training:  { bg: 'bg-green-500/15',  text: 'text-green-300',  label: 'training'  },
+  nutrition: { bg: 'bg-orange-500/15', text: 'text-orange-300', label: 'nutrition' },
+  health:    { bg: 'bg-violet-500/15', text: 'text-violet-300', label: 'health'    },
+  personal:  { bg: 'bg-pink-500/15',   text: 'text-pink-300',   label: 'personal'  },
+  general:   { bg: 'bg-white/10',      text: 'text-white/40',   label: 'general'   },
+}
+
+function ModuleBadge({ module }: { module?: string | null }) {
+  const s = MODULE_STYLES[module ?? 'general'] ?? MODULE_STYLES.general
+  return (
+    <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium ${s.bg} ${s.text}`}>
+      {s.label}
+    </span>
+  )
+}
+
+// ── Inline add form ──────────────────────────────────────────────────────────
+
+type TaskModule = 'general' | 'training' | 'nutrition' | 'trading' | 'health' | 'personal'
+
+function AddTaskForm({ onSave, onCancel }: { onSave: (task: CoachTask) => void; onCancel: () => void }) {
+  const [title, setTitle] = useState('')
+  const [dueTime, setDueTime] = useState('')
+  const [module, setModule] = useState<TaskModule>('general')
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSave = () => {
+    if (!title.trim()) return
+    setError(null)
+    startTransition(async () => {
+      try {
+        const task = await createTask({
+          title: title.trim(),
+          due_date: new Date().toISOString().slice(0, 10),
+          due_time: dueTime || null,
+          module,
+          source: 'user',
+        })
+        onSave(task)
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to save task')
+      }
+    })
+  }
+
+  return (
+    <div className="mt-3 pt-3 border-t border-white/8 space-y-2">
+      <input
+        autoFocus
+        type="text"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') handleSave()
+          if (e.key === 'Escape') onCancel()
+        }}
+        placeholder="Task title…"
+        className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder:text-white/25 focus:outline-none focus:border-white/25"
+      />
+      <div className="flex items-center gap-2">
+        <input
+          type="time"
+          value={dueTime}
+          onChange={(e) => setDueTime(e.target.value)}
+          className="bg-white/5 border border-white/10 rounded-lg px-2 py-1.5 text-xs text-white/70 focus:outline-none focus:border-white/25 w-28"
+        />
+        <select
+          value={module}
+          onChange={(e) => setModule(e.target.value as TaskModule)}
+          className="flex-1 bg-white/5 border border-white/10 rounded-lg px-2 py-1.5 text-xs text-white/70 focus:outline-none focus:border-white/25"
+        >
+          {Object.keys(MODULE_STYLES).map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={handleSave}
+          disabled={!title.trim() || isPending}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-violet-500/20 border border-violet-500/30 text-xs text-violet-300 hover:bg-violet-500/30 transition-colors disabled:opacity-40"
+        >
+          {isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : null}
+          Save
+        </button>
+        <button
+          onClick={onCancel}
+          className="p-1.5 rounded-lg text-white/30 hover:text-white/60 hover:bg-white/5 transition-colors"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      {error && <p className="text-xs text-red-400">{error}</p>}
+    </div>
+  )
+}
+
+// ── Task row ─────────────────────────────────────────────────────────────────
+
+function TaskRow({
+  task,
+  onComplete,
+}: {
+  task: CoachTask
+  onComplete: (id: string) => void
+}) {
+  const [completing, setCompleting] = useState(false)
+  const isDone = !!task.completed_at
+
+  const handleClick = async () => {
+    if (isDone || completing) return
+    setCompleting(true)
+    await onComplete(task.id)
+    setCompleting(false)
+  }
+
+  return (
+    <div
+      className={`flex items-center gap-3 py-2 px-1 rounded-lg transition-colors group ${
+        isDone ? 'opacity-40' : 'hover:bg-white/[0.03]'
+      }`}
+    >
+      <button
+        onClick={handleClick}
+        disabled={isDone || completing}
+        className="shrink-0 text-white/30 hover:text-violet-400 transition-colors disabled:cursor-default"
+        aria-label={isDone ? 'Completed' : 'Mark complete'}
+      >
+        {completing ? (
+          <Loader2 className="h-4 w-4 animate-spin text-violet-400" />
+        ) : isDone ? (
+          <CheckCircle2 className="h-4 w-4 text-emerald-400" />
+        ) : (
+          <Circle className="h-4 w-4" />
+        )}
+      </button>
+
+      <div className="flex-1 min-w-0">
+        <span
+          className={`text-sm ${
+            isDone ? 'line-through text-white/30' : 'text-white/80'
+          }`}
+        >
+          {task.title}
+        </span>
+        {task.notes && (
+          <p className="text-xs text-white/30 truncate mt-0.5">{task.notes}</p>
+        )}
+      </div>
+
+      <div className="flex items-center gap-1.5 shrink-0">
+        {task.due_time && (
+          <span className="flex items-center gap-0.5 text-[10px] text-white/30">
+            <Clock className="h-2.5 w-2.5" />
+            {task.due_time.slice(0, 5)}
+          </span>
+        )}
+        <ModuleBadge module={task.module} />
+      </div>
+    </div>
+  )
+}
+
+// ── Main component ───────────────────────────────────────────────────────────
+
+export function TodaysTasks() {
+  const [tasks, setTasks] = useState<CoachTask[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showAddForm, setShowAddForm] = useState(false)
+
+  useEffect(() => {
+    getTodaysTasks()
+      .then((data) => setTasks(data))
+      .finally(() => setLoading(false))
+  }, [])
+
+  const handleComplete = async (id: string) => {
+    try {
+      await completeTask(id)
+      setTasks((prev) =>
+        prev.map((t) =>
+          t.id === id ? { ...t, completed_at: new Date().toISOString() } : t
+        )
+      )
+    } catch {
+      // Silently fail — task row remains clickable for retry
+    }
+  }
+
+  const handleTaskSaved = (task: CoachTask) => {
+    setTasks((prev) => [...prev, task])
+    setShowAddForm(false)
+  }
+
+  // Separate pending from completed so completed sink to bottom
+  const pending = tasks.filter((t) => !t.completed_at)
+  const completed = tasks.filter((t) => !!t.completed_at)
+  const ordered = [...pending, ...completed]
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/5 overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-5 py-3.5 border-b border-white/10 bg-emerald-500/5">
+        <div className="flex items-center gap-2">
+          <CheckSquare className="h-4 w-4 text-emerald-400" />
+          <span className="text-sm font-semibold text-white">Today&apos;s Tasks</span>
+          {!loading && pending.length > 0 && (
+            <span className="text-xs px-1.5 py-0.5 rounded-full bg-emerald-500/15 text-emerald-300 font-medium">
+              {pending.length}
+            </span>
+          )}
+        </div>
+        <button
+          onClick={() => setShowAddForm((v) => !v)}
+          className="flex items-center gap-1 text-xs text-white/40 hover:text-white/70 transition-colors"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Add
+        </button>
+      </div>
+
+      {/* Task list */}
+      <div className="px-4 py-3">
+        {loading && (
+          <div className="flex items-center gap-2 py-4 justify-center">
+            <Loader2 className="h-4 w-4 text-white/20 animate-spin" />
+            <span className="text-xs text-white/30">Loading tasks…</span>
+          </div>
+        )}
+
+        {!loading && ordered.length === 0 && !showAddForm && (
+          <p className="text-xs text-white/30 py-4 text-center">
+            No tasks today — ask the coach to add one
+          </p>
+        )}
+
+        {!loading && ordered.map((task) => (
+          <TaskRow key={task.id} task={task} onComplete={handleComplete} />
+        ))}
+
+        {showAddForm && (
+          <AddTaskForm
+            onSave={handleTaskSaved}
+            onCancel={() => setShowAddForm(false)}
+          />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/ai/master-coach.ts
+++ b/src/lib/ai/master-coach.ts
@@ -28,6 +28,8 @@ Coaching philosophy:
 - Morning logs contain daily readiness data: RHR, sleep, energy, mood, body readiness. Cross-reference these with training performance and trading outcomes. If recent logs show declining energy or HR spikes, proactively flag it.
 - When asked to make a change, do it immediately with the appropriate tool and explain what you did.
 - Before making a significant change (like pausing a prescribed supplement), confirm intent if the user's message is ambiguous.
+- You can create tasks for the user using the create_task tool. When a user mentions something they need to do, remember, or follow up on, proactively offer to add it as a task. Always confirm after creating: "Added to your tasks: [title] for [date]."
+- You can see all pending tasks in context. Reference them when relevant — e.g. if user asks about today's plan, include their pending tasks.
 - Format responses with clear sections. Use markdown. Keep responses under 500 words unless doing multi-week analysis.
 - When you use a tool, briefly acknowledge what you changed and why.`
 
@@ -45,6 +47,8 @@ export async function buildFullSystemContext(supabase: SupabaseClient): Promise<
   const cutoff14Str = cutoff14.toISOString().slice(0, 10)
   const cutoff7Str = cutoff7.toISOString().slice(0, 10)
 
+  const nextWeekStr = new Date(Date.now() + 7 * 86_400_000).toISOString().slice(0, 10)
+
   const [
     supplementsRes,
     nutritionRes,
@@ -56,6 +60,7 @@ export async function buildFullSystemContext(supabase: SupabaseClient): Promise<
     planConfigsRes,
     recentAuditRes,
     morningLogsRes,
+    tasksRes,
   ] = await Promise.allSettled([
     supabase
       .from('supplements')
@@ -123,6 +128,15 @@ export async function buildFullSystemContext(supabase: SupabaseClient): Promise<
       .eq('user_id', user.id)
       .gte('log_date', cutoff14Str)
       .order('log_date', { ascending: false }),
+
+    supabase
+      .from('coach_tasks')
+      .select('id, title, notes, due_date, due_time, recurrence, module, completed_at, source')
+      .eq('user_id', user.id)
+      .or(`due_date.is.null,due_date.lte.${nextWeekStr}`)
+      .is('completed_at', null)
+      .order('due_date', { ascending: true, nullsFirst: false })
+      .limit(20),
   ])
 
   const sections: string[] = []
@@ -283,6 +297,20 @@ export async function buildFullSystemContext(supabase: SupabaseClient): Promise<
       return `- ${date} [${e.changed_by}] ${e.module}: ${change}${e.reason ? ` — ${e.reason}` : ''}`
     })
     sections.push(`## Recent Changes (audit log)\n${lines.join('\n')}`)
+  }
+
+  // ── Pending Tasks ────────────────────────────────────────────────
+  if (tasksRes.status === 'fulfilled' && tasksRes.value.data?.length) {
+    const tasks = tasksRes.value.data
+    const lines = tasks.map((t) => {
+      const due = t.due_date
+        ? `${t.due_date}${t.due_time ? ' ' + String(t.due_time).slice(0, 5) : ''}`
+        : 'no date'
+      const recNote = t.recurrence !== 'none' ? ` (${t.recurrence})` : ''
+      const noteLine = t.notes ? `\n  Notes: ${t.notes}` : ''
+      return `- [${t.id}] ${t.title} | due:${due}${recNote} | module:${t.module ?? 'general'} | source:${t.source}${noteLine}`
+    })
+    sections.push(`## Pending Tasks (next 7 days)\n${lines.join('\n')}`)
   }
 
   // ── Morning Logs ─────────────────────────────────────────────────

--- a/src/lib/types/coach-task.ts
+++ b/src/lib/types/coach-task.ts
@@ -1,0 +1,19 @@
+export interface CoachTaskInput {
+  title: string
+  notes?: string | null
+  due_date?: string | null       // ISO date string YYYY-MM-DD
+  due_time?: string | null       // HH:MM 24h
+  recurrence?: 'none' | 'daily' | 'weekly' | 'weekdays'
+  module?: 'general' | 'training' | 'nutrition' | 'trading' | 'health' | 'personal'
+  source?: 'user' | 'ai_coach'
+  coach_context?: string | null
+}
+
+export interface CoachTask extends CoachTaskInput {
+  id: string
+  user_id: string
+  completed_at: string | null
+  snoozed_until: string | null
+  created_at: string
+  updated_at: string
+}

--- a/supabase/migrations/20260309000002_coach_tasks.sql
+++ b/supabase/migrations/20260309000002_coach_tasks.sql
@@ -1,0 +1,40 @@
+-- Coach Tasks — tasks/reminders creatable by both user and AI coach.
+-- One row per task; completion sets completed_at (never deleted).
+
+CREATE TABLE coach_tasks (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  title         text NOT NULL,
+  notes         text,
+  -- Scheduling
+  due_date      date,
+  due_time      time,
+  recurrence    text NOT NULL DEFAULT 'none'
+                CHECK (recurrence IN ('none', 'daily', 'weekly', 'weekdays')),
+  -- Categorisation
+  module        text CHECK (module IN
+                  ('general', 'training', 'nutrition', 'trading', 'health', 'personal')),
+  -- State
+  completed_at  timestamptz,
+  snoozed_until date,
+  -- Origin
+  source        text NOT NULL DEFAULT 'user'
+                CHECK (source IN ('user', 'ai_coach')),
+  coach_context text,   -- why the coach created it (for transparency)
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE coach_tasks ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "user owns coach_tasks"
+  ON coach_tasks FOR ALL
+  USING  (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER coach_tasks_updated_at
+  BEFORE UPDATE ON coach_tasks
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- Fast lookup: user's pending tasks ordered by due date
+CREATE INDEX coach_tasks_user_due ON coach_tasks (user_id, due_date, completed_at);


### PR DESCRIPTION
…e tasks

- Add supabase/migrations/20260309000002_coach_tasks.sql coach_tasks table: title, notes, due_date, due_time, recurrence, module, completed_at, source (user/ai_coach), coach_context. RLS + trigger + index.

- Add src/lib/types/coach-task.ts: CoachTaskInput / CoachTask interfaces

- Add src/app/actions/coach-tasks.ts: createTask, updateTask, completeTask (sets completed_at, no delete), deleteTask, getTodaysTasks (handles daily/weekdays/weekly recurrence in JS), getUpcomingTasks(days)

- Add three tools to src/app/api/ai/coach/route.ts: create_task: inserts with source=ai_coach, confirms with message complete_task: by task_id or ilike title_hint match get_tasks: scope=today|upcoming|all_pending

- Add src/components/tasks/TodaysTasks.tsx: Compact card with pending/completed task rows, click-to-complete circle buttons, module colour badges, inline AddTaskForm (title + time + module), completed tasks sink to bottom with strikethrough

- Add TodaysTasks to /dashboard between MorningCheckin and habits row

- Update src/lib/ai/master-coach.ts: Query coach_tasks (pending, next 7 days) in buildFullSystemContext Render ## Pending Tasks section with id, due, module, source, notes Add nextWeekStr calculation before Promise.allSettled Update system prompt: coach can create tasks + references pending tasks

- Fix src/app/api/ai/morning-briefing/route.ts: Change .select('title, priority') to .select('title, module') — priority column does not exist in coach_tasks schema Update task formatting template to use module instead of priority

https://claude.ai/code/session_0151Ye69WomJSejbZE69KaQZ