### PR TITLE
feat: Phase 4 — post-training evaluation flow

### DIFF
--- a/src/app/api/ai/coach/route.ts
+++ b/src/app/api/ai/coach/route.ts
@@ -7,6 +7,7 @@ import { streamText, convertToModelMessages } from 'ai'
 import { z } from 'zod'
 import { createClient } from '@/lib/supabase/server'
 import { MASTER_COACH_SYSTEM_PROMPT, buildFullSystemContext } from '@/lib/ai/master-coach'
+import { evaluateTrainingSession } from '@/lib/ai/training-evaluation'
 import type { UIMessage } from 'ai'
 
 export const runtime = 'nodejs'
@@ -448,6 +449,48 @@ export async function POST(req: Request) {
             return { tasks, count: tasks.length, message: `Found ${tasks.length} task(s).` }
           } catch (e) {
             return { tasks: [], count: 0, message: `Failed to fetch tasks: ${String(e)}` }
+          }
+        },
+      },
+
+      // ── Training eval tool ──────────────────────────────────────
+
+      evaluate_training_session: {
+        description:
+          'Run the AI coach evaluation on a completed training session. ' +
+          'Use when the user asks "evaluate my run", "what did you think of my session", ' +
+          '"rate my training today", or similar. ' +
+          'If no session_id is provided, evaluates the most recent completed session.',
+        parameters: z.object({
+          session_id: z.string().optional().describe('UUID of the training session to evaluate. If omitted, the most recent completed session is used.'),
+        }),
+        execute: async ({ session_id }) => {
+          try {
+            let targetId = session_id
+
+            if (!targetId) {
+              const { data: latest } = await supabase
+                .from('training_sessions')
+                .select('id, session_date, planned_type')
+                .eq('user_id', user.id)
+                .neq('status', 'pending')
+                .order('session_date', { ascending: false })
+                .limit(1)
+                .single()
+
+              if (!latest) return { success: false, message: 'No completed sessions found to evaluate.' }
+              targetId = latest.id
+            }
+
+            const result = await evaluateTrainingSession(supabase, targetId, user.id)
+            return {
+              success: true,
+              flag: result.flag,
+              evaluation: result.evaluation,
+              message: `Session evaluated (flag: ${result.flag}).`,
+            }
+          } catch (e) {
+            return { success: false, message: `Evaluation failed: ${String(e)}` }
           }
         },
       },

