### PR TITLE
feat: Phase 5 — proactive intelligence layer

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,2 +1,14 @@
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-project-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+
+# Supabase service role — used by cron endpoint only (never expose to browser)
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
+
+# Vercel Cron security — set to a random secret, add to Vercel env vars too
+CRON_SECRET=your-random-secret-here
+
+# Web Push VAPID keys — generate at https://web-push-codelab.glitch.me/
+# Add all three to Vercel environment variables for push notifications to work
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_EMAIL=mailto:your@email.com

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,14 @@ P0 — Foundation (auth, app shell, DB schema, deployment)
 ## Database
 See /docs/schema.md for full table reference
 
+## Environment variables (must be set in Vercel)
+- `SUPABASE_SERVICE_ROLE_KEY` — used by cron endpoint (`/api/cron/daily-digest`) to bypass RLS
+- `CRON_SECRET` — random secret; Vercel sends it as `Authorization: Bearer <secret>` header
+- `NEXT_PUBLIC_VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_EMAIL` — web push VAPID keys
+  Generate at https://web-push-codelab.glitch.me/
+
 ## Don't do
 - Never hardcode user IDs
 - Never disable RLS
 - Never commit .env files
+- Never use `createServiceClient()` in browser-side code — service role bypasses all RLS

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,5 +1,6 @@
 import { Sidebar } from "@/components/layout/sidebar";
 import { GlobalCoachPanel } from "@/components/layout/GlobalCoachPanel";
