### PR TITLE
feat: add generative UI running plan drafting to Master Life Coach

### DIFF
--- a/src/app/actions/marathon.ts
+++ b/src/app/actions/marathon.ts
@@ -1,0 +1,51 @@
+'use server'
+
+import { createClient } from '@/lib/supabase/server'
+
+export interface MarathonSession {
+  scheduled_date: string   // YYYY-MM-DD
+  workout_type: string
+  target_distance: number  // km (NUMERIC in DB)
+  target_pace: string      // e.g. "5:01/km"
+}
+
+/**
+ * Deletes all future scheduled sessions (>= today) for the authenticated user.
+ */
+export async function clearMarathonPlan() {
+  const supabase = createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) throw new Error('Unauthorized')
+
+  const today = new Date().toISOString().split('T')[0]
+
+  const { error } = await supabase
+    .from('marathon_plan')
+    .delete()
+    .eq('user_id', user.id)
+    .gte('scheduled_date', today)
+
+  if (error) throw new Error(error.message)
+  return { success: true }
+}
+
+/**
+ * Inserts an array of drafted sessions into marathon_plan for the authenticated user.
+ */
+export async function saveMarathonPlan(sessions: MarathonSession[]) {
+  const supabase = createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) throw new Error('Unauthorized')
+
+  const rows = sessions.map((s) => ({
+    user_id: user.id,
+    scheduled_date: s.scheduled_date,
+    workout_type: s.workout_type,
+    target_distance: s.target_distance,
+    target_pace: s.target_pace,
+  }))
+
+  const { error } = await supabase.from('marathon_plan').insert(rows)
+  if (error) throw new Error(error.message)
+  return { success: true }
+}

--- a/src/app/api/ai/coach/route.ts
+++ b/src/app/api/ai/coach/route.ts
@@ -27,12 +27,13 @@ export async function POST(req: Request) {
 
     Rules:
     - Never guess vitals. If you don't know, use the fetch_vitals tool.
-    - Be concise, direct, and actionable.`,
+    - Be concise, direct, and actionable.
+    - If the user wants to start a fresh running plan or states their race is soon, use \`clear_running_plan\` to wipe the slate, then use \`draft_running_plan\` to propose a new schedule for them to approve.`,
     messages,
-    
+
     // CRITICAL: maxSteps > 1 allows the LLM to call a tool, parse the JSON result, and formulate a human-readable reply.
-    maxSteps: 5, 
-    
+    maxSteps: 5,
+
     tools: {
       // Tool 1: Fetch Morning Vitals
       fetch_vitals: tool({
@@ -72,7 +73,7 @@ export async function POST(req: Request) {
           return data || [];
         },
       }),
-      
+
       // Tool 3: Create a Task (Proactive Coaching)
       create_task: tool({
         description: 'Assign a new task to the user based on our conversation (e.g., "Take Magnesium before bed", "Lower trade size today").',
@@ -89,11 +90,48 @@ export async function POST(req: Request) {
                 target_date,
                 completed: false
              });
-             
+
            if (error) return { status: 'Failed to create task.' };
            return { status: 'Task successfully added to the user\'s agenda.' };
         }
-      })
+      }),
+
+      // Tool 4: Clear future running plan
+      clear_running_plan: tool({
+        description: 'Deletes all future scheduled running sessions (scheduled_date >= today) from the marathon_plan table. Use this before drafting a fresh plan.',
+        parameters: z.object({}),
+        execute: async () => {
+          const today = new Date().toISOString().split('T')[0];
+          const { error } = await supabase
+            .from('marathon_plan')
+            .delete()
+            .eq('user_id', user.id)
+            .gte('scheduled_date', today);
+
+          if (error) return { success: false, message: 'Failed to clear running plan.' };
+          return { success: true, message: 'Running plan cleared. Ready to draft a new schedule.' };
+        },
+      }),
+
+      // Tool 5: Draft a running plan (returns sessions to client for interactive approval)
+      draft_running_plan: tool({
+        description: "Drafts a multi-day or multi-week running plan based on the user's goals. This will display a preview to the user for approval. Do NOT hallucinate past dates.",
+        parameters: z.object({
+          sessions: z.array(
+            z.object({
+              scheduled_date: z.string().describe('YYYY-MM-DD format. Must be today or a future date.'),
+              workout_type: z.string().describe('e.g. Easy Run, Tempo, Long Run, Intervals, Rest'),
+              target_distance: z.number().describe('Distance in kilometres'),
+              target_pace: z.string().describe('Target pace string, e.g. "5:30/km" or "Easy"'),
+            })
+          ).describe('Ordered list of training sessions for the plan'),
+        }),
+        execute: async ({ sessions }) => {
+          // Return the drafted sessions to the client — the frontend renders
+          // PlanDraftPreview so the user can edit and approve before saving.
+          return { draftedSessions: sessions };
+        },
+      }),
     },
   });
 

--- a/src/components/ai/coach-chat.tsx
+++ b/src/components/ai/coach-chat.tsx
@@ -17,6 +17,7 @@ import {
   AlertCircle,
 } from 'lucide-react'
 import type { UIMessage } from 'ai'
+import { PlanDraftPreview } from '@/components/marathon/PlanDraftPreview'
 
 // ── Props ───────────────────────────────────────────────────────────────────
 