--- a/src/app/api/ai/morning-briefing/route.ts
+++ b/src/app/api/ai/morning-briefing/route.ts
@@ -23,6 +23,7 @@ Skip this section if fewer than 3 days of history exist.
 
 ## Today's Focus
 - Training: [what's planned today, or rest day]
+- Recovery: [reference yesterday's session if warning/rest flag, or high RPE, e.g. "Yesterday's tempo was hard (RPE 8) — prioritise easy effort today"]
 - Tasks: [list any due tasks, or "Nothing scheduled"]
 - Nutrition: [any flag based on yesterday, e.g. "alcohol yesterday — hydrate well"]
 
@@ -75,19 +76,29 @@ export async function POST(req: Request) {
   const todayStr = log.log_date
   const { data: trainSession } = await supabase
     .from('training_sessions')
-    .select('session_type, planned_description, completed')
+    .select('planned_type, planned_description, status')
     .eq('user_id', user.id)
     .eq('session_date', todayStr)
     .maybeSingle()
 
-  // ── 4. Fetch yesterday's nutrition log ───────────────────────────────────
+  // ── 3b. Fetch yesterday's completed training session ─────────────────────
   const yesterday = new Date(todayStr)
   yesterday.setDate(yesterday.getDate() - 1)
+  const yesterdayStr = yesterday.toISOString().slice(0, 10)
+  const { data: yesterdaySession } = await supabase
+    .from('training_sessions')
+    .select('planned_type, status, actual_km, actual_duration_min, perceived_effort, went_too_fast, coach_notes, flag')
+    .eq('user_id', user.id)
+    .eq('session_date', yesterdayStr)
+    .neq('status', 'pending')
+    .maybeSingle()
+
+  // ── 4. Fetch yesterday's nutrition log ───────────────────────────────────
   const { data: nutritionYesterday } = await supabase
     .from('nutrition_logs')
     .select('adherence_score, has_alcohol')
     .eq('user_id', user.id)
-    .eq('log_date', yesterday.toISOString().slice(0, 10))
+    .eq('log_date', yesterdayStr)
     .maybeSingle()
 
   // ── 5. Fetch today's pending coach tasks ─────────────────────────────────
@@ -136,8 +147,21 @@ export async function POST(req: Request) {
       : '## History\nNo previous logs available.'
 
   const trainingSection = trainSession
-    ? `## Planned Training Today\nType: ${trainSession.session_type}\nDescription: ${trainSession.planned_description ?? 'N/A'}\nStatus: ${trainSession.completed ? 'completed' : 'not yet done'}`
+    ? `## Planned Training Today\nType: ${trainSession.planned_type}\nDescription: ${trainSession.planned_description ?? 'N/A'}\nStatus: ${trainSession.status === 'completed' || trainSession.status === 'modified' ? 'already completed' : 'not yet done'}`
     : `## Planned Training Today\nNo session planned (rest day or not scheduled).`
+
+  const yesterdaySessionSection = yesterdaySession
+    ? (() => {
+        const km = yesterdaySession.actual_km ? ` ${yesterdaySession.actual_km}km` : ''
+        const rpe = yesterdaySession.perceived_effort ? ` RPE:${yesterdaySession.perceived_effort}/10` : ''
+        const fast = yesterdaySession.went_too_fast ? ` ⚠️ went too fast` : ''
+        const flagStr = yesterdaySession.flag ? ` | Flag: ${yesterdaySession.flag}` : ''
+        const notes = yesterdaySession.coach_notes
+          ? `\nCoach evaluation: ${yesterdaySession.coach_notes.slice(0, 200)}${yesterdaySession.coach_notes.length > 200 ? '…' : ''}`
+          : ''
+        return `## Yesterday's Training Session\nType: ${yesterdaySession.planned_type} | Status: ${yesterdaySession.status}${km}${rpe}${fast}${flagStr}${notes}`
+      })()
+    : `## Yesterday's Training Session\nNo completed session recorded.`
 
   const nutritionSection = nutritionYesterday
     ? `## Yesterday's Nutrition\nAdherence score: ${nutritionYesterday.adherence_score ?? 'N/A'}/100${nutritionYesterday.has_alcohol ? '\n⚠️ Alcohol consumed yesterday' : ''}`
@@ -153,6 +177,7 @@ export async function POST(req: Request) {
     todaySection,
     historySection,
     trainingSection,
+    yesterdaySessionSection,
     nutritionSection,
     tasksSection,
   ].join('\n\n')

--- a/src/app/api/ai/training-eval/route.ts
+++ b/src/app/api/ai/training-eval/route.ts
@@ -1,0 +1,29 @@
+// POST /api/ai/training-eval — evaluate a completed training session
+// Calls the shared evaluateTrainingSession function and returns the result.
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { evaluateTrainingSession } from '@/lib/ai/training-evaluation'
+
+export const runtime = 'nodejs'
+export const maxDuration = 60
+
+export async function POST(req: NextRequest) {
+  const { sessionId } = (await req.json()) as { sessionId: string }
+  if (!sessionId) return NextResponse.json({ error: 'sessionId required' }, { status: 400 })
+
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  try {
+    const result = await evaluateTrainingSession(supabase, sessionId, user.id)
+    return NextResponse.json(result)
+  } catch (err) {
+    console.error('[training-eval]', err)
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Evaluation failed' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/components/marathon/SessionCard.tsx
+++ b/src/components/marathon/SessionCard.tsx
@@ -115,7 +115,7 @@ export function SessionCard({ planned, actual, date, isToday, compact }: Session
       {/* Actual results */}
       {actual && status !== 'pending' && (
         <div className={cn(
-          'rounded-lg p-3 space-y-1 text-sm',
+          'rounded-lg p-3 space-y-2 text-sm',
           wentTooFast ? 'bg-amber-400/10 border border-amber-400/20' : 'bg-white/5',
         )}>
           <div className="flex gap-4 font-mono text-xs flex-wrap">
@@ -127,8 +127,34 @@ export function SessionCard({ planned, actual, date, isToday, compact }: Session
               </span>
             )}
             {actual.actual_avg_hr && <span className="text-white/50">HR {actual.actual_avg_hr}</span>}
+            {actual.flag && (
+              <span className={cn(
+                'inline-flex items-center gap-1 text-xs font-medium',
+                actual.flag === 'ok' ? 'text-emerald-400' :
+                actual.flag === 'warning' ? 'text-amber-400' : 'text-red-400',
+              )}>
+                <span className={cn(
+                  'h-1.5 w-1.5 rounded-full',
+                  actual.flag === 'ok' ? 'bg-emerald-400' :
+                  actual.flag === 'warning' ? 'bg-amber-400' : 'bg-red-400',
+                )} />
+                {actual.flag}
+              </span>
+            )}
           </div>
           {actual.notes && <p className="text-xs text-white/40">{actual.notes}</p>}
+          {actual.coach_notes && (
+            <details className="group">
+              <summary className="cursor-pointer text-xs text-violet-400/70 hover:text-violet-400 transition-colors list-none flex items-center gap-1 select-none">
+                <span className="group-open:hidden">▶</span>
+                <span className="hidden group-open:inline">▼</span>
+                Coach notes
+              </summary>
+              <div className="mt-2 text-xs text-white/60 leading-relaxed whitespace-pre-wrap border-t border-white/10 pt-2">
+                {actual.coach_notes}
+              </div>
+            </details>
+          )}
         </div>
       )}
 

--- a/src/components/marathon/SessionLogForm.tsx
+++ b/src/components/marathon/SessionLogForm.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { z } from 'zod'
-import { CheckCircle2, Loader2 } from 'lucide-react'
+import { CheckCircle2, Loader2, ArrowRight } from 'lucide-react'
 import { PaceDisciplineAlert } from './PaceDisciplineAlert'
 import { checkWentTooFast, SESSION_TYPE_LABELS } from '@/lib/marathon/plan'
 import type { PlannedSession } from '@/lib/marathon/plan'
@@ -47,6 +47,8 @@ export function SessionLogForm({ date, planned, weekNumber, existingActual }: Se
   const [showAlert, setShowAlert] = useState(false)
   const [alertData, setAlertData] = useState<{ actual: string; deviation: number } | null>(null)
   const [acknowledged, setAcknowledged] = useState(false)
+  const [isEvaluating, setIsEvaluating] = useState(false)
+  const [evalResult, setEvalResult] = useState<{ evaluation: string; flag: string } | null>(null)
 
   const isRest = planned.type === 'REST'
   const needsWarmup = ['TEMPO', 'VO2_MAX'].includes(planned.type)
@@ -136,10 +138,31 @@ export function SessionLogForm({ date, planned, weekNumber, existingActual }: Se
       }
 
       setSaved(true)
-      startTransition(() => {
-        router.refresh()
-        setTimeout(() => router.push('/marathon'), 1500)
-      })
+      startTransition(() => { router.refresh() })
+
+      // Fetch session ID then trigger eval
+      try {
+        setIsEvaluating(true)
+        const sessionRes = await fetch(`/api/marathon/session/${date}`)
+        const sessionData = sessionRes.ok ? await sessionRes.json() : null
+        const sessionId = sessionData?.id
+
+        if (sessionId) {
+          const evalRes = await fetch('/api/ai/training-eval', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sessionId }),
+          })
+          if (evalRes.ok) {
+            const data = await evalRes.json()
+            setEvalResult(data)
+          }
+        }
+      } catch {
+        // eval failed silently — user can still navigate away
+      } finally {
+        setIsEvaluating(false)
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to save session')
     }
@@ -147,10 +170,39 @@ export function SessionLogForm({ date, planned, weekNumber, existingActual }: Se
 
   if (saved) {
     return (
-      <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
-        <CheckCircle2 className="h-10 w-10 text-emerald-400" />
-        <p className="text-lg font-semibold text-white">Session logged</p>
-        <p className="text-sm text-white/40">Redirecting to training hub…</p>
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <CheckCircle2 className="h-6 w-6 text-emerald-400 shrink-0" />
+          <p className="text-base font-semibold text-white">Session logged</p>
+        </div>
+
+        {isEvaluating && (
+          <div className="flex items-center gap-3 rounded-xl border border-violet-500/20 bg-violet-500/10 px-4 py-4">
+            <Loader2 className="h-4 w-4 animate-spin text-violet-400 shrink-0" />
+            <p className="text-sm text-violet-300">Coach is evaluating your session…</p>
+          </div>
+        )}
+
+        {evalResult && (
+          <div className="rounded-xl border border-violet-500/30 bg-violet-500/10 p-5 space-y-3">
+            <div className="flex items-center gap-2">
+              <span className={`h-2.5 w-2.5 rounded-full shrink-0 ${
+                evalResult.flag === 'ok' ? 'bg-emerald-400' :
+                evalResult.flag === 'warning' ? 'bg-amber-400' : 'bg-red-400'
+              }`} />
+              <span className="text-xs font-semibold text-violet-300 uppercase tracking-wider">Coach Evaluation</span>
+            </div>
+            <div className="text-sm text-white/80 leading-relaxed whitespace-pre-wrap">{evalResult.evaluation}</div>
+          </div>
+        )}
+
+        <a
+          href="/marathon"
+          className="flex items-center gap-2 text-sm text-white/40 hover:text-white/70 transition-colors"
+        >
+          Back to training hub
+          <ArrowRight className="h-3.5 w-3.5" />
+        </a>
       </div>
     )
   }
@@ -163,14 +215,26 @@ export function SessionLogForm({ date, planned, weekNumber, existingActual }: Se
           actualPace={alertData.actual}
           deviationSec={alertData.deviation}
           sessionType={planned.type}
-          onAcknowledge={() => {
+          onAcknowledge={async () => {
             setAcknowledged(true)
             setShowAlert(false)
             setSaved(true)
-            startTransition(() => {
-              router.refresh()
-              setTimeout(() => router.push('/marathon'), 1500)
-            })
+            startTransition(() => { router.refresh() })
+            try {
+              setIsEvaluating(true)
+              const sessionRes = await fetch(`/api/marathon/session/${date}`)
+              const sessionData = sessionRes.ok ? await sessionRes.json() : null
+              if (sessionData?.id) {
+                const evalRes = await fetch('/api/ai/training-eval', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ sessionId: sessionData.id }),
+                })
+                if (evalRes.ok) setEvalResult(await evalRes.json())
+              }
+            } catch { /* silent */ } finally {
+              setIsEvaluating(false)
+            }
           }}
         />
       )}

--- a/src/lib/ai/master-coach.ts
+++ b/src/lib/ai/master-coach.ts
@@ -30,6 +30,8 @@ Coaching philosophy:
 - Before making a significant change (like pausing a prescribed supplement), confirm intent if the user's message is ambiguous.
 - You can create tasks for the user using the create_task tool. When a user mentions something they need to do, remember, or follow up on, proactively offer to add it as a task. Always confirm after creating: "Added to your tasks: [title] for [date]."
 - You can see all pending tasks in context. Reference them when relevant — e.g. if user asks about today's plan, include their pending tasks.
+- You can evaluate a completed training session using the evaluate_training_session tool. Use it when asked to review, rate, or analyse a session. The evaluation includes a Verdict / Analysis / Next 24h structure and sets a flag (ok/warning/rest) on the session.
+- Marathon sessions in context include a [flag] and first 80 chars of coach notes where available. Use these to spot patterns across sessions.
 - Format responses with clear sections. Use markdown. Keep responses under 500 words unless doing multi-week analysis.
 - When you use a tool, briefly acknowledge what you changed and why.`
 
@@ -104,7 +106,7 @@ export async function buildFullSystemContext(supabase: SupabaseClient): Promise<
 
     supabase
       .from('training_sessions')
-      .select('session_date, session_type, planned_description, completed, actual_distance_km, actual_duration_min, perceived_effort, coach_notes, flag')
+      .select('session_date, planned_type, planned_description, status, actual_km, actual_duration_min, perceived_effort, went_too_fast, coach_notes, flag')
       .eq('user_id', user.id)
       .gte('session_date', cutoff7Str)
       .order('session_date', { ascending: false }),
@@ -256,12 +258,23 @@ export async function buildFullSystemContext(supabase: SupabaseClient): Promise<
   // ── Marathon Plan ───────────────────────────────────────────────
   if (marathonSessionsRes.status === 'fulfilled' && marathonSessionsRes.value.data?.length) {
     const sessions = marathonSessionsRes.value.data
-    const lines = sessions.map((s) => {
-      const done = s.completed ? '✅' : '⬜'
-      const dist = s.actual_distance_km ? ` ${s.actual_distance_km}km` : ''
+    const lines = sessions.map((s: {
+      session_date: string
+      planned_type: string
+      status: string
+      actual_km: number | null
+      perceived_effort: number | null
+      went_too_fast: boolean
+      coach_notes: string | null
+      flag: string | null
+    }) => {
+      const done = s.status === 'completed' || s.status === 'modified' ? '✅' : s.status === 'skipped' ? '❌' : '⬜'
+      const dist = s.actual_km ? ` ${s.actual_km}km` : ''
       const effort = s.perceived_effort ? ` RPE:${s.perceived_effort}` : ''
-      const flag = s.flag ? ` ⚠️ ${s.flag}` : ''
-      return `- ${s.session_date} ${done} ${s.session_type}${dist}${effort}${flag}`
+      const fast = s.went_too_fast ? ' ⚠️ too fast' : ''
+      const flagStr = s.flag ? ` [${s.flag}]` : ''
+      const noteSnippet = s.coach_notes ? `\n  Coach: ${s.coach_notes.slice(0, 80)}…` : ''
+      return `- ${s.session_date} ${done} ${s.planned_type}${dist}${effort}${fast}${flagStr}${noteSnippet}`
     })
     sections.push(`## Marathon Training Sessions (last 7 days)\n${lines.join('\n')}`)
   }

--- a/src/lib/ai/training-evaluation.ts
+++ b/src/lib/ai/training-evaluation.ts
@@ -1,0 +1,179 @@
+// Shared training session evaluation logic
+// Called by both /api/ai/training-eval (post-session flow) and the coach evaluate_training_session tool.
+
+import { google } from '@ai-sdk/google'
+import { generateText } from 'ai'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+const EVAL_SYSTEM_PROMPT = `You are the training coach for a 43yo female marathon runner (Belfast Marathon April 19, goal 3:32). She trains fasted at 4-5am. Key problem: going too fast on easy runs.
+
+You receive one completed training session + 14-day context. Write a concise post-session evaluation in exactly three sections:
+
+## Verdict
+One sentence: overall quality assessment. Include flag: OK ✅ / WARNING ⚠️ / REST 🔴.
+
+## Analysis
+3-5 bullets. Be specific — reference actual numbers. Flag: pace discipline, HR response, RPE vs effort type, warmup/fuel compliance, any deviation from plan. Cross-reference morning readiness if provided.
+
+## Next 24h
+2-3 bullets. Concrete recovery or adaptation actions: sleep, nutrition, tomorrow's session adjustments, supplement timing. If this was a high-load session or RPE ≥ 7, specify recovery actions explicitly.
+
+Rules:
+- No fluff. No "great job". Be a coach, not a cheerleader.
+- If she went too fast, say it directly and tell her what to do next time.
+- Keep total response under 300 words.`
+
+function formatPace(secPerKm: number): string {
+  const m = Math.floor(secPerKm / 60)
+  const s = Math.round(secPerKm % 60)
+  return `${m}:${String(s).padStart(2, '0')}/km`
+}
+
+export async function evaluateTrainingSession(
+  supabase: SupabaseClient,
+  sessionId: string,
+  userId: string,
+): Promise<{ evaluation: string; flag: string }> {
+  // ── 1. Fetch session ────────────────────────────────────────────────────
+  const { data: session, error } = await supabase
+    .from('training_sessions')
+    .select('*')
+    .eq('id', sessionId)
+    .eq('user_id', userId)
+    .single()
+
+  if (error || !session) throw new Error('Session not found or not owned by user')
+
+  // Return cached evaluation
+  if (session.coach_notes) {
+    return { evaluation: session.coach_notes, flag: session.flag ?? 'ok' }
+  }
+
+  // ── 2. Determine flag ───────────────────────────────────────────────────
+  let flag = 'ok'
+  if (session.planned_type === 'REST' || session.status === 'skipped') {
+    flag = 'rest'
+  } else {
+    const highEffort = session.perceived_effort != null && session.perceived_effort >= 7
+    const tooFast = session.went_too_fast === true
+    const bigDeviation =
+      session.planned_km && session.actual_km
+        ? Math.abs(session.actual_km - session.planned_km) / session.planned_km > 0.2
+        : false
+    if (highEffort || tooFast || bigDeviation) flag = 'warning'
+  }
+
+  // ── 3. Calculate pace ───────────────────────────────────────────────────
+  let computedPace: string | null = null
+  if (session.actual_km && session.actual_duration_min && session.actual_km > 0) {
+    const secPerKm = (session.actual_duration_min * 60) / session.actual_km
+    computedPace = formatPace(secPerKm)
+  }
+
+  // ── 4. Fetch supporting data in parallel ────────────────────────────────
+  const [configsRes, morningRes, recentRes] = await Promise.allSettled([
+    supabase
+      .from('plan_configs')
+      .select('config_key, config_value, config_label')
+      .eq('user_id', userId)
+      .in('module', ['running', 'marathon']),
+
+    supabase
+      .from('morning_logs')
+      .select('resting_hr_bpm, sleep_hours, sleep_quality, energy_level, mood, body_readiness')
+      .eq('user_id', userId)
+      .eq('log_date', session.session_date)
+      .maybeSingle(),
+
+    supabase
+      .from('training_sessions')
+      .select('session_date, planned_type, status, actual_km, actual_duration_min, perceived_effort, went_too_fast')
+      .eq('user_id', userId)
+      .neq('status', 'pending')
+      .neq('id', sessionId)
+      .order('session_date', { ascending: false })
+      .limit(7),
+  ])
+
+  // ── 5. Build prompt ─────────────────────────────────────────────────────
+  const sessionBlock = [
+    `Date: ${session.session_date}`,
+    `Type: ${session.planned_type}`,
+    `Status: ${session.status}`,
+    session.planned_km ? `Planned distance: ${session.planned_km}km` : null,
+    session.actual_km ? `Actual distance: ${session.actual_km}km` : null,
+    computedPace ? `Computed pace: ${computedPace}` : session.actual_avg_pace ? `Pace: ${session.actual_avg_pace}/km` : null,
+    session.actual_avg_hr ? `Avg HR: ${session.actual_avg_hr} bpm` : null,
+    session.actual_duration_min ? `Duration: ${session.actual_duration_min} min` : null,
+    session.perceived_effort != null ? `RPE: ${session.perceived_effort}/10` : null,
+    session.went_too_fast ? `⚠️ Went too fast (deviation: +${session.pace_deviation_sec}s/km from plan)` : null,
+    session.skipped_warmup ? `⚠️ Warmup skipped` : null,
+    session.warmup_done === true ? `Warmup completed` : null,
+    session.post_fuel_done === true ? `Post-run fuelling done within 30 min` : null,
+    session.resting_hr ? `Morning RHR: ${session.resting_hr} bpm` : null,
+    session.notes ? `Athlete notes: ${session.notes}` : null,
+  ].filter(Boolean).join('\n')
+
+  const morningLog =
+    morningRes.status === 'fulfilled' && morningRes.value.data
+      ? morningRes.value.data
+      : null
+
+  const morningBlock = morningLog
+    ? [
+        `## Morning Readiness (same day)`,
+        morningLog.resting_hr_bpm != null ? `RHR: ${morningLog.resting_hr_bpm} bpm` : null,
+        morningLog.sleep_hours != null ? `Sleep: ${morningLog.sleep_hours}h (quality ${morningLog.sleep_quality ?? '?'}/5)` : null,
+        morningLog.energy_level != null ? `Energy: ${morningLog.energy_level}/5` : null,
+        morningLog.mood != null ? `Mood: ${morningLog.mood}/5` : null,
+        morningLog.body_readiness != null ? `Body readiness: ${morningLog.body_readiness}/5` : null,
+      ].filter(Boolean).join('\n')
+    : null
+
+  const configs =
+    configsRes.status === 'fulfilled' ? configsRes.value.data ?? [] : []
+  const configBlock = configs.length
+    ? `## Target Paces / Plan Config\n` +
+      configs.map((c) => `- ${c.config_label}: ${c.config_value}`).join('\n')
+    : null
+
+  const recentSessions =
+    recentRes.status === 'fulfilled' ? recentRes.value.data ?? [] : []
+  const recentBlock = recentSessions.length
+    ? `## Recent Sessions (last 7)\n` +
+      recentSessions
+        .map((s: { session_date: string; planned_type: string; status: string; actual_km: number | null; perceived_effort: number | null; went_too_fast: boolean }) => {
+          const km = s.actual_km ? ` ${s.actual_km}km` : ''
+          const rpe = s.perceived_effort ? ` RPE:${s.perceived_effort}` : ''
+          const fast = s.went_too_fast ? ' ⚠️too fast' : ''
+          return `- ${s.session_date} ${s.planned_type} (${s.status})${km}${rpe}${fast}`
+        })
+        .join('\n')
+    : null
+
+  const prompt = [
+    `## Session to Evaluate`,
+    sessionBlock,
+    morningBlock,
+    configBlock,
+    recentBlock,
+  ].filter(Boolean).join('\n\n')
+
+  // ── 6. Generate evaluation ──────────────────────────────────────────────
+  const { text: evaluation } = await generateText({
+    model: google('gemini-2.5-flash'),
+    system: EVAL_SYSTEM_PROMPT,
+    prompt,
+    maxTokens: 600,
+    temperature: 0.35,
+  })
+
+  // ── 7. Persist to session row ───────────────────────────────────────────
+  await supabase
+    .from('training_sessions')
+    .update({ coach_notes: evaluation, flag })
+    .eq('id', sessionId)
+    .eq('user_id', userId)
+
+  return { evaluation, flag }
+}

--- a/src/lib/supabase/marathon.ts
+++ b/src/lib/supabase/marathon.ts
@@ -46,6 +46,8 @@ export interface TrainingSessionRow {
   skipped_warmup: boolean
   notes: string | null
   ai_feedback: string | null
+  coach_notes: string | null
+  flag: 'ok' | 'warning' | 'rest' | null
   resting_hr: number | null
   created_at: string
   updated_at: string

--- a/supabase/migrations/20260309000003_training_session_eval.sql
+++ b/supabase/migrations/20260309000003_training_session_eval.sql
@@ -1,0 +1,7 @@
+-- Add coach evaluation fields to training_sessions
+-- coach_notes: AI-generated post-session evaluation text
+-- flag: traffic-light status from coach evaluation
+
+ALTER TABLE training_sessions
+  ADD COLUMN IF NOT EXISTS coach_notes text,
+  ADD COLUMN IF NOT EXISTS flag text CHECK (flag IN ('ok', 'warning', 'rest'));


### PR DESCRIPTION
- Add coach_notes + flag columns to training_sessions (migration)
- Shared evaluateTrainingSession() in src/lib/ai/training-evaluation.ts
  - Fetches session, plan configs, morning log, last 7 sessions
  - Computes pace in TS, determines flag (ok/warning/rest)
  - Calls Gemini 2.5 Flash for 3-section eval (Verdict/Analysis/Next 24h)
  - Persists coach_notes + flag to session row; returns cached if set
- POST /api/ai/training-eval — thin wrapper around shared function
- SessionLogForm: after save, GETs session ID then POSTs to eval API
  - Shows loading spinner "Coach is evaluating your session…"
  - Renders evaluation card with violet border + flag dot
  - Removes auto-redirect; adds manual "Back to training hub" link
- SessionCard: flag dot (green/amber/red) + <details> expandable coach_notes
- TrainingSessionRow type: adds coach_notes + flag fields
- Coach API: evaluate_training_session tool (evaluates latest if no ID given)
- master-coach.ts: fix marathon sessions query (correct column names: planned_type/status/actual_km/went_too_fast); format includes flag + first 80 chars of coach_notes; system prompt updated
- morning-briefing: fix training session query columns; add yesterday's completed session with flag/coach_notes snippet; updated system prompt to reference yesterday's training in Today's Focus

https://claude.ai/code/session_0151Ye69WomJSejbZE69KaQZ