+import { ProactiveBanner } from "@/components/proactive/ProactiveBanner";
 
 export default function DashboardLayout({
   children,
@@ -11,6 +12,7 @@ export default function DashboardLayout({
       <Sidebar />
       {/* Main content — offset on mobile to account for fixed top bar */}
       <main className="flex-1 overflow-y-auto p-4 pt-18 sm:p-6 lg:pt-6">
+        <ProactiveBanner />
         {children}
       </main>
       {/* Persistent floating Life Coach — accessible from any page */}

--- a/src/app/api/ai/proactive-greeting/route.ts
+++ b/src/app/api/ai/proactive-greeting/route.ts
@@ -1,0 +1,141 @@
+// GET /api/ai/proactive-greeting
+// Called once per day on dashboard load (client caches in sessionStorage).
+// Returns check-in status + proactive flags derived from user data.
+
+import { NextResponse } from 'next/server'
+import { google } from '@ai-sdk/google'
+import { generateText } from 'ai'
+import { createClient } from '@/lib/supabase/server'
+
+export const runtime = 'nodejs'
+export const maxDuration = 30
+
+export type ProactiveFlag = 'unlogged_training' | 'alcohol_yesterday' | 'low_energy_pattern'
+
+export interface ProactiveGreetingResponse {
+  type: 'none' | 'needs_checkin' | 'complete_briefing'
+  message?: string
+  flags: ProactiveFlag[]
+}
+
+export async function GET() {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const todayStr = new Date().toISOString().slice(0, 10)
+  const yesterdayStr = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10)
+
+  // Fetch all context in parallel
+  const [logRes, sessionRes, yestSessionRes, yestNutritionRes, recentLogsRes] =
+    await Promise.allSettled([
+      supabase
+        .from('morning_logs')
+        .select('id, ai_briefing')
+        .eq('user_id', user.id)
+        .eq('log_date', todayStr)
+        .maybeSingle(),
+
+      supabase
+        .from('training_sessions')
+        .select('planned_type, planned_km, status')
+        .eq('user_id', user.id)
+        .eq('session_date', todayStr)
+        .maybeSingle(),
+
+      supabase
+        .from('training_sessions')
+        .select('flag')
+        .eq('user_id', user.id)
+        .eq('session_date', yesterdayStr)
+        .maybeSingle(),
+
+      supabase
+        .from('nutrition_logs')
+        .select('has_alcohol')
+        .eq('user_id', user.id)
+        .eq('log_date', yesterdayStr)
+        .maybeSingle(),
+
+      // Last 3 morning logs for energy pattern check
+      supabase
+        .from('morning_logs')
+        .select('energy_level')
+        .eq('user_id', user.id)
+        .order('log_date', { ascending: false })
+        .limit(3),
+    ])
+
+  const todayLog = logRes.status === 'fulfilled' ? logRes.value.data : null
+  const todaySession = sessionRes.status === 'fulfilled' ? sessionRes.value.data : null
+  const yestSession = yestSessionRes.status === 'fulfilled' ? yestSessionRes.value.data : null
+  const yestNutrition = yestNutritionRes.status === 'fulfilled' ? yestNutritionRes.value.data : null
+  const recentLogs = recentLogsRes.status === 'fulfilled' ? (recentLogsRes.value.data ?? []) : []
+
+  // ── Determine check-in type ─────────────────────────────────────────────
+  let type: ProactiveGreetingResponse['type'] = 'none'
+  let message: string | undefined
+
+  if (!todayLog) {
+    type = 'needs_checkin'
+
+    // Generate personalised nudge via Gemini
+    const sessionStr = todaySession
+      ? `Today has a ${todaySession.planned_type} session${todaySession.planned_km ? ` (${todaySession.planned_km}km)` : ''} planned.`
+      : 'No training session planned today.'
+
+    const yesterdayFlagStr = yestSession?.flag
+      ? `Yesterday's session flag: ${yestSession.flag}.`
+      : ''
+
+    try {
+      const { text } = await generateText({
+        model: google('gemini-2.5-flash'),
+        system:
+          'Write a one-sentence morning greeting (max 80 chars) nudging the user to log their morning check-in. Reference today\'s planned training if relevant. Be direct, no fluff. Example: "Tempo today — log your morning vitals before heading out."',
+        prompt: [sessionStr, yesterdayFlagStr].filter(Boolean).join(' '),
+        maxTokens: 40,
+        temperature: 0.5,
+      })
+      message = text.trim().slice(0, 80)
+    } catch {
+      message = todaySession
+        ? `${todaySession.planned_type} planned today — log your morning vitals first.`
+        : 'Log your morning check-in to start your day.'
+    }
+  } else if (!todayLog.ai_briefing) {
+    type = 'complete_briefing'
+  }
+
+  // ── Build proactive flags ───────────────────────────────────────────────
+  const flags: ProactiveFlag[] = []
+
+  // Unlogged training: has session today, past 06:00 UTC (~08:00 Cyprus), not completed
+  if (
+    todaySession &&
+    todaySession.planned_type !== 'REST' &&
+    todaySession.status !== 'completed' &&
+    todaySession.status !== 'modified' &&
+    new Date().getUTCHours() >= 6
+  ) {
+    flags.push('unlogged_training')
+  }
+
+  // Alcohol yesterday
+  if (yestNutrition?.has_alcohol === true) {
+    flags.push('alcohol_yesterday')
+  }
+
+  // Low energy pattern: last 3 logs all have energy_level < 3
+  if (
+    recentLogs.length >= 3 &&
+    recentLogs.every((l) => l.energy_level != null && l.energy_level < 3)
+  ) {
+    flags.push('low_energy_pattern')
+  }
+
+  const response: ProactiveGreetingResponse = { type, flags }
+  if (message) response.message = message
+
+  return NextResponse.json(response)
+}

--- a/src/app/api/cron/daily-digest/route.ts
+++ b/src/app/api/cron/daily-digest/route.ts
@@ -1,0 +1,178 @@
+// GET /api/cron/daily-digest
+// Vercel cron job — runs at 02:30 UTC (≈ 05:30 Cyprus time).
+// Sends a personalised push notification to every subscribed user.
+// Secured by CRON_SECRET env var.
+
+import { NextRequest, NextResponse } from 'next/server'
+import { google } from '@ai-sdk/google'
+import { generateText } from 'ai'
+import webpush from 'web-push'
+import { createServiceClient } from '@/lib/supabase/service'
+
+export const runtime = 'nodejs'
+export const maxDuration = 300
+
+const DIGEST_PROMPT = `You are the Life OS morning digest generator. Write a push notification body (max 120 characters) that gives the user their most important focus for today. Mention the training session if there is one, or flag a task if not. Be direct and specific. No fluff.
+
+Examples:
+"Long run 18km today. 3 tasks pending. Check-in when you wake up."
+"Rest day. Trading prep + 2 tasks due. Log your morning vitals."
+"Tempo 8km at 4:45/km. No alcohol yesterday — good. Stay sharp."`
+
+export async function GET(req: NextRequest) {
+  // ── Security ────────────────────────────────────────────────────────────
+  const authHeader = req.headers.get('authorization')
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
+
+  // ── VAPID setup ─────────────────────────────────────────────────────────
+  if (!process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY || !process.env.VAPID_PRIVATE_KEY || !process.env.VAPID_EMAIL) {
+    console.error('[daily-digest] VAPID env vars not set — skipping push')
+    return NextResponse.json({ error: 'VAPID not configured' }, { status: 500 })
+  }
+
+  webpush.setVapidDetails(
+    process.env.VAPID_EMAIL,
+    process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY,
+    process.env.VAPID_PRIVATE_KEY,
+  )
+
+  const supabase = createServiceClient()
+  const todayStr = new Date().toISOString().slice(0, 10)
+
+  // ── Fetch all users with push subscriptions ─────────────────────────────
+  const { data: subscriptions, error: subErr } = await supabase
+    .from('push_subscriptions')
+    .select('user_id, endpoint, p256dh, auth_key')
+
+  if (subErr || !subscriptions?.length) {
+    return NextResponse.json({ sent: 0, skipped: 0, message: 'No subscriptions found.' })
+  }
+
+  // Group subscriptions by user_id
+  const byUser = new Map<string, typeof subscriptions>()
+  for (const sub of subscriptions) {
+    const existing = byUser.get(sub.user_id) ?? []
+    existing.push(sub)
+    byUser.set(sub.user_id, existing)
+  }
+
+  let sent = 0
+  let skipped = 0
+
+  for (const [userId, userSubs] of byUser) {
+    // Skip if digest already sent today
+    const { data: existing } = await supabase
+      .from('daily_digest_log')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('digest_date', todayStr)
+      .maybeSingle()
+
+    if (existing) {
+      skipped++
+      continue
+    }
+
+    // Build context for this user
+    const [sessionRes, tasksRes, morningRes, nutritionRes] = await Promise.allSettled([
+      supabase
+        .from('training_sessions')
+        .select('planned_type, planned_description, planned_km')
+        .eq('user_id', userId)
+        .eq('session_date', todayStr)
+        .maybeSingle(),
+
+      supabase
+        .from('coach_tasks')
+        .select('title')
+        .eq('user_id', userId)
+        .eq('due_date', todayStr)
+        .is('completed_at', null),
+
+      supabase
+        .from('morning_logs')
+        .select('energy_level, resting_hr_bpm, sleep_hours')
+        .eq('user_id', userId)
+        .order('log_date', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+
+      supabase
+        .from('nutrition_logs')
+        .select('has_alcohol')
+        .eq('user_id', userId)
+        .eq('log_date', new Date(Date.now() - 86_400_000).toISOString().slice(0, 10))
+        .maybeSingle(),
+    ])
+
+    const session = sessionRes.status === 'fulfilled' ? sessionRes.value.data : null
+    const tasks = tasksRes.status === 'fulfilled' ? (tasksRes.value.data ?? []) : []
+    const lastLog = morningRes.status === 'fulfilled' ? morningRes.value.data : null
+    const yestNutrition = nutritionRes.status === 'fulfilled' ? nutritionRes.value.data : null
+
+    const context = [
+      session
+        ? `Today's training: ${session.planned_type}${session.planned_km ? ` ${session.planned_km}km` : ''}${session.planned_description ? ` — ${session.planned_description}` : ''}`
+        : `Today's training: rest day or not scheduled`,
+      tasks.length ? `${tasks.length} task(s) due today` : `No tasks due today`,
+      lastLog
+        ? `Last morning log: energy ${lastLog.energy_level ?? '?'}/5, HR ${lastLog.resting_hr_bpm ?? '?'}bpm, sleep ${lastLog.sleep_hours ?? '?'}h`
+        : `No recent morning log`,
+      yestNutrition?.has_alcohol ? `Alcohol consumed yesterday` : null,
+    ].filter(Boolean).join('. ')
+
+    // Generate digest text
+    let digestText: string
+    try {
+      const { text } = await generateText({
+        model: google('gemini-2.5-flash'),
+        system: DIGEST_PROMPT,
+        prompt: context,
+        maxTokens: 80,
+        temperature: 0.4,
+      })
+      digestText = text.trim().slice(0, 120)
+    } catch (err) {
+      console.error(`[daily-digest] Gemini failed for user ${userId}:`, err)
+      // Fallback to simple message
+      digestText = session
+        ? `${session.planned_type} today${session.planned_km ? ` — ${session.planned_km}km` : ''}. Check in when you wake up.`
+        : `Morning check-in ready. ${tasks.length} task(s) due today.`
+    }
+
+    // Send push to all user's subscriptions
+    let userSent = false
+    for (const sub of userSubs) {
+      try {
+        await webpush.sendNotification(
+          { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth_key } },
+          JSON.stringify({ title: 'Life OS', body: digestText, icon: '/icons/icon-192.png' }),
+        )
+        userSent = true
+      } catch (err) {
+        console.error(`[daily-digest] Push failed for endpoint ${sub.endpoint.slice(0, 40)}:`, err)
+        // Remove expired/invalid subscriptions (410 Gone)
+        if ((err as { statusCode?: number }).statusCode === 410) {
+          await supabase
+            .from('push_subscriptions')
+            .delete()
+            .eq('endpoint', sub.endpoint)
+        }
+      }
+    }
+
+    if (userSent) {
+      // Record in daily_digest_log to prevent re-send
+      await supabase.from('daily_digest_log').insert({
+        user_id: userId,
+        digest_date: todayStr,
+        digest_text: digestText,
+      })
+      sent++
+    }
+  }
+
+  return NextResponse.json({ sent, skipped, total: byUser.size })
+}

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -1,0 +1,37 @@
+// POST /api/push/subscribe — upsert a web push subscription
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function POST(req: NextRequest) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { subscription } = (await req.json()) as {
+    subscription: { endpoint: string; keys: { p256dh: string; auth: string } }
+  }
+
+  if (!subscription?.endpoint || !subscription?.keys?.p256dh || !subscription?.keys?.auth) {
+    return NextResponse.json({ error: 'Invalid subscription object' }, { status: 400 })
+  }
+
+  const { error } = await supabase
+    .from('push_subscriptions')
+    .upsert(
+      {
+        user_id: user.id,
+        endpoint: subscription.endpoint,
+        p256dh: subscription.keys.p256dh,
+        auth_key: subscription.keys.auth,
+      },
+      { onConflict: 'endpoint' },
+    )
+
+  if (error) {
+    console.error('[push/subscribe]', error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/push/unsubscribe/route.ts
+++ b/src/app/api/push/unsubscribe/route.ts
@@ -1,0 +1,26 @@
+// POST /api/push/unsubscribe — remove a web push subscription
+
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+export async function POST(req: NextRequest) {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { endpoint } = (await req.json()) as { endpoint: string }
+  if (!endpoint) return NextResponse.json({ error: 'endpoint required' }, { status: 400 })
+
+  const { error } = await supabase
+    .from('push_subscriptions')
+    .delete()
+    .eq('endpoint', endpoint)
+    .eq('user_id', user.id)
+
+  if (error) {
+    console.error('[push/unsubscribe]', error)
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/src/components/notifications/notification-setup.tsx
+++ b/src/components/notifications/notification-setup.tsx
@@ -3,6 +3,10 @@
 import { useEffect, useState } from "react";
 import { Bell, BellOff } from "lucide-react";
 
+// VAPID public key — generate a key pair at https://web-push-codelab.glitch.me/
+// Set NEXT_PUBLIC_VAPID_PUBLIC_KEY in your Vercel / .env.local environment variables.
+const VAPID_PUBLIC_KEY = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY ?? '';
+
 // Converts a base64 URL-safe string to a Uint8Array (required by PushManager)
 function urlBase64ToUint8Array(base64String: string): Uint8Array {
   const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
@@ -40,26 +44,22 @@ export function NotificationSetup() {
   }, []);
 
   async function subscribe() {
+    if (!VAPID_PUBLIC_KEY) {
+      console.warn('[NotificationSetup] NEXT_PUBLIC_VAPID_PUBLIC_KEY is not set.');
+      return;
+    }
     setStatus("checking");
     try {
-      const res = await fetch("/api/notifications/vapid-public-key");
-      if (!res.ok) throw new Error("VAPID key unavailable");
-      const { publicKey } = (await res.json()) as { publicKey: string };
-
       const reg = await navigator.serviceWorker.ready;
       const sub = await reg.pushManager.subscribe({
         userVisibleOnly: true,
-        applicationServerKey: urlBase64ToUint8Array(publicKey),
+        applicationServerKey: urlBase64ToUint8Array(VAPID_PUBLIC_KEY),
       });
 
-      const json = sub.toJSON();
-      await fetch("/api/notifications/subscribe", {
+      await fetch("/api/push/subscribe", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          endpoint: sub.endpoint,
-          keys: json.keys,
-        }),
+        body: JSON.stringify({ subscription: sub.toJSON() }),
       });
 
       setStatus("subscribed");
@@ -74,8 +74,8 @@ export function NotificationSetup() {
       const reg = await navigator.serviceWorker.ready;
       const sub = await reg.pushManager.getSubscription();
       if (sub) {
-        await fetch("/api/notifications/subscribe", {
-          method: "DELETE",
+        await fetch("/api/push/unsubscribe", {
+          method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ endpoint: sub.endpoint }),
         });
@@ -115,7 +115,7 @@ export function NotificationSetup() {
   return (
     <button
       onClick={subscribe}
-      title="Enable daily reminders (8 am check-in, 4 pm trading)"
+      title="Enable daily digest at 05:30 (Cyprus time)"
       className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs font-medium text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
     >
       <Bell className="h-3.5 w-3.5" />

--- a/src/components/proactive/ProactiveBanner.tsx
+++ b/src/components/proactive/ProactiveBanner.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { X, ArrowRight } from 'lucide-react'
+import type { ProactiveGreetingResponse, ProactiveFlag } from '@/app/api/ai/proactive-greeting/route'
+
+// Cache keys — scoped to today so banner re-appears tomorrow
+function todayKey(suffix: string) {
+  return `proactive-${new Date().toISOString().slice(0, 10)}-${suffix}`
+}
+
+export function ProactiveBanner() {
+  const [data, setData] = useState<ProactiveGreetingResponse | null>(null)
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    const cacheKey = todayKey('greeting')
+    const cached = sessionStorage.getItem(cacheKey)
+
+    if (cached) {
+      try {
+        setData(JSON.parse(cached))
+      } catch {
+        sessionStorage.removeItem(cacheKey)
+      }
+    } else {
+      fetch('/api/ai/proactive-greeting')
+        .then((r) => r.json())
+        .then((res: ProactiveGreetingResponse) => {
+          sessionStorage.setItem(cacheKey, JSON.stringify(res))
+          setData(res)
+        })
+        .catch(() => {/* silent — non-critical */})
+    }
+
+    // Restore dismissed state from sessionStorage
+    const dismissedKey = todayKey('dismissed')
+    const savedDismissed = sessionStorage.getItem(dismissedKey)
+    if (savedDismissed) {
+      try {
+        setDismissed(new Set(JSON.parse(savedDismissed)))
+      } catch { /* ignore */ }
+    }
+  }, [])
+
+  function dismiss(key: string) {
+    setDismissed((prev) => {
+      const next = new Set(prev)
+      next.add(key)
+      sessionStorage.setItem(todayKey('dismissed'), JSON.stringify([...next]))
+      return next
+    })
+  }
+
+  if (!data) return null
+
+  const showMainBanner = (data.type === 'needs_checkin' || data.type === 'complete_briefing') && !dismissed.has('main')
+
+  return (
+    <div className="space-y-2 mb-4">
+      {/* Main check-in banner */}
+      {showMainBanner && (
+        <div className="flex items-center justify-between gap-3 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <span className="text-base shrink-0">🌅</span>
+            <p className="text-sm text-amber-200 truncate">
+              {data.type === 'needs_checkin' && data.message
+                ? data.message
+                : 'Your morning check-in is ready — add your briefing.'}
+            </p>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <a
+              href="/dashboard"
+              className="flex items-center gap-1 text-xs font-semibold text-amber-300 hover:text-amber-200 transition-colors whitespace-nowrap"
+            >
+              Log Check-In
+              <ArrowRight className="h-3 w-3" />
+            </a>
+            <button
+              onClick={() => dismiss('main')}
+              className="text-amber-400/60 hover:text-amber-400 transition-colors"
+              aria-label="Dismiss"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Proactive flags */}
+      {data.flags.map((flag) => {
+        if (dismissed.has(flag)) return null
+        return <FlagBanner key={flag} flag={flag} onDismiss={() => dismiss(flag)} />
+      })}
+    </div>
+  )
+}
+
+function FlagBanner({ flag, onDismiss }: { flag: ProactiveFlag; onDismiss: () => void }) {
+  const config: Record<ProactiveFlag, { icon: string; text: string; classes: string }> = {
+    alcohol_yesterday: {
+      icon: '⚠️',
+      text: 'Alcohol logged yesterday. Consider reduced position size when trading today.',
+      classes: 'border-red-500/30 bg-red-500/10 text-red-200',
+    },
+    unlogged_training: {
+      icon: '🏃',
+      text: 'You have a training session due today. Log it when done so the coach can evaluate it.',
+      classes: 'border-blue-500/30 bg-blue-500/10 text-blue-200',
+    },
+    low_energy_pattern: {
+      icon: '📉',
+      text: 'Energy has been low for 3+ days. Coach recommendation available — ask in the chat.',
+      classes: 'border-violet-500/30 bg-violet-500/10 text-violet-200',
+    },
+  }
+
+  const { icon, text, classes } = config[flag]
+
+  return (
+    <div className={`flex items-start justify-between gap-3 rounded-xl border px-4 py-3 ${classes}`}>
+      <div className="flex items-start gap-3 min-w-0">
+        <span className="text-base shrink-0 mt-0.5">{icon}</span>
+        <p className="text-sm leading-relaxed">{text}</p>
+      </div>
+      <button
+        onClick={onDismiss}
+        className="opacity-60 hover:opacity-100 transition-opacity shrink-0 mt-0.5"
+        aria-label="Dismiss"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  )
+}

--- a/src/lib/ai/master-coach.ts
+++ b/src/lib/ai/master-coach.ts
@@ -32,6 +32,8 @@ Coaching philosophy:
 - You can see all pending tasks in context. Reference them when relevant — e.g. if user asks about today's plan, include their pending tasks.
 - You can evaluate a completed training session using the evaluate_training_session tool. Use it when asked to review, rate, or analyse a session. The evaluation includes a Verdict / Analysis / Next 24h structure and sets a flag (ok/warning/rest) on the session.
 - Marathon sessions in context include a [flag] and first 80 chars of coach notes where available. Use these to spot patterns across sessions.
+- Proactive flags the UI may surface to the user: alcohol_yesterday (suggest reduced position size for trading that day), low_energy_pattern (3+ days avg energy < 3 — suggest recovery week or modified training load), unlogged_training (remind user to log their session after completion).
+- You have full visibility across all time-of-day contexts. The user may message you at 4am before a run, at 9am during trading, or at 10pm reviewing their day. Adapt your tone and focus accordingly.
 - Format responses with clear sections. Use markdown. Keep responses under 500 words unless doing multi-week analysis.
 - When you use a tool, briefly acknowledge what you changed and why.`
 

--- a/src/lib/supabase/service.ts
+++ b/src/lib/supabase/service.ts
@@ -1,0 +1,17 @@
+// Service-role Supabase client — bypasses RLS.
+// Use ONLY in server-side cron/admin routes. Never expose to the browser.
+
+import { createClient as createSupabaseClient } from '@supabase/supabase-js'
+
+export function createServiceClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!url || !key) {
+    throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY')
+  }
+
+  return createSupabaseClient(url, key, {
+    auth: { persistSession: false },
+  })
+}

--- a/supabase/migrations/20260309000004_proactive.sql
+++ b/supabase/migrations/20260309000004_proactive.sql
@@ -1,0 +1,35 @@
+-- Proactive intelligence layer: push subscriptions + daily digest log
+
+-- Store web push subscriptions (one per browser endpoint per user)
+CREATE TABLE push_subscriptions (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  endpoint   text NOT NULL UNIQUE,
+  p256dh     text NOT NULL,
+  auth_key   text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE push_subscriptions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "user owns push_subscriptions"
+  ON push_subscriptions FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- Track daily digest sends — prevents double-sending per user per day
+CREATE TABLE daily_digest_log (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  digest_date date NOT NULL DEFAULT current_date,
+  sent_at     timestamptz NOT NULL DEFAULT now(),
+  digest_text text,
+  UNIQUE (user_id, digest_date)
+);
+
+ALTER TABLE daily_digest_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "user owns daily_digest_log"
+  ON daily_digest_log FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/daily-digest",
+      "schedule": "30 2 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
DB:
- push_subscriptions table (endpoint, p256dh, auth_key, RLS)
- daily_digest_log table (prevents double-sending, RLS)

Push API:
- POST /api/push/subscribe — upsert subscription (conflict on endpoint)
- POST /api/push/unsubscribe — delete by endpoint + user_id

Cron (vercel.json + /api/cron/daily-digest):
- Runs 02:30 UTC (≈ 05:30 Cyprus) — secured by CRON_SECRET
- Fetches all subscribed users, skips if digest already sent today
- Builds per-user context (training session, tasks, last log, alcohol)
- Generates 120-char digest via Gemini 2.5 Flash with fallback
- Sends via web-push, auto-removes 410-expired subscriptions
- Inserts into daily_digest_log to prevent re-send

Proactive greeting (GET /api/ai/proactive-greeting):
- Returns { type, message?, flags } — cached in client sessionStorage
- type: none | needs_checkin | complete_briefing
- Gemini-generated personalised nudge when check-in missing
- Flags: alcohol_yesterday, unlogged_training (past 06:00 UTC), low_energy_pattern (3+ days avg energy < 3)

ProactiveBanner component:
- Client component, fetches greeting once per day (sessionStorage cache)
- Main amber banner for needs_checkin / complete_briefing
- Per-flag banners: red (alcohol), blue (unlogged training), violet (low energy)
- All banners dismissible (persisted in sessionStorage for the day)

Infrastructure:
- src/lib/supabase/service.ts — service-role client for cron
- ProactiveBanner added to (dashboard)/layout.tsx (all pages)
- NotificationSetup updated to use /api/push/subscribe + unsubscribe; reads NEXT_PUBLIC_VAPID_PUBLIC_KEY directly (no extra API round-trip)
- .env.local.example updated with SUPABASE_SERVICE_ROLE_KEY, CRON_SECRET, VAPID vars + generation instructions
- CLAUDE.md documents required Vercel env vars
- master-coach system prompt updated with proactive flags + time-of-day note

https://claude.ai/code/session_0151Ye69WomJSejbZE69KaQZ