### PR TITLE
feat: align morning check-in and coach route to unified schema

### DIFF
--- a/src/app/actions/morning-log.ts
+++ b/src/app/actions/morning-log.ts
@@ -1,38 +1,25 @@
 'use server'
 
 import { createClient } from '@/lib/supabase/server'
-import type { MorningLogInput, MorningLog } from '@/lib/types/morning-log'
+import type { MorningLog, MorningLogInput } from '@/lib/types/morning-log'
 
-export async function saveMorningLog(
+export async function submitMorningLog(
   data: MorningLogInput
-): Promise<{ id: string; isNew: boolean }> {
+): Promise<{ success: boolean; error?: string }> {
   const supabase = createClient()
   const {
     data: { user },
   } = await supabase.auth.getUser()
-  if (!user) throw new Error('Not authenticated')
+  if (!user) return { success: false, error: 'Not authenticated' }
 
-  const log_date = data.log_date ?? new Date().toISOString().slice(0, 10)
+  const date = data.date ?? new Date().toISOString().slice(0, 10)
 
-  // Check if a row already exists for today
-  const { data: existing } = await supabase
+  const { error } = await supabase
     .from('morning_logs')
-    .select('id')
-    .eq('user_id', user.id)
-    .eq('log_date', log_date)
-    .maybeSingle()
+    .upsert({ ...data, date, user_id: user.id }, { onConflict: 'user_id,date' })
 
-  const payload = { ...data, log_date, user_id: user.id }
-
-  const { data: row, error } = await supabase
-    .from('morning_logs')
-    .upsert(payload, { onConflict: 'user_id,log_date' })
-    .select('id')
-    .single()
-
-  if (error || !row) throw new Error(error?.message ?? 'Failed to save morning log')
-
-  return { id: row.id, isNew: !existing }
+  if (error) return { success: false, error: error.message }
+  return { success: true }
 }
 
 export async function getTodaysMorningLog(): Promise<MorningLog | null> {
@@ -48,7 +35,7 @@ export async function getTodaysMorningLog(): Promise<MorningLog | null> {
     .from('morning_logs')
     .select('*')
     .eq('user_id', user.id)
-    .eq('log_date', today)
+    .eq('date', today)
     .maybeSingle()
 
   return data as MorningLog | null
@@ -69,8 +56,8 @@ export async function getRecentMorningLogs(days: number): Promise<MorningLog[]> 
     .from('morning_logs')
     .select('*')
     .eq('user_id', user.id)
-    .gte('log_date', cutoffStr)
-    .order('log_date', { ascending: false })
+    .gte('date', cutoffStr)
+    .order('date', { ascending: false })
 
   return (data ?? []) as MorningLog[]
 }

--- a/src/app/api/ai/coach/route.ts
+++ b/src/app/api/ai/coach/route.ts
@@ -2,31 +2,29 @@
 // Reads all modules for context, can modify supplements and plan configs.
 // Persists every turn to coach_conversations for session continuity.
 
-import { openai } from '@ai-sdk/openai'; // Or whichever provider you are using
+import { google } from '@ai-sdk/google';
 import { streamText, tool } from 'ai';
 import { z } from 'zod';
-import { createClient } from '@/lib/supabase/server'; 
+import { createClient } from '@/lib/supabase/server';
 
-// Allow the route more time to execute, since the AI might take multiple steps (thought -> tool -> thought -> reply)
-export const maxDuration = 60; 
+export const maxDuration = 60;
 
 export async function POST(req: Request) {
   const { messages } = await req.json();
   const supabase = createClient();
-  
-  // Secure the route
+
   const { data: { user }, error: authError } = await supabase.auth.getUser();
   if (authError || !user) {
     return new Response('Unauthorized', { status: 401 });
   }
 
   const result = await streamText({
-    model: openai('gpt-4o'), // Swap with anthropic('claude-3-5-sonnet-20240620') if preferred
-    system: `You are Life OS, an elite, highly contextual life coach. 
+    model: google('gemini-2.5-flash'),
+    system: `You are Life OS, an elite, highly contextual life coach.
     You have direct access to the user's database. Before giving advice on trading, running, or nutrition, ALWAYS use your tools to check their physical and psychological state.
-    
-    Current Date: ${new Date().toISOString().split('T')[0]}
-    
+
+    Current Date and Time: ${new Date().toISOString()}
+
     Rules:
     - Never guess vitals. If you don't know, use the fetch_vitals tool.
     - Be concise, direct, and actionable.`,

--- a/src/components/morning/MorningCheckin.tsx
+++ b/src/components/morning/MorningCheckin.tsx
@@ -1,44 +1,13 @@
 'use client'
 
-// Morning Check-In card — vitals form + AI briefing panel.
-// On mount: loads today's log; if ai_briefing exists, shows it immediately.
-// On submit: saves log → fetches briefing → renders it.
-
 import { useState, useEffect, useTransition } from 'react'
-import { Sunrise, Loader2, Circle, CircleDot } from 'lucide-react'
-import { saveMorningLog, getTodaysMorningLog } from '@/app/actions/morning-log'
-import type { MorningLog, MorningLogInput } from '@/lib/types/morning-log'
+import { Sunrise, Loader2, CheckCircle2 } from 'lucide-react'
+import { submitMorningLog, getTodaysMorningLog } from '@/app/actions/morning-log'
+import type { MorningLogInput, MorningLog } from '@/lib/types/morning-log'
 
-// ── Markdown renderer (minimal, matches CoachChat style) ─────────────────────
+// ── Score selector (1-10 clickable dots) ────────────────────────────────────
 
-function renderMarkdown(text: string) {
-  return text.split('\n').map((line, i) => {
-    if (line.startsWith('## ')) {
-      return (
-        <h3 key={i} className="text-sm font-semibold text-white/90 mt-4 mb-1 first:mt-0">
-          {line.slice(3)}
-        </h3>
-      )
-    }
-    if (line.startsWith('- ')) {
-      return (
-        <li key={i} className="text-sm text-white/70 ml-3 list-disc list-inside leading-relaxed">
-          {line.slice(2)}
-        </li>
-      )
-    }
-    if (line.trim() === '') return <div key={i} className="h-1.5" />
-    return (
-      <p key={i} className="text-sm text-white/70 leading-relaxed">
-        {line}
-      </p>
-    )
-  })
-}
-
-// ── Sub-components ───────────────────────────────────────────────────────────
-
-function DotSelector({
+function ScoreSelector({
   label,
   value,
   onChange,
@@ -48,22 +17,27 @@ function DotSelector({
   onChange: (v: number) => void
 }) {
   return (
-    <div className="flex items-center justify-between gap-3">
-      <span className="text-xs text-white/50 w-28 shrink-0">{label}</span>
-      <div className="flex gap-1.5">
-        {[1, 2, 3, 4, 5].map((n) => (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-white/50">{label}</span>
+        {value != null && (
+          <span className="text-xs font-medium text-violet-400">{value}/10</span>
+        )}
+      </div>
+      <div className="flex gap-1">
+        {Array.from({ length: 10 }, (_, i) => i + 1).map((n) => (
           <button
             key={n}
             type="button"
             onClick={() => onChange(n)}
             aria-label={`${label} ${n}`}
-            className="transition-colors"
+            className={`flex-1 h-6 rounded text-xs font-medium transition-colors ${
+              value != null && n <= value
+                ? 'bg-violet-500/60 text-white'
+                : 'bg-white/5 text-white/20 hover:bg-white/10 hover:text-white/50'
+            }`}
           >
-            {value != null && n <= value ? (
-              <CircleDot className="h-4 w-4 text-violet-400" />
-            ) : (
-              <Circle className="h-4 w-4 text-white/20 hover:text-white/40" />
-            )}
+            {n}
           </button>
         ))}
       </div>
@@ -71,47 +45,46 @@ function DotSelector({
   )
 }
 
-function YesNoToggle({
+// ── Number input ─────────────────────────────────────────────────────────────
+
+function VitalInput({
   label,
   value,
   onChange,
+  placeholder,
+  min,
+  max,
+  step,
+  unit,
 }: {
   label: string
-  value: boolean | null
-  onChange: (v: boolean) => void
+  value: string
+  onChange: (v: string) => void
+  placeholder: string
+  min: number
+  max: number
+  step?: number
+  unit?: string
 }) {
   return (
-    <div className="flex items-center justify-between gap-3">
-      <span className="text-xs text-white/50 w-28 shrink-0">{label}</span>
-      <div className="flex gap-2">
-        <button
-          type="button"
-          onClick={() => onChange(true)}
-          className={`text-xs px-3 py-1 rounded-full border transition-colors ${
-            value === true
-              ? 'bg-violet-500/20 border-violet-500/50 text-violet-300'
-              : 'bg-white/5 border-white/10 text-white/40 hover:text-white/60'
-          }`}
-        >
-          Yes
-        </button>
-        <button
-          type="button"
-          onClick={() => onChange(false)}
-          className={`text-xs px-3 py-1 rounded-full border transition-colors ${
-            value === false
-              ? 'bg-violet-500/20 border-violet-500/50 text-violet-300'
-              : 'bg-white/5 border-white/10 text-white/40 hover:text-white/60'
-          }`}
-        >
-          No
-        </button>
-      </div>
+    <div className="space-y-1">
+      <label className="text-xs text-white/50">
+        {label}
+        {unit && <span className="text-white/30"> ({unit})</span>}
+      </label>
+      <input
+        type="number"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        min={min}
+        max={max}
+        step={step ?? 1}
+        placeholder={placeholder}
+        className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder:text-white/20 focus:outline-none focus:border-violet-500/40"
+      />
     </div>
   )
 }
-
-type DreamQuality = 'good' | 'neutral' | 'bad' | 'nightmare'
 
 // ── Main component ───────────────────────────────────────────────────────────
 
@@ -124,225 +97,172 @@ export function MorningCheckin() {
   })
 
   // Form state
-  const [restingHr, setRestingHr] = useState<string>('')
   const [sleepHours, setSleepHours] = useState<string>('')
-  const [sleepQuality, setSleepQuality] = useState<number | null>(null)
+  const [rhr, setRhr] = useState<string>('')
+  const [hrv, setHrv] = useState<string>('')
+  const [moodScore, setMoodScore] = useState<number | null>(null)
   const [energyLevel, setEnergyLevel] = useState<number | null>(null)
-  const [mood, setMood] = useState<number | null>(null)
-  const [bodyReadiness, setBodyReadiness] = useState<number | null>(null)
-  const [wokeEasily, setWokeEasily] = useState<boolean | null>(null)
-  const [hadDreams, setHadDreams] = useState<boolean | null>(null)
-  const [dreamQuality, setDreamQuality] = useState<DreamQuality | null>(null)
-  const [notes, setNotes] = useState<string>('')
+  const [journalNotes, setJournalNotes] = useState<string>('')
 
   // UI state
-  const [briefing, setBriefing] = useState<string | null>(null)
-  const [submitted, setSubmitted] = useState(false)
-  const [fetchingBriefing, setFetchingBriefing] = useState(false)
+  const [success, setSuccess] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [isPending, startTransition] = useTransition()
+  const [alreadyLogged, setAlreadyLogged] = useState(false)
 
-  // On mount: load today's log
+  // On mount: pre-populate if already logged today
   useEffect(() => {
     getTodaysMorningLog().then((log) => {
       if (!log) return
       populateFromLog(log)
+      setAlreadyLogged(true)
     })
   }, [])
 
   function populateFromLog(log: MorningLog) {
-    if (log.resting_hr_bpm != null) setRestingHr(String(log.resting_hr_bpm))
     if (log.sleep_hours != null) setSleepHours(String(log.sleep_hours))
-    if (log.sleep_quality != null) setSleepQuality(log.sleep_quality)
+    if (log.rhr != null) setRhr(String(log.rhr))
+    if (log.hrv != null) setHrv(String(log.hrv))
+    if (log.mood_score != null) setMoodScore(log.mood_score)
     if (log.energy_level != null) setEnergyLevel(log.energy_level)
-    if (log.mood != null) setMood(log.mood)
-    if (log.body_readiness != null) setBodyReadiness(log.body_readiness)
-    if (log.woke_easily != null) setWokeEasily(log.woke_easily)
-    if (log.had_dreams != null) setHadDreams(log.had_dreams)
-    if (log.dream_quality) setDreamQuality(log.dream_quality as DreamQuality)
-    if (log.notes) setNotes(log.notes)
-    if (log.ai_briefing) {
-      setBriefing(log.ai_briefing)
-      setSubmitted(true)
-    }
+    if (log.journal_notes) setJournalNotes(log.journal_notes)
+  }
+
+  function resetForm() {
+    setSleepHours('')
+    setRhr('')
+    setHrv('')
+    setMoodScore(null)
+    setEnergyLevel(null)
+    setJournalNotes('')
   }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setError(null)
+    setSuccess(false)
 
     const input: MorningLogInput = {
-      resting_hr_bpm: restingHr ? Number(restingHr) : null,
       sleep_hours: sleepHours ? Number(sleepHours) : null,
-      sleep_quality: sleepQuality,
+      rhr: rhr ? Number(rhr) : null,
+      hrv: hrv ? Number(hrv) : null,
+      mood_score: moodScore,
       energy_level: energyLevel,
-      mood,
-      body_readiness: bodyReadiness,
-      woke_easily: wokeEasily,
-      had_dreams: hadDreams,
-      dream_quality: hadDreams ? dreamQuality : null,
-      notes: notes.trim() || null,
+      journal_notes: journalNotes.trim() || null,
     }
 
     startTransition(async () => {
-      try {
-        const { id } = await saveMorningLog(input)
-        setSubmitted(true)
-
-        // Fetch briefing only if we don't already have one
-        if (!briefing) {
-          setFetchingBriefing(true)
-          const res = await fetch('/api/ai/morning-briefing', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ logId: id }),
-          })
-          const data = await res.json() as { briefing?: string; error?: string }
-          if (data.briefing) {
-            setBriefing(data.briefing)
-          } else {
-            setError('Failed to generate briefing — your log was saved.')
-          }
-          setFetchingBriefing(false)
-        }
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Something went wrong')
-        setFetchingBriefing(false)
+      const result = await submitMorningLog(input)
+      if (result.success) {
+        setSuccess(true)
+        setAlreadyLogged(true)
+        // Auto-hide toast after 3s
+        setTimeout(() => setSuccess(false), 3000)
+      } else {
+        setError(result.error ?? 'Failed to save log')
       }
     })
   }
 
-  // Derive readiness colour from briefing header
-  const readinessColor = briefing?.includes('🟢')
-    ? 'text-emerald-400'
-    : briefing?.includes('🔴')
-      ? 'text-red-400'
-      : 'text-amber-400'
-
   return (
-    <div className="space-y-4">
-      {/* ── Form card ─────────────────────────────────────────────────────── */}
-      <div className="rounded-xl border border-white/10 bg-white/5 overflow-hidden">
-        {/* Header */}
-        <div className="flex items-center justify-between px-5 py-3.5 border-b border-white/10 bg-amber-500/5">
-          <div className="flex items-center gap-2">
-            <Sunrise className="h-4 w-4 text-amber-400" />
-            <span className="text-sm font-semibold text-white">Morning Check-In</span>
-          </div>
-          <span className="text-xs text-white/40">{dateLabel}</span>
-        </div>
-
-        <form onSubmit={handleSubmit} className="px-5 py-4 space-y-5">
-          {/* Vitals row */}
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-1">
-              <label className="text-xs text-white/50">RHR (bpm)</label>
-              <input
-                type="number"
-                value={restingHr}
-                onChange={(e) => setRestingHr(e.target.value)}
-                min={30}
-                max={120}
-                placeholder="e.g. 46"
-                className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder:text-white/20 focus:outline-none focus:border-white/25"
-              />
-            </div>
-            <div className="space-y-1">
-              <label className="text-xs text-white/50">Sleep (hours)</label>
-              <input
-                type="number"
-                value={sleepHours}
-                onChange={(e) => setSleepHours(e.target.value)}
-                min={0}
-                max={14}
-                step={0.5}
-                placeholder="e.g. 7.5"
-                className="w-full bg-white/5 border border-white/10 rounded-lg px-3 py-2 text-sm text-white placeholder:text-white/20 focus:outline-none focus:border-white/25"
-              />
-            </div>
-          </div>
-
-          {/* 1–5 dot selectors */}
-          <div className="space-y-3">
-            <DotSelector label="Sleep quality" value={sleepQuality} onChange={setSleepQuality} />
-            <DotSelector label="Energy" value={energyLevel} onChange={setEnergyLevel} />
-            <DotSelector label="Mood" value={mood} onChange={setMood} />
-            <DotSelector label="Body readiness" value={bodyReadiness} onChange={setBodyReadiness} />
-          </div>
-
-          {/* Yes/No toggles */}
-          <div className="space-y-3">
-            <YesNoToggle label="Woke easily?" value={wokeEasily} onChange={setWokeEasily} />
-            <YesNoToggle label="Dreams?" value={hadDreams} onChange={setHadDreams} />
-          </div>
-
-          {/* Dream quality (only when hadDreams=true) */}
-          {hadDreams === true && (
-            <div className="flex items-center gap-2 flex-wrap">
-              <span className="text-xs text-white/50 w-28 shrink-0">Dream quality</span>
-              {(['good', 'neutral', 'bad', 'nightmare'] as DreamQuality[]).map((q) => (
-                <button
-                  key={q}
-                  type="button"
-                  onClick={() => setDreamQuality(q)}
-                  className={`text-xs px-3 py-1 rounded-full border capitalize transition-colors ${
-                    dreamQuality === q
-                      ? 'bg-violet-500/20 border-violet-500/50 text-violet-300'
-                      : 'bg-white/5 border-white/10 text-white/40 hover:text-white/60'
-                  }`}
-                >
-                  {q}
-                </button>
-              ))}
-            </div>
+    <div className="rounded-xl border border-white/10 bg-white/5 overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-5 py-3.5 border-b border-white/10 bg-amber-500/5">
+        <div className="flex items-center gap-2">
+          <Sunrise className="h-4 w-4 text-amber-400" />
+          <span className="text-sm font-semibold text-white">Morning Check-In</span>
+          {alreadyLogged && (
+            <span className="text-xs px-2 py-0.5 rounded-full bg-emerald-500/15 text-emerald-400 border border-emerald-500/20">
+              Logged
+            </span>
           )}
-
-          {/* Notes */}
-          <div className="space-y-1">
-            <label className="text-xs text-white/50">How are you feeling? (optional)</label>
-            <textarea
-              value={notes}
-              onChange={(e) => setNotes(e.target.value)}
-              rows={2}
-              placeholder="Any aches, thoughts, or context for today…"
-              className="w-full resize-none bg-white/5 border border-white/10 rounded-lg px-3 py-2.5 text-sm text-white placeholder:text-white/20 focus:outline-none focus:border-white/25"
-            />
-          </div>
-
-          {error && <p className="text-xs text-red-400">{error}</p>}
-
-          <div className="flex justify-end">
-            <button
-              type="submit"
-              disabled={isPending || fetchingBriefing}
-              className="flex items-center gap-2 px-4 py-2 rounded-lg bg-amber-500/15 border border-amber-500/30 text-sm text-amber-300 hover:bg-amber-500/25 transition-colors disabled:opacity-40"
-            >
-              {(isPending || fetchingBriefing) && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-              {submitted && !fetchingBriefing ? 'Update Check-In' : 'Submit Check-In'}
-            </button>
-          </div>
-        </form>
+        </div>
+        <span className="text-xs text-white/40">{dateLabel}</span>
       </div>
 
-      {/* ── Briefing card ─────────────────────────────────────────────────── */}
-      {fetchingBriefing && (
-        <div className="rounded-xl border border-white/10 bg-white/5 px-5 py-8 flex flex-col items-center gap-3 text-center">
-          <Loader2 className="h-5 w-5 text-amber-400 animate-spin" />
-          <p className="text-sm text-white/40">Analysing your morning…</p>
+      <form onSubmit={handleSubmit} className="px-5 py-4 space-y-5">
+        {/* Vitals row */}
+        <div className="grid grid-cols-3 gap-3">
+          <VitalInput
+            label="Sleep"
+            unit="hrs"
+            value={sleepHours}
+            onChange={setSleepHours}
+            placeholder="7.5"
+            min={0}
+            max={14}
+            step={0.5}
+          />
+          <VitalInput
+            label="RHR"
+            unit="bpm"
+            value={rhr}
+            onChange={setRhr}
+            placeholder="46"
+            min={30}
+            max={120}
+          />
+          <VitalInput
+            label="HRV"
+            unit="ms"
+            value={hrv}
+            onChange={setHrv}
+            placeholder="62"
+            min={10}
+            max={200}
+          />
         </div>
-      )}
 
-      {briefing && !fetchingBriefing && (
-        <div className="rounded-xl border border-white/10 bg-white/5 overflow-hidden">
-          <div className="flex items-center gap-2 px-5 py-3.5 border-b border-white/10 bg-amber-500/5">
-            <span className={`text-base ${readinessColor}`}>
-              {briefing.includes('🟢') ? '🟢' : briefing.includes('🔴') ? '🔴' : '🟡'}
-            </span>
-            <span className="text-sm font-semibold text-white">Morning Briefing</span>
-          </div>
-          <div className="px-5 py-4 space-y-1">{renderMarkdown(briefing)}</div>
+        {/* 1–10 score selectors */}
+        <div className="space-y-4">
+          <ScoreSelector label="Mood" value={moodScore} onChange={setMoodScore} />
+          <ScoreSelector label="Energy" value={energyLevel} onChange={setEnergyLevel} />
         </div>
-      )}
+
+        {/* Journal */}
+        <div className="space-y-1">
+          <label className="text-xs text-white/50">Journal (optional)</label>
+          <textarea
+            value={journalNotes}
+            onChange={(e) => setJournalNotes(e.target.value)}
+            rows={2}
+            placeholder="How are you feeling? Any context for today…"
+            className="w-full resize-none bg-white/5 border border-white/10 rounded-lg px-3 py-2.5 text-sm text-white placeholder:text-white/20 focus:outline-none focus:border-violet-500/40"
+          />
+        </div>
+
+        {/* Success toast */}
+        {success && (
+          <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 text-sm">
+            <CheckCircle2 className="h-4 w-4 shrink-0" />
+            Morning log saved!
+          </div>
+        )}
+
+        {error && (
+          <p className="text-xs text-red-400">{error}</p>
+        )}
+
+        <div className="flex items-center justify-between">
+          {alreadyLogged && (
+            <button
+              type="button"
+              onClick={resetForm}
+              className="text-xs text-white/30 hover:text-white/50 transition-colors"
+            >
+              Clear
+            </button>
+          )}
+          <button
+            type="submit"
+            disabled={isPending}
+            className="ml-auto flex items-center gap-2 px-4 py-2 rounded-lg bg-amber-500/15 border border-amber-500/30 text-sm text-amber-300 hover:bg-amber-500/25 transition-colors disabled:opacity-40"
+          >
+            {isPending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            {alreadyLogged ? 'Update Check-In' : 'Submit Check-In'}
+          </button>
+        </div>
+      </form>
     </div>
   )
 }

--- a/src/lib/types/morning-log.ts
+++ b/src/lib/types/morning-log.ts
@@ -1,21 +1,16 @@
 export interface MorningLogInput {
-  log_date?: string
-  resting_hr_bpm?: number | null
+  date?: string
   sleep_hours?: number | null
-  sleep_quality?: number | null
+  rhr?: number | null
+  hrv?: number | null
+  mood_score?: number | null
   energy_level?: number | null
-  mood?: number | null
-  body_readiness?: number | null
-  woke_easily?: boolean | null
-  had_dreams?: boolean | null
-  dream_quality?: 'good' | 'neutral' | 'bad' | 'nightmare' | null
-  notes?: string | null
+  journal_notes?: string | null
 }
 
 export interface MorningLog extends MorningLogInput {
   id: string
   user_id: string
-  ai_briefing: string | null
   created_at: string
   updated_at: string
 }


### PR DESCRIPTION
- Update MorningLogInput/MorningLog types to new column names (date, rhr, hrv, mood_score, energy_level, journal_notes)
- Replace saveMorningLog with submitMorningLog returning success/error object; update getTodaysMorningLog + getRecentMorningLogs to use new 'date' column
- Rewrite MorningCheckin UI: HRV field added, mood/energy upgraded to 1-10 score selector, inline success toast, pre-populate from today's log
- Fix coach route: swap missing @ai-sdk/openai for @ai-sdk/google (gemini-2.5-flash); all tool definitions already matched new schema