@@ -275,6 +276,17 @@ function ToolInvocationRenderer({
   }
 
   const result = part.result
+
+  // Generative UI: render interactive plan preview for draft_running_plan results
+  if (
+    part.toolName === 'draft_running_plan' &&
+    result &&
+    'draftedSessions' in result &&
+    Array.isArray((result as Record<string, unknown>).draftedSessions)
+  ) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return <PlanDraftPreview draftedSessions={(result as any).draftedSessions} />
+  }
 
   if (result && 'type' in result && result.type === 'proposal' && confirmEndpoint) {
     const proposalState = proposalStates[part.toolInvocationId] ?? 'pending'

--- a/src/components/marathon/PlanDraftPreview.tsx
+++ b/src/components/marathon/PlanDraftPreview.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+import { CheckCircle, Loader2, AlertCircle } from 'lucide-react'
+import { saveMarathonPlan } from '@/app/actions/marathon'
+import type { MarathonSession } from '@/app/actions/marathon'
+
+interface PlanDraftPreviewProps {
+  draftedSessions: MarathonSession[]
+}
+
+export function PlanDraftPreview({ draftedSessions }: PlanDraftPreviewProps) {
+  const [sessions, setSessions] = useState<MarathonSession[]>(draftedSessions)
+  const [saved, setSaved] = useState(false)
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+
+  const updateSession = (
+    index: number,
+    field: keyof MarathonSession,
+    value: string | number,
+  ) => {
+    setSessions((prev) =>
+      prev.map((s, i) => (i === index ? { ...s, [field]: value } : s)),
+    )
+  }
+
+  const handleSave = () => {
+    setError(null)
+    startTransition(async () => {
+      try {
+        await saveMarathonPlan(sessions)
+        setSaved(true)
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to save plan.')
+      }
+    })
+  }
+
+  if (saved) {
+    return (
+      <div className="flex items-center gap-2 px-3 py-2.5 rounded-lg border bg-emerald-500/5 border-emerald-500/20">
+        <CheckCircle className="h-4 w-4 text-emerald-400 shrink-0" />
+        <p className="text-sm text-emerald-300 font-medium">
+          Training plan saved successfully!
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="rounded-xl border border-orange-500/30 bg-orange-500/5 overflow-hidden w-full">
+      {/* Header */}
+      <div className="flex items-center gap-2 px-3 py-2.5 border-b border-orange-500/20 bg-orange-500/10">
+        <div className="h-1.5 w-1.5 rounded-full bg-orange-400 animate-pulse" />
+        <span className="text-xs font-semibold text-orange-300">
+          Draft Running Plan — Review &amp; Edit
+        </span>
+      </div>
+
+      {/* Editable table */}
+      <div className="overflow-x-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b border-white/10">
+              <th className="text-left px-3 py-2 text-white/40 font-medium whitespace-nowrap">
+                Date
+              </th>
+              <th className="text-left px-3 py-2 text-white/40 font-medium whitespace-nowrap">
+                Workout Type
+              </th>
+              <th className="text-left px-3 py-2 text-white/40 font-medium whitespace-nowrap">
+                Dist (km)
+              </th>
+              <th className="text-left px-3 py-2 text-white/40 font-medium whitespace-nowrap">
+                Pace
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {sessions.map((session, i) => (
+              <tr
+                key={i}
+                className="border-b border-white/5 hover:bg-white/[0.03] transition-colors"
+              >
+                {/* Date — not editable to avoid scheduling errors */}
+                <td className="px-3 py-2 text-white/50 whitespace-nowrap font-mono">
+                  {session.scheduled_date}
+                </td>
+
+                {/* Workout type */}
+                <td className="px-3 py-2">
+                  <input
+                    value={session.workout_type}
+                    onChange={(e) =>
+                      updateSession(i, 'workout_type', e.target.value)
+                    }
+                    className="bg-transparent text-white/80 w-full min-w-[100px] focus:outline-none focus:text-white border-b border-transparent focus:border-orange-500/50 pb-px transition-colors"
+                  />
+                </td>
+
+                {/* Distance */}
+                <td className="px-3 py-2">
+                  <input
+                    type="number"
+                    step="0.1"
+                    min="0"
+                    value={session.target_distance}
+                    onChange={(e) =>
+                      updateSession(
+                        i,
+                        'target_distance',
+                        parseFloat(e.target.value) || 0,
+                      )
+                    }
+                    className="bg-transparent text-white/80 w-16 focus:outline-none focus:text-white border-b border-transparent focus:border-orange-500/50 pb-px transition-colors"
+                  />
+                </td>
+
+                {/* Pace */}
+                <td className="px-3 py-2">
+                  <input
+                    value={session.target_pace}
+                    onChange={(e) =>
+                      updateSession(i, 'target_pace', e.target.value)
+                    }
+                    className="bg-transparent text-white/80 w-full min-w-[70px] focus:outline-none focus:text-white border-b border-transparent focus:border-orange-500/50 pb-px transition-colors font-mono"
+                  />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between gap-3 px-3 py-2.5 border-t border-orange-500/20">
+        <p className="text-xs text-white/30">
+          {sessions.length} session{sessions.length !== 1 ? 's' : ''} · click any field to edit
+        </p>
+        <div className="flex items-center gap-2">
+          {error && (
+            <div className="flex items-center gap-1 text-xs text-red-400">
+              <AlertCircle className="h-3 w-3 shrink-0" />
+              {error}
+            </div>
+          )}
+          <button
+            onClick={handleSave}
+            disabled={isPending}
+            className="flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-md bg-orange-500/20 border border-orange-500/30 text-orange-300 hover:bg-orange-500/30 transition-colors disabled:opacity-40 whitespace-nowrap"
+          >
+            {isPending ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <CheckCircle className="h-3 w-3" />
+            )}
+            Approve &amp; Save Plan
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
- Add clearMarathonPlan and saveMarathonPlan server actions (actions/marathon.ts)
- Add PlanDraftPreview component — editable table with inline field editing and approve/save flow
- Extend coach API with clear_running_plan and draft_running_plan tools + updated system prompt
- Render PlanDraftPreview in chat when AI invokes draft_running_plan (Generative UI)