### PR TITLE
fix: remove await from streamText — AI SDK v6 breaks toDataStreamResp…

### DIFF
--- a/src/app/api/ai/coach/route.ts
+++ b/src/app/api/ai/coach/route.ts
@@ -18,9 +18,10 @@ export async function POST(req: Request) {
     return new Response('Unauthorized', { status: 401 });
   }
 
-  let result
-  try {
-    result = await streamText({
+  // NOTE: do NOT await streamText — in AI SDK v6 it returns a StreamTextResult
+  // synchronously. Awaiting it resolves to the final text and loses the streaming
+  // helper methods like toDataStreamResponse().
+  const result = streamText({
     model: google('gemini-2.5-flash'),
     system: `You are Life OS, an elite, highly contextual life coach.
     You have direct access to the user's database. Before giving advice on trading, running, or nutrition, ALWAYS use your tools to check their physical and psychological state.
@@ -35,6 +36,9 @@ export async function POST(req: Request) {
 
     // CRITICAL: maxSteps > 1 allows the LLM to call a tool, parse the JSON result, and formulate a human-readable reply.
     maxSteps: 5,
+    onError: ({ error }) => {
+      console.error('[coach/route] streamText error:', error)
+    },
 
     tools: {
       // Tool 1: Fetch Morning Vitals
@@ -137,15 +141,7 @@ export async function POST(req: Request) {
         },
       }),
     },
-  })
-  } catch (err) {
-    console.error('[coach/route] streamText error:', err)
-    const message = err instanceof Error ? err.message : String(err)
-    return new Response(JSON.stringify({ error: message }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    })
-  }
+  });
 
   return result.toDataStreamResponse();
 }


### PR DESCRIPTION
…onse

streamText() in AI SDK v6 returns a StreamTextResult synchronously. Awaiting it resolves to the final text value, losing the streaming helper methods including toDataStreamResponse(). Replaced try/catch wrapper with the v6 onError callback for error logging instead.