### PR TITLE
feat: correlation engine, production schema & generative UI charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react": "^18",
         "react-dom": "^18",
         "recharts": "^3.7.0",
+        "simple-statistics": "^7.8.9",
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7",
         "web-push": "^3.6.7",
@@ -336,16 +337,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/@ai-sdk/solid/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@ai-sdk/solid/node_modules/zod-to-json-schema": {
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.2.tgz",
@@ -461,16 +452,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/@ai-sdk/svelte/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@ai-sdk/svelte/node_modules/zod-to-json-schema": {
@@ -590,16 +571,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/@ai-sdk/vue/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@ai-sdk/vue/node_modules/zod-to-json-schema": {
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.23.2.tgz",
@@ -613,26 +584,13 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4292,35 +4250,6 @@
       "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
       "license": "MIT"
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -4394,7 +4323,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -5007,314 +4936,6 @@
         "win32"
       ]
     },
-    "node_modules/@vue/compiler-core": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
-      "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/parser": "^7.29.2",
-        "@vue/shared": "3.5.32",
-        "entities": "^7.0.1",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@vue/compiler-dom": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
-      "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vue/compiler-core": "3.5.32",
-        "@vue/shared": "3.5.32"
-      }
-    },
-    "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz",
-      "integrity": "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/parser": "^7.29.2",
-        "@vue/compiler-core": "3.5.32",
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/compiler-ssr": "3.5.32",
-        "@vue/shared": "3.5.32",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.21",
-        "postcss": "^8.5.8",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz",
-      "integrity": "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/shared": "3.5.32"
-      }
-    },
-    "node_modules/@vue/reactivity": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.32.tgz",
-      "integrity": "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vue/shared": "3.5.32"
-      }
-    },
-    "node_modules/@vue/runtime-core": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.32.tgz",
-      "integrity": "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vue/reactivity": "3.5.32",
-        "@vue/shared": "3.5.32"
-      }
-    },
-    "node_modules/@vue/runtime-dom": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz",
-      "integrity": "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vue/reactivity": "3.5.32",
-        "@vue/runtime-core": "3.5.32",
-        "@vue/shared": "3.5.32",
-        "csstype": "^3.2.3"
-      }
-    },
-    "node_modules/@vue/server-renderer": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.32.tgz",
-      "integrity": "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vue/compiler-ssr": "3.5.32",
-        "@vue/shared": "3.5.32"
-      },
-      "peerDependencies": {
-        "vue": "3.5.32"
-      }
-    },
-    "node_modules/@vue/shared": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
-      "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/ast": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
-      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/helper-numbers": "1.13.2",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
-      }
-    },
-    "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
-      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
-      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
-      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-numbers": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
-      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
-        "@webassemblyjs/helper-api-error": "1.13.2",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
-      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
-      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-buffer": "1.14.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/wasm-gen": "1.14.1"
-      }
-    },
-    "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
-      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@xtuc/ieee754": "^1.2.0"
-      }
-    },
-    "node_modules/@webassemblyjs/leb128": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
-      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/utf8": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
-      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
-      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-buffer": "1.14.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/helper-wasm-section": "1.14.1",
-        "@webassemblyjs/wasm-gen": "1.14.1",
-        "@webassemblyjs/wasm-opt": "1.14.1",
-        "@webassemblyjs/wasm-parser": "1.14.1",
-        "@webassemblyjs/wast-printer": "1.14.1"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
-      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/ieee754": "1.13.2",
-        "@webassemblyjs/leb128": "1.13.2",
-        "@webassemblyjs/utf8": "1.13.2"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
-      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-buffer": "1.14.1",
-        "@webassemblyjs/wasm-gen": "1.14.1",
-        "@webassemblyjs/wasm-parser": "1.14.1"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
-      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-api-error": "1.13.2",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/ieee754": "1.13.2",
-        "@webassemblyjs/leb128": "1.13.2",
-        "@webassemblyjs/utf8": "1.13.2"
-      }
-    },
-    "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
-      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@xtuc/ieee754": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
-    "node_modules/@xtuc/long": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "license": "Apache-2.0",
-      "peer": true
-    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -5325,19 +4946,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-phases": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "peerDependencies": {
-        "acorn": "^8.14.0"
       }
     },
     "node_modules/acorn-jsx": {
@@ -5636,12 +5244,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -5655,6 +5265,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -5680,6 +5291,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
       "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -5933,6 +5545,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -6056,6 +5669,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6245,6 +5859,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -6291,6 +5906,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -6315,22 +5931,13 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/chrome-trace-event": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
-      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.0"
       }
     },
     "node_modules/class-variance-authority": {
@@ -6375,30 +5982,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/code-red": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
-      "integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15",
-        "@types/estree": "^1.0.1",
-        "acorn": "^8.10.0",
-        "estree-walker": "^3.0.3",
-        "periscopic": "^3.1.0"
-      }
-    },
-    "node_modules/code-red/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6423,6 +6006,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -6505,24 +6089,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/css-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "mdn-data": "2.0.30",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -6906,6 +6477,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/diff-match-patch": {
@@ -6930,6 +6502,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -7010,33 +6583,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/enhanced-resolve": {
-      "version": "5.20.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
-      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -7152,13 +6698,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -7674,6 +7213,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -7686,6 +7226,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -7711,16 +7252,6 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.8.x"
-      }
     },
     "node_modules/eventsource-parser": {
       "version": "3.0.6",
@@ -8156,6 +7687,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -8163,13 +7695,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "license": "BSD-2-Clause",
-      "peer": true
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -8559,6 +8084,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -8825,16 +8351,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-reference": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
-      "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "^1.0.6"
-      }
-    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -9092,6 +8608,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -9134,13 +8651,6 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
@@ -9318,6 +8828,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -9330,21 +8841,8 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/loader-runner": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
-      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.11.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
     },
     "node_modules/loader-utils": {
       "version": "2.0.4",
@@ -9371,13 +8869,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/locate-character": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
-      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -9490,13 +8981,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/mdn-data": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-      "license": "CC0-1.0",
-      "peer": true
-    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -9523,29 +9007,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -9595,6 +9056,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -9642,13 +9104,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/next": {
       "version": "14.2.35",
@@ -9784,6 +9239,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9802,6 +9258,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -10096,28 +9553,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/periscopic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
-      "integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^3.0.0",
-        "is-reference": "^3.0.0"
-      }
-    },
-    "node_modules/periscopic/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -10140,6 +9575,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10170,6 +9606,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -10252,6 +9689,7 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
       "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10280,6 +9718,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -10297,6 +9736,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10322,6 +9762,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10364,6 +9805,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10389,6 +9831,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -10402,6 +9845,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -10505,6 +9949,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-redux": {
@@ -10603,6 +10048,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -10612,6 +10058,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -11219,6 +10666,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-statistics": {
+      "version": "7.8.9",
+      "resolved": "https://registry.npmjs.org/simple-statistics/-/simple-statistics-7.8.9.tgz",
+      "integrity": "sha512-YT6MLqYsz7y1rQZOLFlOCCgSRpCi6bqY417yhoOLI7aVoBi29dD39EPrOE03W9DY25H0J0jizVsHZnkLzyGJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -11588,6 +11044,7 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -11628,52 +11085,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/svelte": {
-      "version": "4.2.20",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.20.tgz",
-      "integrity": "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@ampproject/remapping": "^2.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.15",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "@types/estree": "^1.0.1",
-        "acorn": "^8.9.0",
-        "aria-query": "^5.3.0",
-        "axobject-query": "^4.0.0",
-        "code-red": "^1.0.3",
-        "css-tree": "^2.3.1",
-        "estree-walker": "^3.0.3",
-        "is-reference": "^3.0.1",
-        "locate-character": "^3.0.0",
-        "magic-string": "^0.30.4",
-        "periscopic": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/svelte/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/svelte/node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/swr": {
@@ -11718,6 +11129,7 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -11758,20 +11170,6 @@
       "license": "MIT",
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders"
-      }
-    },
-    "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/temp-dir": {
@@ -11934,6 +11332,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -11943,6 +11342,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -11973,6 +11373,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11989,6 +11390,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -12006,6 +11408,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -12052,6 +11455,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {
@@ -12177,7 +11581,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12412,6 +11816,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/victory-vendor": {
@@ -12445,42 +11850,6 @@
         "@types/d3-path": "*"
       }
     },
-    "node_modules/vue": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
-      "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.32",
-        "@vue/compiler-sfc": "3.5.32",
-        "@vue/runtime-dom": "3.5.32",
-        "@vue/server-renderer": "3.5.32",
-        "@vue/shared": "3.5.32"
-      },
-      "peerDependencies": {
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/watchpack": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
-      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/web-push": {
       "version": "3.6.7",
       "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
@@ -12505,146 +11874,6 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "license": "BSD-2-Clause"
-    },
-    "node_modules/webpack": {
-      "version": "5.105.4",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
-      "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
-        "@types/estree": "^1.0.8",
-        "@types/json-schema": "^7.0.15",
-        "@webassemblyjs/ast": "^1.14.1",
-        "@webassemblyjs/wasm-edit": "^1.14.1",
-        "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.16.0",
-        "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.28.1",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.20.0",
-        "es-module-lexer": "^2.0.0",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.3.1",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.3",
-        "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.17",
-        "watchpack": "^2.5.1",
-        "webpack-sources": "^3.3.4"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/webpack-sources": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
-      "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/webpack/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/webpack/node_modules/ajv-keywords": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
-      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      },
-      "peerDependencies": {
-        "ajv": "^8.8.2"
-      }
-    },
-    "node_modules/webpack/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/webpack/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/webpack/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/webpack/node_modules/schema-utils": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
-      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "ajv": "^8.9.0",
-        "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.1.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
     },
     "node_modules/whatwg-url": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react": "^18",
     "react-dom": "^18",
     "recharts": "^3.7.0",
+    "simple-statistics": "^7.8.9",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7",
     "web-push": "^3.6.7",

--- a/src/app/api/ai/coach/route.ts
+++ b/src/app/api/ai/coach/route.ts
@@ -19,18 +19,33 @@ export async function POST(req: Request) {
     return new Response('Unauthorized', { status: 401 });
   }
 
+  // Fetch the 5 most recent actionable insights produced by the correlation engine
+  const { data: insights } = await supabase
+    .from('user_insights')
+    .select('insight_text, confidence')
+    .eq('user_id', user.id)
+    .eq('actionable', true)
+    .order('created_at', { ascending: false })
+    .limit(5);
+
+  const insightBlock = insights && insights.length > 0
+    ? `\n\nRecent Mathematical Insights from the Correlation Engine:\n${insights.map((ins, i) => `${i + 1}. ${ins.insight_text}${ins.confidence != null ? ` (confidence: ${(ins.confidence * 100).toFixed(0)}%)` : ''}`).join('\n')}\nRely on these facts instead of attempting to calculate statistical trends yourself.`
+    : '';
+
   const result = await streamText({
     model: geminiFlash(),
     system: systemOverride ?? `You are the Life OS orchestrator. You help the user set up their life goals across Training, Nutrition, Work, Hobbies, and Morning routines. You track their data flexibly. If they lack a setup, guide them through it.
 
-    Current Date and Time: ${new Date().toISOString()}
+    Current Date and Time: ${new Date().toISOString()}${insightBlock}
 
     Rules:
     - Never guess vitals. If you don't know, use the fetch_vitals tool.
     - Be concise, direct, and actionable.
     - During onboarding, gather the user's name, key life domains, and specific goals, then call \`complete_onboarding\` to save their profile.
     - For each goal, extract a \`target_metrics\` JSONB object with measurable keys (e.g. {"sessions_per_week": 3} for training, {"protein_g": 150} for nutrition).
-    - If the user wants to start a fresh running plan or states their race is soon, use \`clear_running_plan\` to wipe the slate, then use \`draft_running_plan\` to propose a new schedule for them to approve.`,
+    - If the user wants to start a fresh running plan or states their race is soon, use \`clear_running_plan\` to wipe the slate, then use \`draft_running_plan\` to propose a new schedule for them to approve.
+    - When the user asks for a summary, progress report, dashboard, or "how am I doing" for any category, call \`show_metrics_dashboard\` to render a visual widget. Populate dataPoints from context — do not fetch data first unless you genuinely need live values.
+    - When the user asks to see their data visually, or when you identify a trend they should track over time, call \`suggest_dashboard_widget\` to propose a chart they can pin to their dashboard.`,
     messages,
 
     // CRITICAL: maxSteps > 1 allows the LLM to call a tool, parse the JSON result, and formulate a human-readable reply.
@@ -175,7 +190,88 @@ export async function POST(req: Request) {
         },
       }),
 
-      // Tool 6: Draft a running plan (returns sessions to client for interactive approval)
+      // Tool 6: Generative UI — render a metrics dashboard widget in the chat
+      show_metrics_dashboard: tool({
+        description: 'Call this tool whenever the user asks for a summary, progress report, or visual dashboard of their metrics for a specific category (e.g., training, work, nutrition). Populate dataPoints from your knowledge of the conversation context.',
+        parameters: z.object({
+          category: z.string().describe('Life domain: training, nutrition, work, hobby, or morning'),
+          summaryText: z.string().describe('1-2 sentence narrative summary of the user\'s current status in this category.'),
+          dataPoints: z.array(
+            z.object({
+              label: z.string().describe('Short metric name, e.g. "Sessions this week"'),
+              value: z.union([z.string(), z.number()]).describe('The metric value, e.g. 4 or "4 km"'),
+            })
+          ).describe('Key metrics to display. Use 2-6 points for best layout.'),
+        }),
+        execute: async ({ category, summaryText, dataPoints }) => {
+          // Return params directly — the frontend renders the widget.
+          return { category, summaryText, dataPoints };
+        },
+      }),
+
+      // Tool 7: Suggest a dashboard widget (Generative UI — pinnable by user)
+      suggest_dashboard_widget: tool({
+        description: 'Suggest a visual dashboard widget when the user asks to see their data or when you identify a trend they should track over time. The frontend will render the chart inside the chat with a "Pin to Dashboard" button.',
+        parameters: z.object({
+          chart_type: z.enum(['line', 'bar', 'scatter']).describe('The Recharts chart type to render'),
+          metric_keys: z.array(z.string()).describe('The metric keys from daily_logs.metrics to plot, e.g. ["sleep_hours", "deep_work_hours"]'),
+          title: z.string().optional().describe('Optional human-readable title for the widget'),
+        }),
+        execute: async ({ chart_type, metric_keys, title }) => {
+          // Return the raw config — the frontend renders DynamicWidget and handles pinning.
+          return { chart_type, metric_keys, title: title ?? null };
+        },
+      }),
+
+      // Tool 9: Render an interactive chart with live daily_logs data
+      render_dashboard_widget: tool({
+        description: 'Generates an interactive visual chart for the user when they ask about their metrics, or when you want to visually prove a correlation or insight. Fetches real data from the last 14 days.',
+        parameters: z.object({
+          chartType: z.enum(['line', 'bar']).describe('line for trends over time, bar for comparing totals'),
+          metricKeys: z.array(z.string()).describe('Metric keys to plot from daily_logs.metrics, e.g. ["hrv", "sleep_hours"]'),
+          explanation: z.string().describe('A brief natural language summary of what the chart shows and why it matters'),
+        }),
+        execute: async ({ chartType, metricKeys, explanation }) => {
+          const since = new Date();
+          since.setDate(since.getDate() - 14);
+          const sinceStr = since.toISOString().split('T')[0];
+
+          const { data: logs } = await supabase
+            .from('daily_logs')
+            .select('date, metrics')
+            .eq('user_id', user.id)
+            .gte('date', sinceStr)
+            .order('date', { ascending: true });
+
+          // Reshape sparse JSONB rows into flat Recharts-compatible objects
+          const formattedData: Record<string, unknown>[] = (logs ?? []).map((log) => {
+            const metrics = (log.metrics ?? {}) as Record<string, unknown>;
+            const point: Record<string, unknown> = {
+              // Trim to MM-DD for compact x-axis labels
+              date: log.date.slice(5),
+            };
+            for (const key of metricKeys) {
+              const v = metrics[key];
+              if (typeof v === 'number') {
+                point[key] = v;
+              } else if (typeof v === 'string') {
+                const n = parseFloat(v);
+                if (isFinite(n)) point[key] = n;
+              }
+              // Absent keys are omitted — connectNulls handles gaps on LineChart
+            }
+            return point;
+          });
+
+          return {
+            config: { chartType, metricKeys },
+            data: formattedData,
+            explanation,
+          };
+        },
+      }),
+
+      // Tool 8: Draft a running plan (returns sessions to client for interactive approval)
       draft_running_plan: tool({
         description: "Drafts a multi-day or multi-week running plan based on the user's goals. This will display a preview to the user for approval. Do NOT hallucinate past dates.",
         parameters: z.object({

--- a/src/app/api/cron/correlations/route.ts
+++ b/src/app/api/cron/correlations/route.ts
@@ -1,0 +1,70 @@
+// Nightly cron: compute Pearson correlations across daily_logs metrics
+// and persist strong findings to user_insights.
+// Vercel invokes this via cron with: Authorization: Bearer <CRON_SECRET>
+
+import { NextResponse } from 'next/server'
+import { createServiceClient } from '@/lib/supabase/service'
+import { calculateCorrelations, buildInsightText } from '@/lib/math/correlation'
+
+// Allow up to 60 s on Vercel Pro; safe to reduce on Hobby
+export const maxDuration = 60
+
+export async function GET(req: Request) {
+  // Auth: Vercel cron sends Authorization: Bearer <CRON_SECRET>
+  const secret = process.env.CRON_SECRET
+  if (!secret) {
+    return new NextResponse('CRON_SECRET not configured', { status: 500 })
+  }
+  if (req.headers.get('authorization') !== `Bearer ${secret}`) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
+
+  const supabase = createServiceClient()
+
+  // Use user_profiles as the source of active users (guaranteed to exist post-signup)
+  const { data: profiles, error: profilesErr } = await supabase
+    .from('user_profiles')
+    .select('user_id')
+
+  if (profilesErr) {
+    return NextResponse.json({ error: profilesErr.message }, { status: 500 })
+  }
+
+  const since = new Date()
+  since.setDate(since.getDate() - 30)
+  const sinceStr = since.toISOString().split('T')[0]
+
+  let totalInsights = 0
+
+  for (const { user_id } of profiles ?? []) {
+    const { data: logs } = await supabase
+      .from('daily_logs')
+      .select('metrics')
+      .eq('user_id', user_id)
+      .gte('date', sinceStr)
+      .order('date', { ascending: true })
+
+    if (!logs || logs.length < 5) continue
+
+    const correlations = calculateCorrelations(
+      logs as { metrics: Record<string, unknown> }[]
+    )
+
+    if (correlations.length === 0) continue
+
+    const rows = correlations.map(({ metricA, metricB, coefficient }) => ({
+      user_id,
+      metric_a: metricA,
+      metric_b: metricB,
+      coefficient,
+      confidence: parseFloat(Math.abs(coefficient).toFixed(4)),
+      insight_text: buildInsightText(metricA, metricB, coefficient),
+      actionable: true,
+    }))
+
+    const { error } = await supabase.from('user_insights').insert(rows)
+    if (!error) totalInsights += rows.length
+  }
+
+  return NextResponse.json({ success: true, insights_created: totalInsights })
+}

--- a/src/app/api/dashboard/pin-widget/route.ts
+++ b/src/app/api/dashboard/pin-widget/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { z } from 'zod';
+
+const bodySchema = z.object({
+  widget_config: z.object({
+    chart_type: z.enum(['line', 'bar', 'scatter']),
+    metric_keys: z.array(z.string()).min(1),
+    title: z.string().optional().nullable(),
+  }),
+});
+
+export async function POST(req: Request) {
+  const supabase = createClient();
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const body = await req.json();
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid widget config' }, { status: 400 });
+  }
+
+  const { error } = await supabase
+    .from('user_dashboards')
+    .insert({ user_id: user.id, widget_config: parsed.data.widget_config });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/ai/CoachTaskCard.tsx
+++ b/src/components/ai/CoachTaskCard.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+
+export interface CoachTask {
+  id: string
+  title: string
+  notes?: string | null
+  due_date?: string | null
+  module?: string | null
+  coach_context?: string | null
+  confidence_score?: number | null
+  rationale?: string | null
+  completed_at?: string | null
+}
+
+interface CoachTaskCardProps {
+  task: CoachTask
+  onComplete?: (id: string) => void
+}
+
+function ConfidenceBadge({ score }: { score: number }) {
+  if (score > 0.8) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold bg-emerald-500/15 text-emerald-300 border border-emerald-500/25">
+        Confirmed Pattern
+      </span>
+    )
+  }
+  if (score < 0.6) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold bg-white/5 text-white/35 border border-white/10">
+        Hypothesis
+      </span>
+    )
+  }
+  return null
+}
+
+export function CoachTaskCard({ task, onComplete }: CoachTaskCardProps) {
+  const score = task.confidence_score ?? null
+  const isHypothesis = score !== null && score < 0.6
+  const isConfirmed  = score !== null && score > 0.8
+  const isDone       = !!task.completed_at
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl border px-4 py-3 space-y-1.5 transition-opacity',
+        isDone && 'opacity-40',
+        isHypothesis
+          ? 'border-dashed border-white/15 bg-white/[0.02]'
+          : isConfirmed
+          ? 'border-emerald-500/25 bg-emerald-500/5'
+          : 'border-white/10 bg-white/5',
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <p
+            className={cn(
+              'text-sm font-medium leading-snug',
+              isHypothesis ? 'text-white/40' : isConfirmed ? 'text-emerald-100' : 'text-white/80',
+            )}
+          >
+            {task.title}
+          </p>
+
+          {task.notes && (
+            <p className="text-xs text-white/35 mt-0.5 leading-relaxed">{task.notes}</p>
+          )}
+
+          {task.rationale && (
+            <p className="text-xs text-white/25 mt-1 leading-relaxed italic">
+              {task.rationale}
+            </p>
+          )}
+        </div>
+
+        <div className="flex flex-col items-end gap-1.5 shrink-0">
+          {score !== null && <ConfidenceBadge score={score} />}
+
+          {!isDone && onComplete && (
+            <button
+              onClick={() => onComplete(task.id)}
+              className="text-[10px] px-2.5 py-1 rounded-md bg-white/5 border border-white/10 text-white/35 hover:text-white/60 hover:bg-white/10 transition-colors"
+            >
+              Done
+            </button>
+          )}
+        </div>
+      </div>
+
+      {task.due_date && (
+        <p className="text-[10px] text-white/25">Due {task.due_date}</p>
+      )}
+    </div>
+  )
+}

--- a/src/components/ai/coach-chat.tsx
+++ b/src/components/ai/coach-chat.tsx
@@ -14,8 +14,13 @@ import {
   CheckCircle,
   XCircle,
   AlertCircle,
+  Pin,
 } from 'lucide-react'
 import type { UIMessage } from 'ai'
+import { MetricsDashboard } from '@/components/ai/widgets/MetricsDashboard'
+import { DynamicWidget, type WidgetConfig } from '@/components/dashboard/DynamicWidget'
+import { DynamicWidget as ChatDynamicWidget, type DynamicWidgetProps } from '@/components/ai/widgets/DynamicWidget'
+import { Skeleton } from '@/components/ui/skeleton'
 
 // ── Props ───────────────────────────────────────────────────────────────────
 
@@ -243,6 +248,62 @@ function ProposalCard({
   )
 }
 
+// ── DashboardWidgetCard — renders suggested widget with pin-to-dashboard ─────
+
+function DashboardWidgetCard({ config }: { config: WidgetConfig }) {
+  const [pinState, setPinState] = useState<'idle' | 'pinning' | 'pinned' | 'error'>('idle')
+
+  const handlePin = async () => {
+    setPinState('pinning')
+    try {
+      const res = await fetch('/api/dashboard/pin-widget', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ widget_config: config }),
+      })
+      if (res.ok) {
+        setPinState('pinned')
+      } else {
+        setPinState('error')
+      }
+    } catch {
+      setPinState('error')
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <DynamicWidget widget_config={config} data={[]} />
+      <div className="flex items-center justify-end">
+        {pinState === 'pinned' ? (
+          <span className="flex items-center gap-1.5 text-xs text-emerald-300">
+            <CheckCircle className="h-3 w-3" />
+            Pinned to dashboard
+          </span>
+        ) : pinState === 'error' ? (
+          <span className="flex items-center gap-1.5 text-xs text-red-400">
+            <AlertCircle className="h-3 w-3" />
+            Failed to pin
+          </span>
+        ) : (
+          <button
+            onClick={handlePin}
+            disabled={pinState === 'pinning'}
+            className="flex items-center gap-1.5 text-xs px-3 py-1 rounded-md bg-indigo-500/15 border border-indigo-500/25 text-indigo-300 hover:bg-indigo-500/25 transition-colors disabled:opacity-40"
+          >
+            {pinState === 'pinning' ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <Pin className="h-3 w-3" />
+            )}
+            📌 Pin to Dashboard
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
 // ── ToolInvocationPart renderer ──────────────────────────────────────────────
 
 function ToolInvocationRenderer({
@@ -263,7 +324,46 @@ function ToolInvocationRenderer({
   onProposalStateChange: (id: string, next: ProposalState) => void
 }) {
   const isPending = part.state === 'call' || part.state === 'partial-call'
+  const result = part.result
 
+  // Generative UI: metrics dashboard widget — own skeleton while generating
+  if (part.toolName === 'show_metrics_dashboard') {
+    if (isPending || !result) {
+      return <Skeleton className="h-48 w-full rounded-xl" />
+    }
+    const { category, summaryText, dataPoints } = result as {
+      category: string
+      summaryText: string
+      dataPoints: Array<{ label: string; value: string | number }>
+    }
+    return (
+      <MetricsDashboard
+        category={category}
+        summaryText={summaryText}
+        dataPoints={dataPoints}
+      />
+    )
+  }
+
+  // Generative UI: live-data chart widget from render_dashboard_widget tool
+  if (part.toolName === 'render_dashboard_widget') {
+    if (isPending || !result) {
+      return <Skeleton className="h-[300px] w-full rounded-xl animate-pulse [box-shadow:0_0_20px_rgba(99,102,241,0.15)]" />
+    }
+    const { config, data, explanation } = result as DynamicWidgetProps
+    return <ChatDynamicWidget config={config} data={data} explanation={explanation} />
+  }
+
+  // Generative UI: suggested pinnable chart widget
+  if (part.toolName === 'suggest_dashboard_widget') {
+    if (isPending || !result) {
+      return <Skeleton className="h-52 w-full rounded-xl" />
+    }
+    const config = result as WidgetConfig
+    return <DashboardWidgetCard config={config} />
+  }
+
+  // Generic pending state for all other tools
   if (isPending) {
     return (
       <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-xs text-white/40">
@@ -272,8 +372,6 @@ function ToolInvocationRenderer({
       </div>
     )
   }
-
-  const result = part.result
 
   // Render drafted training sessions inline
   if (

--- a/src/components/ai/widgets/DynamicWidget.tsx
+++ b/src/components/ai/widgets/DynamicWidget.tsx
@@ -1,0 +1,170 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  Cell,
+} from 'recharts'
+import { Pin, CheckCircle, AlertCircle, Loader2 } from 'lucide-react'
+
+export interface DynamicWidgetProps {
+  config: {
+    chartType: 'line' | 'bar'
+    metricKeys: string[]
+  }
+  /** Recharts-ready array: each object has a 'date' key + one key per metricKey */
+  data: Record<string, unknown>[]
+  explanation: string
+}
+
+const LINE_COLORS = ['#818cf8', '#34d399', '#38bdf8', '#fb923c', '#f472b6']
+
+const tooltipStyle = {
+  contentStyle: {
+    background: 'rgba(0,0,0,0.85)',
+    border: '1px solid rgba(255,255,255,0.1)',
+    borderRadius: '8px',
+    fontSize: '11px',
+    color: 'rgba(255,255,255,0.8)',
+  },
+  cursor: { fill: 'rgba(255,255,255,0.04)' },
+}
+
+const axisProps = {
+  tick: { fontSize: 9, fill: 'rgba(255,255,255,0.3)' },
+  axisLine: false as const,
+  tickLine: false as const,
+}
+
+export function DynamicWidget({ config, data, explanation }: DynamicWidgetProps) {
+  const { chartType, metricKeys } = config
+  const [pinState, setPinState] = useState<'idle' | 'pinning' | 'pinned' | 'error'>('idle')
+
+  const handlePin = async () => {
+    setPinState('pinning')
+    try {
+      const res = await fetch('/api/dashboard/pin-widget', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          widget_config: {
+            chart_type: chartType,
+            metric_keys: metricKeys,
+            title: metricKeys.join(' · '),
+          },
+        }),
+      })
+      setPinState(res.ok ? 'pinned' : 'error')
+    } catch {
+      setPinState('error')
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-indigo-500/25 bg-indigo-500/5 overflow-hidden w-full">
+      {/* Header row */}
+      <div className="flex items-center justify-between gap-2 px-4 py-2.5 border-b border-indigo-500/20 bg-indigo-500/10">
+        <span className="text-xs font-semibold text-indigo-300 capitalize truncate">
+          {chartType} — {metricKeys.join(' · ')}
+        </span>
+
+        {pinState === 'pinned' ? (
+          <span className="flex items-center gap-1 text-[10px] text-emerald-400 shrink-0">
+            <CheckCircle className="h-3 w-3" />
+            Pinned
+          </span>
+        ) : pinState === 'error' ? (
+          <span className="flex items-center gap-1 text-[10px] text-red-400 shrink-0">
+            <AlertCircle className="h-3 w-3" />
+            Failed
+          </span>
+        ) : (
+          <button
+            onClick={handlePin}
+            disabled={pinState === 'pinning'}
+            className="flex items-center gap-1 text-[10px] px-2 py-1 rounded-md bg-indigo-500/20 border border-indigo-500/30 text-indigo-300 hover:bg-indigo-500/30 transition-colors disabled:opacity-40 shrink-0"
+          >
+            {pinState === 'pinning' ? (
+              <Loader2 className="h-2.5 w-2.5 animate-spin" />
+            ) : (
+              <Pin className="h-2.5 w-2.5" />
+            )}
+            📌 Pin
+          </button>
+        )}
+      </div>
+
+      {/* Chart */}
+      <div className="px-2 pt-4 pb-2">
+        {data.length === 0 ? (
+          <div className="flex items-center justify-center h-[180px] text-xs text-white/30">
+            No data available for the selected period
+          </div>
+        ) : chartType === 'line' ? (
+          <ResponsiveContainer width="100%" height={180}>
+            <LineChart data={data}>
+              <CartesianGrid stroke="rgba(255,255,255,0.04)" strokeDasharray="3 3" />
+              <XAxis dataKey="date" {...axisProps} />
+              <YAxis {...axisProps} width={28} />
+              <Tooltip {...tooltipStyle} />
+              <Legend
+                wrapperStyle={{ fontSize: '10px', color: 'rgba(255,255,255,0.4)', paddingTop: '8px' }}
+              />
+              {metricKeys.map((key, i) => (
+                <Line
+                  key={key}
+                  type="monotone"
+                  dataKey={key}
+                  stroke={LINE_COLORS[i % LINE_COLORS.length]}
+                  strokeWidth={1.5}
+                  dot={false}
+                  activeDot={{ r: 3 }}
+                  connectNulls
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        ) : (
+          <ResponsiveContainer width="100%" height={180}>
+            <BarChart data={data} barCategoryGap="25%">
+              <CartesianGrid stroke="rgba(255,255,255,0.04)" strokeDasharray="3 3" vertical={false} />
+              <XAxis dataKey="date" {...axisProps} />
+              <YAxis {...axisProps} width={28} />
+              <Tooltip {...tooltipStyle} />
+              <Legend
+                wrapperStyle={{ fontSize: '10px', color: 'rgba(255,255,255,0.4)', paddingTop: '8px' }}
+              />
+              {metricKeys.map((key, i) => (
+                <Bar key={key} dataKey={key} radius={[3, 3, 0, 0]}>
+                  {data.map((_, j) => (
+                    <Cell
+                      key={j}
+                      fill={LINE_COLORS[i % LINE_COLORS.length]}
+                      fillOpacity={0.8}
+                    />
+                  ))}
+                </Bar>
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      {/* Explanation */}
+      {explanation && (
+        <p className="px-4 pb-3 text-[11px] text-white/40 leading-relaxed border-t border-white/5 pt-2.5 mt-1">
+          {explanation}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/ai/widgets/MetricsDashboard.tsx
+++ b/src/components/ai/widgets/MetricsDashboard.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import {
+  Dumbbell,
+  Salad,
+  Briefcase,
+  Puzzle,
+  Sunrise,
+  TrendingUp,
+  TrendingDown,
+  Minus,
+} from 'lucide-react'
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Cell,
+} from 'recharts'
+
+export interface MetricsDashboardProps {
+  category: string
+  summaryText: string
+  dataPoints: Array<{ label: string; value: string | number }>
+}
+
+const CATEGORY_META: Record<string, { icon: React.ElementType; color: string; bg: string; border: string }> = {
+  training: { icon: Dumbbell,  color: 'text-violet-400', bg: 'bg-violet-500/10', border: 'border-violet-500/20' },
+  nutrition: { icon: Salad,    color: 'text-emerald-400', bg: 'bg-emerald-500/10', border: 'border-emerald-500/20' },
+  work:      { icon: Briefcase, color: 'text-sky-400',    bg: 'bg-sky-500/10',    border: 'border-sky-500/20' },
+  hobby:     { icon: Puzzle,   color: 'text-amber-400',  bg: 'bg-amber-500/10',  border: 'border-amber-500/20' },
+  morning:   { icon: Sunrise,  color: 'text-orange-400', bg: 'bg-orange-500/10', border: 'border-orange-500/20' },
+}
+
+const DEFAULT_META = { icon: TrendingUp, color: 'text-indigo-400', bg: 'bg-indigo-500/10', border: 'border-indigo-500/20' }
+
+const BAR_COLORS = ['#818cf8', '#34d399', '#38bdf8', '#fb923c', '#f472b6']
+
+// Determine if a numeric value looks like it improved (positive), declined (negative),
+// or is neutral (non-numeric / exactly 0).
+function trendIcon(value: string | number) {
+  const n = typeof value === 'number' ? value : parseFloat(String(value))
+  if (isNaN(n) || n === 0) return <Minus className="h-3 w-3 text-white/30" />
+  if (n > 0) return <TrendingUp className="h-3 w-3 text-emerald-400" />
+  return <TrendingDown className="h-3 w-3 text-red-400" />
+}
+
+// Only include data points that have a numeric value for the chart
+function numericPoints(dataPoints: MetricsDashboardProps['dataPoints']) {
+  return dataPoints
+    .map((d) => ({ ...d, num: typeof d.value === 'number' ? d.value : parseFloat(String(d.value)) }))
+    .filter((d) => !isNaN(d.num))
+}
+
+export function MetricsDashboard({ category, summaryText, dataPoints }: MetricsDashboardProps) {
+  const meta = CATEGORY_META[category.toLowerCase()] ?? DEFAULT_META
+  const Icon = meta.icon
+  const chartData = numericPoints(dataPoints)
+  const showChart = chartData.length >= 2
+
+  return (
+    <div className={`rounded-xl border ${meta.border} ${meta.bg} overflow-hidden w-full`}>
+      {/* Header */}
+      <div className={`flex items-center gap-2.5 px-4 py-3 border-b ${meta.border}`}>
+        <div className={`flex h-7 w-7 items-center justify-center rounded-lg ${meta.bg} border ${meta.border}`}>
+          <Icon className={`h-3.5 w-3.5 ${meta.color}`} />
+        </div>
+        <div>
+          <p className={`text-xs font-semibold capitalize ${meta.color}`}>{category} Dashboard</p>
+          <p className="text-[10px] text-white/35 leading-tight mt-0.5 line-clamp-2">{summaryText}</p>
+        </div>
+      </div>
+
+      {/* Metric cards grid */}
+      <div className="grid grid-cols-2 gap-px bg-white/5 border-b border-white/5">
+        {dataPoints.map((dp, i) => (
+          <div key={i} className="flex items-center justify-between px-3 py-2.5 bg-black/20">
+            <span className="text-xs text-white/50 truncate pr-2">{dp.label}</span>
+            <div className="flex items-center gap-1.5 shrink-0">
+              <span className="text-sm font-semibold text-white tabular-nums">{dp.value}</span>
+              {trendIcon(dp.value)}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Bar chart — only if 2+ numeric points */}
+      {showChart && (
+        <div className="px-3 pt-3 pb-2">
+          <ResponsiveContainer width="100%" height={80}>
+            <BarChart data={chartData} barCategoryGap="30%">
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: 9, fill: 'rgba(255,255,255,0.3)' }}
+                axisLine={false}
+                tickLine={false}
+              />
+              <YAxis hide />
+              <Tooltip
+                contentStyle={{
+                  background: 'rgba(0,0,0,0.8)',
+                  border: '1px solid rgba(255,255,255,0.1)',
+                  borderRadius: '6px',
+                  fontSize: '11px',
+                  color: 'rgba(255,255,255,0.8)',
+                }}
+                cursor={{ fill: 'rgba(255,255,255,0.04)' }}
+              />
+              <Bar dataKey="num" radius={[3, 3, 0, 0]}>
+                {chartData.map((_, i) => (
+                  <Cell key={i} fill={BAR_COLORS[i % BAR_COLORS.length]} fillOpacity={0.8} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/dashboard/DynamicWidget.tsx
+++ b/src/components/dashboard/DynamicWidget.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Cell,
+} from 'recharts'
+
+export interface WidgetConfig {
+  chart_type: 'line' | 'bar' | 'scatter'
+  metric_keys: string[]
+  /** Optional human-readable title shown above the chart */
+  title?: string
+}
+
+interface DynamicWidgetProps {
+  widget_config: WidgetConfig
+  /** Array of data objects. Keys must overlap with widget_config.metric_keys. */
+  data: Record<string, unknown>[]
+}
+
+const LINE_COLORS = ['#818cf8', '#34d399', '#38bdf8', '#fb923c', '#f472b6']
+
+const tooltipStyle = {
+  contentStyle: {
+    background: 'rgba(0,0,0,0.85)',
+    border: '1px solid rgba(255,255,255,0.1)',
+    borderRadius: '6px',
+    fontSize: '11px',
+    color: 'rgba(255,255,255,0.8)',
+  },
+  cursor: { fill: 'rgba(255,255,255,0.04)', stroke: 'rgba(255,255,255,0.1)' },
+}
+
+const axisProps = {
+  tick: { fontSize: 9, fill: 'rgba(255,255,255,0.3)' },
+  axisLine: false as const,
+  tickLine: false as const,
+}
+
+function TrendLineChart({ data, keys }: { data: Record<string, unknown>[]; keys: string[] }) {
+  return (
+    <ResponsiveContainer width="100%" height={140}>
+      <LineChart data={data}>
+        <CartesianGrid stroke="rgba(255,255,255,0.04)" strokeDasharray="3 3" />
+        <XAxis dataKey="date" {...axisProps} />
+        <YAxis {...axisProps} width={28} />
+        <Tooltip {...tooltipStyle} />
+        {keys.map((key, i) => (
+          <Line
+            key={key}
+            type="monotone"
+            dataKey={key}
+            stroke={LINE_COLORS[i % LINE_COLORS.length]}
+            strokeWidth={1.5}
+            dot={false}
+            activeDot={{ r: 3 }}
+          />
+        ))}
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}
+
+function TrendBarChart({ data, keys }: { data: Record<string, unknown>[]; keys: string[] }) {
+  const primaryKey = keys[0]
+  return (
+    <ResponsiveContainer width="100%" height={140}>
+      <BarChart data={data} barCategoryGap="30%">
+        <CartesianGrid stroke="rgba(255,255,255,0.04)" strokeDasharray="3 3" vertical={false} />
+        <XAxis dataKey="date" {...axisProps} />
+        <YAxis {...axisProps} width={28} />
+        <Tooltip {...tooltipStyle} />
+        <Bar dataKey={primaryKey} radius={[3, 3, 0, 0]}>
+          {data.map((_, i) => (
+            <Cell key={i} fill={LINE_COLORS[i % LINE_COLORS.length]} fillOpacity={0.8} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}
+
+function TrendScatterChart({ data, keys }: { data: Record<string, unknown>[]; keys: string[] }) {
+  const [xKey, yKey] = [keys[0], keys[1] ?? keys[0]]
+  // Reshape for Recharts Scatter: needs {x, y} shaped data
+  const shaped = data.map((row) => ({ x: row[xKey], y: row[yKey] }))
+  return (
+    <ResponsiveContainer width="100%" height={140}>
+      <ScatterChart>
+        <CartesianGrid stroke="rgba(255,255,255,0.04)" strokeDasharray="3 3" />
+        <XAxis type="number" dataKey="x" name={xKey} {...axisProps} />
+        <YAxis type="number" dataKey="y" name={yKey} {...axisProps} width={28} />
+        <Tooltip {...tooltipStyle} />
+        <Scatter data={shaped} fill={LINE_COLORS[0]} fillOpacity={0.7} />
+      </ScatterChart>
+    </ResponsiveContainer>
+  )
+}
+
+export function DynamicWidget({ widget_config, data }: DynamicWidgetProps) {
+  const { chart_type, metric_keys, title } = widget_config
+  const label = title ?? metric_keys.join(' · ')
+
+  return (
+    <div className="rounded-xl border border-indigo-500/20 bg-indigo-500/5 overflow-hidden w-full">
+      <div className="flex items-center gap-2 px-4 py-2.5 border-b border-indigo-500/20">
+        <span className="text-xs font-semibold text-indigo-300 capitalize">
+          {chart_type} — {label}
+        </span>
+      </div>
+      <div className="px-2 pt-3 pb-2">
+        {chart_type === 'line' && <TrendLineChart data={data} keys={metric_keys} />}
+        {chart_type === 'bar'  && <TrendBarChart  data={data} keys={metric_keys} />}
+        {chart_type === 'scatter' && <TrendScatterChart data={data} keys={metric_keys} />}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/math/correlation.ts
+++ b/src/lib/math/correlation.ts
@@ -1,0 +1,91 @@
+import { sampleCorrelation } from 'simple-statistics'
+
+export interface CorrelationResult {
+  metricA: string
+  metricB: string
+  coefficient: number
+  sampleSize: number
+}
+
+// Minimum overlapping data points required to trust the correlation
+const MIN_SAMPLE_SIZE = 5
+// Only surface correlations with strong signal
+const SIGNIFICANCE_THRESHOLD = 0.7
+
+export function calculateCorrelations(logs: { metrics: Record<string, unknown> }[]): CorrelationResult[] {
+  // Build aligned pairs per metric combination directly from logs.
+  // We iterate logs once per pair rather than pre-bucketing, so sparse
+  // metrics (e.g. hrv only logged some days) align correctly with each other.
+  const keys = extractNumericKeys(logs)
+  const results: CorrelationResult[] = []
+
+  for (let i = 0; i < keys.length; i++) {
+    for (let j = i + 1; j < keys.length; j++) {
+      const a = keys[i]
+      const b = keys[j]
+      const pairsA: number[] = []
+      const pairsB: number[] = []
+
+      for (const log of logs) {
+        if (!log.metrics) continue
+        const na = toNumber(log.metrics[a])
+        const nb = toNumber(log.metrics[b])
+        if (na !== null && nb !== null) {
+          pairsA.push(na)
+          pairsB.push(nb)
+        }
+      }
+
+      if (pairsA.length < MIN_SAMPLE_SIZE) continue
+
+      // sampleCorrelation throws if a series has zero variance (constant values)
+      let coefficient: number
+      try {
+        coefficient = sampleCorrelation(pairsA, pairsB)
+      } catch {
+        continue
+      }
+
+      if (!isFinite(coefficient)) continue
+      if (Math.abs(coefficient) < SIGNIFICANCE_THRESHOLD) continue
+
+      results.push({
+        metricA: a,
+        metricB: b,
+        coefficient: parseFloat(coefficient.toFixed(4)),
+        sampleSize: pairsA.length,
+      })
+    }
+  }
+
+  return results
+}
+
+export function buildInsightText(metricA: string, metricB: string, coefficient: number): string {
+  const direction = coefficient > 0 ? 'positive' : 'negative'
+  const strength = Math.abs(coefficient) >= 0.9 ? 'very strong' : 'strong'
+  const rounded = coefficient.toFixed(2)
+  return `Your '${metricA}' and '${metricB}' have a ${strength} ${direction} correlation (${rounded}).`
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+function extractNumericKeys(logs: { metrics: Record<string, unknown> }[]): string[] {
+  const seen = new Set<string>()
+  for (const log of logs) {
+    if (!log.metrics) continue
+    for (const [key, value] of Object.entries(log.metrics)) {
+      if (toNumber(value) !== null) seen.add(key)
+    }
+  }
+  return Array.from(seen)
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === 'number') return isFinite(value) ? value : null
+  if (typeof value === 'string') {
+    const n = parseFloat(value)
+    return isFinite(n) ? n : null
+  }
+  return null
+}

--- a/supabase/migrations/20260310000001_adaptation_engine.sql
+++ b/supabase/migrations/20260310000001_adaptation_engine.sql
@@ -1,0 +1,67 @@
+-- Adaptation Engine: adds confidence/rationale to coach_tasks,
+-- plus user_dashboards (pinned widgets) and user_insights (correlation results).
+
+-- ── coach_tasks: add AI confidence columns ────────────────────────────────────
+
+ALTER TABLE public.coach_tasks
+  ADD COLUMN IF NOT EXISTS confidence_score NUMERIC,
+  ADD COLUMN IF NOT EXISTS rationale TEXT;
+
+-- ── user_dashboards ───────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.user_dashboards (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  widget_config JSONB NOT NULL DEFAULT '{}',
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.user_dashboards ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "user_dashboards: owner select"
+  ON public.user_dashboards FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "user_dashboards: owner insert"
+  ON public.user_dashboards FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "user_dashboards: owner update"
+  ON public.user_dashboards FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX IF NOT EXISTS user_dashboards_user ON public.user_dashboards (user_id);
+
+DROP TRIGGER IF EXISTS user_dashboards_updated_at ON public.user_dashboards;
+CREATE TRIGGER user_dashboards_updated_at
+  BEFORE UPDATE ON public.user_dashboards
+  FOR EACH ROW EXECUTE PROCEDURE public.set_updated_at();
+
+-- ── user_insights ─────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.user_insights (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  insight_text TEXT NOT NULL,
+  confidence   NUMERIC NOT NULL CHECK (confidence >= 0 AND confidence <= 1),
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.user_insights ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "user_insights: owner select"
+  ON public.user_insights FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "user_insights: owner insert"
+  ON public.user_insights FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "user_insights: owner update"
+  ON public.user_insights FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX IF NOT EXISTS user_insights_user_created ON public.user_insights (user_id, created_at DESC);

--- a/supabase/migrations/20260311000000_production_schema.sql
+++ b/supabase/migrations/20260311000000_production_schema.sql
@@ -1,0 +1,189 @@
+-- Production schema: pgvector, generated columns, override tracking,
+-- and expanded correlation engine tables.
+--
+-- Fully defensive: every ALTER TABLE is wrapped in a DO $$ existence check.
+-- Safe to run regardless of which prior migrations landed.
+
+-- ── 1. Extensions ─────────────────────────────────────────────────────────────
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- ── 2. user_profiles — weekly summary + AI override tracking ─────────────────
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='user_profiles' AND column_name='weekly_summaries') THEN
+    ALTER TABLE public.user_profiles ADD COLUMN weekly_summaries TEXT;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='user_profiles' AND column_name='ai_preferences') THEN
+    ALTER TABLE public.user_profiles
+      ADD COLUMN ai_preferences JSONB NOT NULL DEFAULT '{"overrides": {}}';
+  END IF;
+END;
+$$;
+
+-- ── 3. daily_logs — pgvector embedding + HRV generated column ─────────────────
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='daily_logs' AND column_name='embedding') THEN
+    ALTER TABLE public.daily_logs ADD COLUMN embedding vector(1536);
+  END IF;
+
+  -- Generated columns have no IF NOT EXISTS syntax — guard manually
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='daily_logs' AND column_name='hrv_numeric') THEN
+    ALTER TABLE public.daily_logs
+      ADD COLUMN hrv_numeric NUMERIC
+        GENERATED ALWAYS AS ((metrics->>'hrv')::numeric) STORED;
+  END IF;
+END;
+$$;
+
+-- IVFFlat index for approximate nearest-neighbour cosine search
+CREATE INDEX IF NOT EXISTS daily_logs_embedding_ivfflat
+  ON public.daily_logs
+  USING ivfflat (embedding vector_cosine_ops)
+  WITH (lists = 100);
+
+-- Partial btree on the generated HRV column
+CREATE INDEX IF NOT EXISTS daily_logs_hrv_numeric
+  ON public.daily_logs (user_id, hrv_numeric)
+  WHERE hrv_numeric IS NOT NULL;
+
+-- ── 4. user_insights — full correlation engine schema ─────────────────────────
+-- May not exist at all if adaptation_engine migration never ran.
+
+CREATE TABLE IF NOT EXISTS public.user_insights (
+  id                    UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id               UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  insight_text          TEXT        NOT NULL,
+  confidence            NUMERIC     CHECK (confidence IS NULL OR (confidence >= 0 AND confidence <= 1)),
+  metric_a              TEXT,
+  metric_b              TEXT,
+  coefficient           NUMERIC,
+  p_value               NUMERIC,
+  confounding_variables JSONB,
+  actionable            BOOLEAN     NOT NULL DEFAULT false,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- If the table already existed in its thin form, add missing columns
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='user_insights' AND column_name='metric_a') THEN
+    ALTER TABLE public.user_insights ADD COLUMN metric_a TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='user_insights' AND column_name='metric_b') THEN
+    ALTER TABLE public.user_insights ADD COLUMN metric_b TEXT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='user_insights' AND column_name='coefficient') THEN
+    ALTER TABLE public.user_insights ADD COLUMN coefficient NUMERIC;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='user_insights' AND column_name='p_value') THEN
+    ALTER TABLE public.user_insights ADD COLUMN p_value NUMERIC;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='user_insights' AND column_name='confounding_variables') THEN
+    ALTER TABLE public.user_insights ADD COLUMN confounding_variables JSONB;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='user_insights' AND column_name='actionable') THEN
+    ALTER TABLE public.user_insights ADD COLUMN actionable BOOLEAN NOT NULL DEFAULT false;
+  END IF;
+END;
+$$;
+
+ALTER TABLE public.user_insights ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies
+      WHERE schemaname='public' AND tablename='user_insights' AND policyname='user_insights: owner') THEN
+    EXECUTE $p$
+      CREATE POLICY "user_insights: owner"
+        ON public.user_insights FOR ALL
+        USING  (auth.uid() = user_id)
+        WITH CHECK (auth.uid() = user_id)
+    $p$;
+  END IF;
+END;
+$$;
+
+CREATE INDEX IF NOT EXISTS user_insights_actionable
+  ON public.user_insights (user_id, actionable, created_at DESC);
+
+-- ── 5. coach_tasks — status, confidence_score, rationale ─────────────────────
+-- The master_schema (00000000000000) created coach_tasks with a minimal schema:
+--   task_description TEXT, completed BOOLEAN, completed_at TIMESTAMPTZ.
+-- Later migrations may have added title/source/confidence_score/rationale.
+-- We add only what's missing, then add the new status column.
+
+DO $$
+BEGIN
+  -- Columns from 20260309000002 that may not exist
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='coach_tasks' AND column_name='source') THEN
+    ALTER TABLE public.coach_tasks
+      ADD COLUMN source TEXT NOT NULL DEFAULT 'user'
+        CHECK (source IN ('user', 'ai_coach'));
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='coach_tasks' AND column_name='confidence_score') THEN
+    ALTER TABLE public.coach_tasks ADD COLUMN confidence_score NUMERIC;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='coach_tasks' AND column_name='rationale') THEN
+    ALTER TABLE public.coach_tasks ADD COLUMN rationale TEXT;
+  END IF;
+
+  -- New status column for override tracking
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='coach_tasks' AND column_name='status') THEN
+    ALTER TABLE public.coach_tasks
+      ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'completed', 'dismissed'));
+  END IF;
+END;
+$$;
+
+-- Backfill: rows completed via the old completed_at / completed=true paths
+UPDATE public.coach_tasks
+   SET status = 'completed'
+ WHERE status = 'pending'
+   AND (completed_at IS NOT NULL OR completed = true);
+
+-- Trigger: keep completed_at in sync when status is set via the new path
+CREATE OR REPLACE FUNCTION public.sync_coach_task_status()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.status = 'completed' AND OLD.status <> 'completed' THEN
+    NEW.completed_at = COALESCE(NEW.completed_at, now());
+  END IF;
+  IF NEW.status IN ('pending', 'dismissed') THEN
+    NEW.completed_at = NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS coach_tasks_sync_status ON public.coach_tasks;
+CREATE TRIGGER coach_tasks_sync_status
+  BEFORE UPDATE ON public.coach_tasks
+  FOR EACH ROW EXECUTE FUNCTION public.sync_coach_task_status();
+
+-- Partial index: pending AI suggestions ranked by confidence
+-- Only created once source column exists (guaranteed above)
+CREATE INDEX IF NOT EXISTS coach_tasks_pending_ai
+  ON public.coach_tasks (user_id, confidence_score DESC)
+  WHERE status = 'pending' AND source = 'ai_coach';

--- a/supabase/reset_schema.sql
+++ b/supabase/reset_schema.sql
@@ -1,0 +1,1073 @@
+-- ============================================================
+-- Life OS — Full Reset Schema
+-- Run this on a FRESH / WIPED Supabase database.
+-- Paste into the Supabase SQL editor and execute once.
+-- ============================================================
+
+-- ── Extensions ────────────────────────────────────────────────
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- ── Shared updated_at trigger function ────────────────────────
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+-- ============================================================
+-- ENUMS
+-- ============================================================
+
+CREATE TYPE instrument      AS ENUM ('NQ', 'Gold', 'CL', '6E', 'ES');
+CREATE TYPE trade_direction AS ENUM ('long', 'short');
+CREATE TYPE trade_outcome   AS ENUM ('win', 'loss', 'break_even', 'open');
+CREATE TYPE prop_firm       AS ENUM ('FundedNext', 'AlphaFutures', 'TakeProfitTrader', 'YRM');
+CREATE TYPE trading_session AS ENUM ('london', 'new_york_am', 'new_york_pm', 'overnight', 'asia');
+CREATE TYPE mood_rating     AS ENUM ('1', '2', '3', '4', '5');
+CREATE TYPE workout_type    AS ENUM ('easy','long_run','tempo','threshold','interval','recovery','race','other');
+
+-- ============================================================
+-- AUTH LAYER
+-- profiles: thin extension of auth.users
+-- ============================================================
+
+CREATE TABLE public.profiles (
+  id         UUID        PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  username   TEXT        UNIQUE,
+  full_name  TEXT,
+  avatar_url TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "profiles: owner" ON public.profiles FOR ALL
+  USING (auth.uid() = id) WITH CHECK (auth.uid() = id);
+
+CREATE TRIGGER profiles_updated_at
+  BEFORE UPDATE ON public.profiles
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  INSERT INTO public.profiles (id) VALUES (NEW.id);
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- ============================================================
+-- LIFE OS CORE
+-- user_profiles, user_goals, daily_logs, user_insights,
+-- user_dashboards, coach_conversations, coach_tasks
+-- ============================================================
+
+-- ── user_profiles ─────────────────────────────────────────────
+CREATE TABLE public.user_profiles (
+  user_id          UUID        PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  ai_context       TEXT,
+  setup_completed  BOOLEAN     NOT NULL DEFAULT false,
+  weekly_summaries TEXT,
+  ai_preferences   JSONB       NOT NULL DEFAULT '{"overrides": {}}',
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.user_profiles ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "user_profiles: owner" ON public.user_profiles FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER user_profiles_updated_at
+  BEFORE UPDATE ON public.user_profiles
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE OR REPLACE FUNCTION public.handle_new_user_profile()
+RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  INSERT INTO public.user_profiles (user_id)
+  VALUES (NEW.id)
+  ON CONFLICT (user_id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER on_auth_user_created_profile
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user_profile();
+
+-- ── user_goals ────────────────────────────────────────────────
+CREATE TABLE public.user_goals (
+  id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id        UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  category       TEXT        NOT NULL CHECK (category IN ('training','nutrition','work','hobby','morning')),
+  title          TEXT        NOT NULL,
+  description    TEXT,
+  target_metrics JSONB       NOT NULL DEFAULT '{}',
+  is_active      BOOLEAN     NOT NULL DEFAULT true,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.user_goals ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "user_goals: owner" ON public.user_goals FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX user_goals_user_category ON public.user_goals (user_id, category);
+
+CREATE TRIGGER user_goals_updated_at
+  BEFORE UPDATE ON public.user_goals
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- ── daily_logs ────────────────────────────────────────────────
+-- The flexible JSONB log for all domains (training, nutrition, work, hobby, morning).
+-- embedding: pgvector for semantic retrieval of journal notes.
+-- hrv_numeric: generated column for fast HRV range queries without JSONB deserialization.
+
+CREATE TABLE public.daily_logs (
+  id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id        UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  category       TEXT        NOT NULL CHECK (category IN ('training','nutrition','work','hobby','morning')),
+  date           DATE        NOT NULL,
+  metrics        JSONB       NOT NULL DEFAULT '{}',
+  journal_notes  TEXT,
+  embedding      vector(1536),
+  hrv_numeric    NUMERIC     GENERATED ALWAYS AS ((metrics->>'hrv')::numeric) STORED,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.daily_logs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "daily_logs: owner" ON public.daily_logs FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX daily_logs_user_category_date ON public.daily_logs (user_id, category, date DESC);
+CREATE UNIQUE INDEX daily_logs_unique_day   ON public.daily_logs (user_id, category, date);
+CREATE INDEX daily_logs_hrv_numeric        ON public.daily_logs (user_id, hrv_numeric) WHERE hrv_numeric IS NOT NULL;
+CREATE INDEX daily_logs_embedding_ivfflat
+  ON public.daily_logs USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
+
+CREATE TRIGGER daily_logs_updated_at
+  BEFORE UPDATE ON public.daily_logs
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- ── user_insights ─────────────────────────────────────────────
+-- Mathematical correlation facts produced by background CRON jobs.
+
+CREATE TABLE public.user_insights (
+  id                    UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id               UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  insight_text          TEXT        NOT NULL,
+  confidence            NUMERIC     CHECK (confidence IS NULL OR (confidence >= 0 AND confidence <= 1)),
+  metric_a              TEXT,
+  metric_b              TEXT,
+  coefficient           NUMERIC,
+  p_value               NUMERIC,
+  confounding_variables JSONB,
+  actionable            BOOLEAN     NOT NULL DEFAULT false,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.user_insights ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "user_insights: owner" ON public.user_insights FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX user_insights_user_created  ON public.user_insights (user_id, created_at DESC);
+CREATE INDEX user_insights_actionable    ON public.user_insights (user_id, actionable, created_at DESC);
+
+-- ── user_dashboards ───────────────────────────────────────────
+CREATE TABLE public.user_dashboards (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  widget_config JSONB       NOT NULL DEFAULT '{}',
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.user_dashboards ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "user_dashboards: owner" ON public.user_dashboards FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX user_dashboards_user ON public.user_dashboards (user_id);
+
+CREATE TRIGGER user_dashboards_updated_at
+  BEFORE UPDATE ON public.user_dashboards
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- ── coach_conversations ───────────────────────────────────────
+CREATE TABLE public.coach_conversations (
+  id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id          UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  session_id       UUID        NOT NULL DEFAULT gen_random_uuid(),
+  role             TEXT        NOT NULL CHECK (role IN ('user', 'assistant', 'system', 'tool')),
+  content          TEXT        NOT NULL,
+  tool_calls       JSONB,
+  context_snapshot JSONB,
+  embedding        vector(1536),
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.coach_conversations ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "coach_conversations: owner" ON public.coach_conversations FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX coach_conversations_user_created ON public.coach_conversations (user_id, created_at DESC);
+
+-- ── coach_tasks ───────────────────────────────────────────────
+-- status lifecycle: pending → completed | dismissed
+-- 'dismissed' signals the app layer to increment ai_preferences.overrides[task_text]
+
+CREATE TABLE public.coach_tasks (
+  id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id          UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  title            TEXT        NOT NULL,
+  notes            TEXT,
+  due_date         DATE,
+  due_time         TIME,
+  recurrence       TEXT        NOT NULL DEFAULT 'none'
+                               CHECK (recurrence IN ('none','daily','weekly','weekdays')),
+  module           TEXT        CHECK (module IN ('general','training','nutrition','trading','health','personal')),
+  status           TEXT        NOT NULL DEFAULT 'pending'
+                               CHECK (status IN ('pending','completed','dismissed')),
+  completed_at     TIMESTAMPTZ,
+  snoozed_until    DATE,
+  source           TEXT        NOT NULL DEFAULT 'user'
+                               CHECK (source IN ('user','ai_coach')),
+  coach_context    TEXT,
+  confidence_score NUMERIC,
+  rationale        TEXT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.coach_tasks ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "coach_tasks: owner" ON public.coach_tasks FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX coach_tasks_user_due    ON public.coach_tasks (user_id, due_date, status);
+CREATE INDEX coach_tasks_pending_ai  ON public.coach_tasks (user_id, confidence_score DESC)
+  WHERE status = 'pending' AND source = 'ai_coach';
+
+CREATE OR REPLACE FUNCTION public.sync_coach_task_status()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.status = 'completed' AND OLD.status <> 'completed' THEN
+    NEW.completed_at = COALESCE(NEW.completed_at, now());
+  END IF;
+  IF NEW.status IN ('pending', 'dismissed') THEN
+    NEW.completed_at = NULL;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER coach_tasks_sync_status
+  BEFORE UPDATE ON public.coach_tasks
+  FOR EACH ROW EXECUTE FUNCTION public.sync_coach_task_status();
+
+CREATE TRIGGER coach_tasks_updated_at
+  BEFORE UPDATE ON public.coach_tasks
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- ============================================================
+-- HABITS
+-- ============================================================
+
+CREATE TABLE public.habits (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name         TEXT        NOT NULL,
+  description  TEXT,
+  category     TEXT        NOT NULL DEFAULT 'general',
+  frequency    TEXT        NOT NULL DEFAULT 'daily' CHECK (frequency IN ('daily','weekly')),
+  target_count INT         NOT NULL DEFAULT 1 CHECK (target_count >= 1),
+  color        TEXT        NOT NULL DEFAULT '#6366f1',
+  icon         TEXT,
+  is_archived  BOOLEAN     NOT NULL DEFAULT false,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.habits ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "habits: owner" ON public.habits FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER habits_updated_at
+  BEFORE UPDATE ON public.habits
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TABLE public.habit_logs (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  habit_id   UUID        NOT NULL REFERENCES public.habits(id) ON DELETE CASCADE,
+  logged_at  DATE        NOT NULL DEFAULT current_date,
+  count      INT         NOT NULL DEFAULT 1 CHECK (count >= 1),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (habit_id, logged_at)
+);
+
+ALTER TABLE public.habit_logs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "habit_logs: owner" ON public.habit_logs FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX habit_logs_habit_logged ON public.habit_logs (habit_id, logged_at DESC);
+
+-- ============================================================
+-- TRADING
+-- ============================================================
+
+CREATE TABLE public.prop_accounts (
+  id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id          UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  firm             prop_firm   NOT NULL,
+  account_label    TEXT        NOT NULL,
+  account_size     NUMERIC(14,2) NOT NULL,
+  balance          NUMERIC(14,2),
+  daily_loss_limit NUMERIC(14,2),
+  max_drawdown     NUMERIC(14,2),
+  profit_target    NUMERIC(14,2),
+  is_active        BOOLEAN     NOT NULL DEFAULT true,
+  is_funded        BOOLEAN     NOT NULL DEFAULT false,
+  notes            TEXT,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.prop_accounts ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "prop_accounts: owner" ON public.prop_accounts FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER prop_accounts_updated_at
+  BEFORE UPDATE ON public.prop_accounts
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TABLE public.strategies (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name        TEXT        NOT NULL,
+  description TEXT,
+  rules       TEXT,
+  instruments instrument[],
+  timeframes  TEXT[],
+  tags        TEXT[],
+  is_active   BOOLEAN     NOT NULL DEFAULT true,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.strategies ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "strategies: owner" ON public.strategies FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER strategies_updated_at
+  BEFORE UPDATE ON public.strategies
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TABLE public.trades (
+  id               UUID           PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id          UUID           NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  prop_account_id  UUID           REFERENCES public.prop_accounts(id) ON DELETE SET NULL,
+  strategy_id      UUID           REFERENCES public.strategies(id) ON DELETE SET NULL,
+  instrument       instrument     NOT NULL,
+  direction        trade_direction NOT NULL,
+  entry_price      NUMERIC(14,5)  NOT NULL,
+  exit_price       NUMERIC(14,5),
+  contracts        NUMERIC(10,2)  NOT NULL DEFAULT 1,
+  entry_time       TIMESTAMPTZ    NOT NULL,
+  exit_time        TIMESTAMPTZ,
+  gross_pnl        NUMERIC(14,2),
+  fees             NUMERIC(14,2)  NOT NULL DEFAULT 0,
+  net_pnl          NUMERIC(14,2)  GENERATED ALWAYS AS (
+                     CASE WHEN gross_pnl IS NOT NULL THEN gross_pnl - fees ELSE NULL END
+                   ) STORED,
+  outcome          trade_outcome  NOT NULL DEFAULT 'open',
+  session          trading_session,
+  setup_tags       TEXT[],
+  confluence_notes TEXT,
+  entry_notes      TEXT,
+  exit_notes       TEXT,
+  lessons          TEXT,
+  screenshots      TEXT[],
+  pre_emotion      TEXT,
+  post_emotion     TEXT,
+  followed_rules   BOOLEAN,
+  is_reviewed      BOOLEAN        NOT NULL DEFAULT false,
+  -- Tradovate import columns
+  position_id      TEXT,
+  pair_id          TEXT,
+  contract         TEXT,
+  exchange_fee     DECIMAL(10,4),
+  clearing_fee     DECIMAL(10,4),
+  nfa_fee          DECIMAL(10,4),
+  commission       DECIMAL(10,4),
+  total_fees       DECIMAL(10,4),
+  created_at       TIMESTAMPTZ    NOT NULL DEFAULT now(),
+  updated_at       TIMESTAMPTZ    NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.trades ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "trades: owner" ON public.trades FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER trades_updated_at
+  BEFORE UPDATE ON public.trades
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE INDEX trades_user_entry_time ON public.trades (user_id, entry_time DESC);
+CREATE INDEX trades_user_instrument ON public.trades (user_id, instrument);
+CREATE INDEX trades_user_outcome    ON public.trades (user_id, outcome);
+CREATE UNIQUE INDEX trades_user_pair_id ON public.trades (user_id, pair_id) WHERE pair_id IS NOT NULL;
+
+CREATE TABLE public.trading_sessions (
+  id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  session_date      DATE        NOT NULL,
+  pre_market_notes  TEXT,
+  mood_before       mood_rating,
+  plan              TEXT,
+  post_market_notes TEXT,
+  mood_after        mood_rating,
+  lessons           TEXT,
+  followed_plan     BOOLEAN,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, session_date)
+);
+
+ALTER TABLE public.trading_sessions ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "trading_sessions: owner" ON public.trading_sessions FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER trading_sessions_updated_at
+  BEFORE UPDATE ON public.trading_sessions
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE INDEX trading_sessions_user_date ON public.trading_sessions (user_id, session_date DESC);
+
+-- ============================================================
+-- ATHLETICS
+-- ============================================================
+
+CREATE TABLE public.running_activities (
+  id                         UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                    UUID         NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  started_at                 TIMESTAMPTZ  NOT NULL,
+  name                       TEXT,
+  workout_type               workout_type NOT NULL DEFAULT 'easy',
+  distance_meters            NUMERIC      NOT NULL,
+  duration_seconds           INT          NOT NULL,
+  avg_pace_sec_per_km        NUMERIC,
+  prescribed_pace_sec_per_km NUMERIC,
+  avg_hr                     INT,
+  max_hr                     INT,
+  resting_hr                 INT,
+  elevation_gain_m           NUMERIC,
+  elevation_loss_m           NUMERIC,
+  avg_cadence                NUMERIC,
+  avg_stride_length_m        NUMERIC,
+  calories                   INT,
+  notes                      TEXT,
+  fit_filename               TEXT,
+  scheduled_workout_id       UUID,        -- FK added after training_schedule
+  created_at                 TIMESTAMPTZ  NOT NULL DEFAULT now(),
+  updated_at                 TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.running_activities ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "running_activities: owner" ON public.running_activities FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER running_activities_updated_at
+  BEFORE UPDATE ON public.running_activities
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE INDEX running_activities_user_started ON public.running_activities (user_id, started_at DESC);
+
+CREATE TABLE public.running_laps (
+  id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id             UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  activity_id         UUID        NOT NULL REFERENCES public.running_activities(id) ON DELETE CASCADE,
+  lap_number          INT         NOT NULL,
+  start_time          TIMESTAMPTZ,
+  distance_meters     NUMERIC     NOT NULL,
+  duration_seconds    INT         NOT NULL,
+  avg_pace_sec_per_km NUMERIC,
+  avg_hr              INT,
+  max_hr              INT,
+  elevation_gain_m    NUMERIC,
+  avg_cadence         NUMERIC,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (activity_id, lap_number)
+);
+
+ALTER TABLE public.running_laps ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "running_laps: owner" ON public.running_laps FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX running_laps_activity ON public.running_laps (activity_id, lap_number);
+
+CREATE TABLE public.resting_hr_logs (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  logged_date  DATE        NOT NULL DEFAULT CURRENT_DATE,
+  resting_hr   INT         NOT NULL,
+  source       TEXT        NOT NULL DEFAULT 'garmin' CHECK (source IN ('garmin','manual')),
+  is_spike     BOOLEAN     NOT NULL DEFAULT false,
+  notes        TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, logged_date)
+);
+
+ALTER TABLE public.resting_hr_logs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "resting_hr_logs: owner" ON public.resting_hr_logs FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TABLE public.race_targets (
+  id                     UUID    PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                UUID    NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  race_name              TEXT    NOT NULL,
+  location               TEXT,
+  race_date              DATE    NOT NULL,
+  distance_km            NUMERIC NOT NULL,
+  target_time_seconds    INT     NOT NULL,
+  target_pace_sec_per_km NUMERIC GENERATED ALWAYS AS (
+    CASE WHEN distance_km > 0 THEN target_time_seconds::numeric / distance_km ELSE NULL END
+  ) STORED,
+  actual_time_seconds    INT,
+  activity_id            UUID    REFERENCES public.running_activities(id) ON DELETE SET NULL,
+  notes                  TEXT,
+  created_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at             TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.race_targets ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "race_targets: owner" ON public.race_targets FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER race_targets_updated_at
+  BEFORE UPDATE ON public.race_targets
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TABLE public.training_schedule (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  date            DATE        NOT NULL,
+  title           TEXT        NOT NULL,
+  description     TEXT,
+  target_distance DECIMAL(6,2),
+  target_pace     TEXT,
+  type            TEXT        NOT NULL DEFAULT 'base'
+                              CHECK (type IN ('base','interval','long','rest','race')),
+  week_number     INT,
+  day_of_week     TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.training_schedule ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "training_schedule: owner" ON public.training_schedule FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX training_schedule_user_date ON public.training_schedule (user_id, date);
+
+-- Now add the FK from running_activities → training_schedule
+ALTER TABLE public.running_activities
+  ADD CONSTRAINT running_activities_schedule_fk
+  FOREIGN KEY (scheduled_workout_id) REFERENCES public.training_schedule(id) ON DELETE SET NULL;
+
+CREATE INDEX running_activities_schedule_id
+  ON public.running_activities (user_id, scheduled_workout_id)
+  WHERE scheduled_workout_id IS NOT NULL;
+
+-- Marathon plan tables
+CREATE TABLE public.training_weeks (
+  id                      UUID    PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                 UUID    NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  week_number             INT     NOT NULL CHECK (week_number BETWEEN 1 AND 9),
+  week_label              TEXT    NOT NULL,
+  week_type               TEXT    NOT NULL DEFAULT 'normal'
+    CHECK (week_type IN ('normal','limassol','post_limassol','peak','taper')),
+  planned_km              NUMERIC(5,1),
+  actual_km               NUMERIC(5,1) DEFAULT 0,
+  status                  TEXT    NOT NULL DEFAULT 'upcoming'
+    CHECK (status IN ('upcoming','in_progress','completed')),
+  blood_donation_recovery BOOLEAN NOT NULL DEFAULT false,
+  notes                   TEXT,
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, week_number)
+);
+
+ALTER TABLE public.training_weeks ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "training_weeks: owner" ON public.training_weeks FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TABLE public.training_sessions (
+  id                    UUID    PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id               UUID    NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  session_date          DATE    NOT NULL,
+  week_number           INT     NOT NULL,
+  day_of_week           TEXT    NOT NULL,
+  planned_type          TEXT    NOT NULL
+    CHECK (planned_type IN ('EASY','VO2_MAX','TEMPO','HILLS','LONG_RUN','REST','RACE','SHAKEOUT')),
+  planned_description   TEXT,
+  planned_km            NUMERIC(5,1),
+  planned_pace_min      TEXT,
+  planned_pace_max      TEXT,
+  has_strength          BOOLEAN NOT NULL DEFAULT false,
+  strength_workout      TEXT    CHECK (strength_workout IN ('A','B')),
+  status                TEXT    NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending','completed','skipped','modified')),
+  actual_km             NUMERIC(5,1),
+  actual_avg_pace       TEXT,
+  actual_avg_hr         INT,
+  actual_duration_min   INT,
+  pace_target_met       BOOLEAN,
+  pace_deviation_sec    INT,
+  warmup_done           BOOLEAN,
+  post_fuel_done        BOOLEAN,
+  perceived_effort      INT     CHECK (perceived_effort BETWEEN 1 AND 10),
+  went_too_fast         BOOLEAN NOT NULL DEFAULT false,
+  skipped_warmup        BOOLEAN NOT NULL DEFAULT false,
+  notes                 TEXT,
+  ai_feedback           TEXT,
+  coach_notes           TEXT,
+  flag                  TEXT    CHECK (flag IN ('ok','warning','rest')),
+  resting_hr            INT,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, session_date)
+);
+
+ALTER TABLE public.training_sessions ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "training_sessions: owner" ON public.training_sessions FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER training_sessions_updated_at
+  BEFORE UPDATE ON public.training_sessions
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE INDEX training_sessions_user_date ON public.training_sessions (user_id, session_date DESC);
+CREATE INDEX training_sessions_user_week ON public.training_sessions (user_id, week_number);
+
+CREATE TABLE public.race_results (
+  id                  UUID    PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id             UUID    NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  race_date           DATE    NOT NULL,
+  race_name           TEXT    NOT NULL,
+  distance_km         NUMERIC(5,2),
+  finish_time         TEXT,
+  finish_time_seconds INT,
+  avg_pace            TEXT,
+  official            BOOLEAN NOT NULL DEFAULT true,
+  notes               TEXT,
+  ai_debrief          TEXT,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, race_date)
+);
+
+ALTER TABLE public.race_results ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "race_results: owner" ON public.race_results FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- ============================================================
+-- MORNING LOGS
+-- ============================================================
+
+CREATE TABLE public.morning_logs (
+  id             UUID     PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id        UUID     NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  log_date       DATE     NOT NULL DEFAULT current_date,
+  resting_hr_bpm SMALLINT,
+  sleep_hours    NUMERIC(3,1),
+  sleep_quality  SMALLINT CHECK (sleep_quality BETWEEN 1 AND 5),
+  energy_level   SMALLINT CHECK (energy_level BETWEEN 1 AND 5),
+  mood           SMALLINT CHECK (mood BETWEEN 1 AND 5),
+  body_readiness SMALLINT CHECK (body_readiness BETWEEN 1 AND 5),
+  woke_easily    BOOLEAN,
+  had_dreams     BOOLEAN,
+  dream_quality  TEXT     CHECK (dream_quality IN ('good','neutral','bad','nightmare')),
+  notes          TEXT,
+  ai_briefing    TEXT,
+  -- Legacy fields from master_schema (kept for compat)
+  hrv            INT,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (user_id, log_date)
+);
+
+ALTER TABLE public.morning_logs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "morning_logs: owner" ON public.morning_logs FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER morning_logs_updated_at
+  BEFORE UPDATE ON public.morning_logs
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- ============================================================
+-- NUTRITION & SUPPLEMENTS
+-- ============================================================
+
+CREATE TABLE public.meals (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  day_type    TEXT        NOT NULL CHECK (day_type IN ('training','rest')),
+  meal_name   TEXT        NOT NULL,
+  label       TEXT        NOT NULL,
+  icon        TEXT        NOT NULL DEFAULT '🍽️',
+  description TEXT,
+  calories    INT,
+  protein     DECIMAL(5,1),
+  carbs       DECIMAL(5,1),
+  fats        DECIMAL(5,1),
+  order_index INT         NOT NULL DEFAULT 0,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.meals ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "meals: owner" ON public.meals FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX meals_user_day_type ON public.meals (user_id, day_type, order_index);
+
+CREATE TRIGGER meals_updated_at
+  BEFORE UPDATE ON public.meals
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TABLE public.meal_changes (
+  id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  meal_id        UUID        NOT NULL REFERENCES public.meals(id) ON DELETE CASCADE,
+  user_id        UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  changed_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  changed_by     TEXT        NOT NULL DEFAULT 'user',
+  previous_value JSONB,
+  new_value      JSONB,
+  reason         TEXT
+);
+
+ALTER TABLE public.meal_changes ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "meal_changes: owner" ON public.meal_changes FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TABLE public.supplements (
+  id                      UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                 UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name                    TEXT        NOT NULL,
+  brand                   TEXT,
+  dose_amount             DECIMAL(8,2),
+  dose_unit               TEXT,
+  dose_count              DECIMAL(4,1) DEFAULT 1,
+  frequency               TEXT        NOT NULL DEFAULT 'daily',
+  frequency_days          JSONB,
+  frequency_times_per_week INT,
+  timing                  TEXT,
+  timing_notes            TEXT,
+  take_with_food          BOOLEAN     DEFAULT false,
+  has_duration            BOOLEAN     DEFAULT false,
+  start_date              DATE,
+  end_date                DATE,
+  duration_days           INT,
+  duration_notes          TEXT,
+  is_active               BOOLEAN     DEFAULT true,
+  is_paused               BOOLEAN     DEFAULT false,
+  pause_reason            TEXT,
+  paused_at               DATE,
+  resume_at               DATE,
+  prescribed_by           TEXT,
+  prescribed_for          TEXT,
+  notes                   TEXT,
+  blood_donation_override BOOLEAN     DEFAULT false,
+  created_at              TIMESTAMPTZ DEFAULT now(),
+  updated_at              TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE public.supplements ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "supplements: owner" ON public.supplements FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER supplements_updated_at
+  BEFORE UPDATE ON public.supplements
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TABLE public.supplement_log_entries (
+  id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id        UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  supplement_id  UUID        NOT NULL REFERENCES public.supplements(id) ON DELETE CASCADE,
+  log_date       DATE        NOT NULL,
+  taken          BOOLEAN     DEFAULT false,
+  taken_at       TIMESTAMPTZ,
+  skipped_reason TEXT,
+  notes          TEXT,
+  created_at     TIMESTAMPTZ DEFAULT now(),
+  UNIQUE (user_id, supplement_id, log_date)
+);
+
+ALTER TABLE public.supplement_log_entries ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "supplement_log_entries: owner" ON public.supplement_log_entries FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TABLE public.supplement_changes (
+  id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  supplement_id  UUID        NOT NULL REFERENCES public.supplements(id) ON DELETE CASCADE,
+  user_id        UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  changed_at     TIMESTAMPTZ DEFAULT now(),
+  change_type    TEXT,
+  previous_value JSONB,
+  new_value      JSONB,
+  reason         TEXT,
+  changed_by     TEXT        DEFAULT 'user'
+);
+
+ALTER TABLE public.supplement_changes ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "supplement_changes: owner" ON public.supplement_changes FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- ============================================================
+-- PLAN CONFIGS + AUDIT
+-- ============================================================
+
+CREATE TABLE public.plan_configs (
+  id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id          UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  module           TEXT        NOT NULL,
+  config_key       TEXT        NOT NULL,
+  config_label     TEXT        NOT NULL,
+  config_value     TEXT        NOT NULL,
+  config_type      TEXT        NOT NULL,
+  config_unit      TEXT,
+  description      TEXT,
+  editable_by_user BOOLEAN     DEFAULT true,
+  editable_by_ai   BOOLEAN     DEFAULT true,
+  last_changed_at  TIMESTAMPTZ,
+  last_changed_by  TEXT,
+  change_reason    TEXT,
+  created_at       TIMESTAMPTZ DEFAULT now(),
+  UNIQUE (user_id, module, config_key)
+);
+
+ALTER TABLE public.plan_configs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "plan_configs: owner" ON public.plan_configs FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TABLE public.plan_audit_log (
+  id                    UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id               UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  changed_at            TIMESTAMPTZ DEFAULT now(),
+  module                TEXT        NOT NULL,
+  entity_type           TEXT        NOT NULL,
+  entity_description    TEXT,
+  action                TEXT        NOT NULL,
+  field_changed         TEXT,
+  previous_value        TEXT,
+  new_value             TEXT,
+  reason                TEXT,
+  changed_by            TEXT        NOT NULL,
+  coach_conversation_id TEXT
+);
+
+ALTER TABLE public.plan_audit_log ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "plan_audit_log: owner" ON public.plan_audit_log FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- ============================================================
+-- ADAPTATION ENGINE
+-- ============================================================
+
+CREATE TABLE public.adaptation_events (
+  id                    UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id               UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  reported_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  event_date            DATE        NOT NULL DEFAULT CURRENT_DATE,
+  trigger_type          TEXT        NOT NULL
+    CHECK (trigger_type IN ('illness','injury','fatigue','poor_sleep')),
+  severity              INT         NOT NULL CHECK (severity BETWEEN 1 AND 5),
+  symptoms              TEXT,
+  affected_body_part    TEXT,
+  sleep_hours           NUMERIC(3,1),
+  resting_hr            INT,
+  estimated_days        INT,
+  status                TEXT        NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending','adjustments_proposed','approved','rejected','recovered')),
+  ai_triage             TEXT,
+  ai_generated_at       TIMESTAMPTZ,
+  recovery_confirmed_at TIMESTAMPTZ,
+  notes                 TEXT,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.adaptation_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "adaptation_events: owner" ON public.adaptation_events FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX adaptation_events_user     ON public.adaptation_events (user_id, reported_at DESC);
+CREATE INDEX adaptation_events_status   ON public.adaptation_events (user_id, status)
+  WHERE status NOT IN ('rejected','recovered');
+
+CREATE TABLE public.adaptation_adjustments (
+  id                 UUID    PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id           UUID    NOT NULL REFERENCES public.adaptation_events(id) ON DELETE CASCADE,
+  user_id            UUID    NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  module             TEXT    NOT NULL CHECK (module IN ('marathon','nutrition','trading')),
+  target_date        DATE    NOT NULL,
+  target_id          UUID,
+  target_description TEXT,
+  change_type        TEXT    NOT NULL,
+  original_value     JSONB,
+  adjusted_value     JSONB,
+  reasoning          TEXT,
+  approved           BOOLEAN,
+  applied_at         TIMESTAMPTZ,
+  user_override      TEXT,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.adaptation_adjustments ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "adaptation_adjustments: owner" ON public.adaptation_adjustments FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TABLE public.recovery_checkins (
+  id                UUID    PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id          UUID    NOT NULL REFERENCES public.adaptation_events(id) ON DELETE CASCADE,
+  user_id           UUID    NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  checkin_date      DATE    NOT NULL,
+  feeling_score     INT     NOT NULL CHECK (feeling_score BETWEEN 1 AND 10),
+  symptoms_present  BOOLEAN,
+  resting_hr        INT,
+  notes             TEXT,
+  ai_recommendation TEXT,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (event_id, checkin_date)
+);
+
+ALTER TABLE public.recovery_checkins ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "recovery_checkins: owner" ON public.recovery_checkins FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- AI-driven adapt events (separate from manual adaptation_events)
+CREATE TABLE public.adapt_events (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  event_type  TEXT        NOT NULL,
+  payload     JSONB       NOT NULL DEFAULT '{}',
+  status      TEXT        NOT NULL DEFAULT 'pending'
+              CHECK (status IN ('pending','proposed','approved','rejected')),
+  proposal    JSONB,
+  proposal_at TIMESTAMPTZ,
+  resolved_at TIMESTAMPTZ,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.adapt_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "adapt_events: owner" ON public.adapt_events FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX adapt_events_user_status ON public.adapt_events (user_id, status, created_at DESC);
+
+-- ============================================================
+-- BOOKSHELF + PROJECTS
+-- ============================================================
+
+CREATE TABLE public.books (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  title       TEXT        NOT NULL,
+  author      TEXT,
+  isbn        TEXT,
+  status      TEXT        NOT NULL DEFAULT 'want-to-read'
+              CHECK (status IN ('want-to-read','reading','done','abandoned')),
+  rating      INT         CHECK (rating >= 1 AND rating <= 5),
+  notes       TEXT,
+  started_at  DATE,
+  finished_at DATE,
+  cover_url   TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.books ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "books: owner" ON public.books FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER books_updated_at
+  BEFORE UPDATE ON public.books
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE INDEX books_user_status ON public.books (user_id, status);
+
+CREATE TABLE public.projects (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name        TEXT        NOT NULL,
+  description TEXT,
+  status      TEXT        NOT NULL DEFAULT 'active'
+              CHECK (status IN ('active','paused','done','abandoned')),
+  color       TEXT        NOT NULL DEFAULT '#6366f1',
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.projects ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "projects: owner" ON public.projects FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER projects_updated_at
+  BEFORE UPDATE ON public.projects
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TABLE public.project_tasks (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  project_id UUID        NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
+  title      TEXT        NOT NULL,
+  status     TEXT        NOT NULL DEFAULT 'todo'
+             CHECK (status IN ('todo','in_progress','done')),
+  notes      TEXT,
+  position   INT         NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.project_tasks ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "project_tasks: owner" ON public.project_tasks FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TRIGGER project_tasks_updated_at
+  BEFORE UPDATE ON public.project_tasks
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE INDEX project_tasks_project_position ON public.project_tasks (project_id, position);
+
+-- ============================================================
+-- PUSH NOTIFICATIONS
+-- ============================================================
+
+CREATE TABLE public.push_subscriptions (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  endpoint   TEXT        NOT NULL UNIQUE,
+  p256dh     TEXT        NOT NULL,
+  auth_key   TEXT        NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.push_subscriptions ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "push_subscriptions: owner" ON public.push_subscriptions FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+CREATE TABLE public.daily_digest_log (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  digest_date DATE        NOT NULL DEFAULT current_date,
+  sent_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  digest_text TEXT,
+  UNIQUE (user_id, digest_date)
+);
+
+ALTER TABLE public.daily_digest_log ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "daily_digest_log: owner" ON public.daily_digest_log FOR ALL
+  USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/daily-digest",
       "schedule": "30 2 * * *"
+    },
+    {
+      "path": "/api/cron/correlations",
+      "schedule": "0 2 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- **Correlation Engine** — nightly CRON (`/api/cron/correlations`, 02:00 UTC) computes Pearson correlations across each user's `daily_logs` JSONB metrics using `simple-statistics`. Strong findings (`|r| >= 0.7`, `n >= 5`) are persisted to `user_insights` with `metric_a`, `metric_b`, `coefficient`, and `actionable = true`. Sparse metrics align correctly via per-pair iteration so a metric logged 3x/week still correlates correctly against one logged daily.
- **Production Schema** — `20260311000000_production_schema.sql` adds `pgvector` embedding + `hrv_numeric` STORED generated column to `daily_logs`, `weekly_summaries` + `ai_preferences` (override tracking) to `user_profiles`, full correlation columns to `user_insights`, and `status` (`pending/completed/dismissed`) to `coach_tasks`. Every ALTER is wrapped in a defensive `DO $$` guard. `supabase/reset_schema.sql` is a clean single-file reset script for fresh provisioning.
- **Generative UI** — New `render_dashboard_widget` tool in the coach route fetches 14 days of live `daily_logs`, reshapes sparse JSONB into Recharts-ready arrays, and streams the result to the client. `src/components/ai/widgets/DynamicWidget.tsx` renders it inline in chat with a glowing skeleton while pending and a wired Pin button on completion. Coach system prompt now injects the 5 most recent `actionable = true` insights from the correlation engine.

## What changed

- `package.json` — added `simple-statistics`
- `vercel.json` — registered `/api/cron/correlations` at `0 2 * * *`
- `src/lib/math/correlation.ts` — replaced hand-rolled Pearson with `sampleCorrelation`; exports `calculateCorrelations()` and `buildInsightText()`
- `src/app/api/cron/correlations/route.ts` — rewrote to use new math utils, query `user_profiles` for active users, write full correlation schema columns
- `src/app/api/ai/coach/route.ts` — insight injection upgraded to 5 actionable insights + new `render_dashboard_widget` tool with live data fetch
- `src/components/ai/widgets/DynamicWidget.tsx` — new chat-native chart component with `explanation` prop and Pin button
- `src/components/ai/coach-chat.tsx` — added `render_dashboard_widget` interceptor: skeleton while pending, `DynamicWidget` on result
- `supabase/migrations/20260311000000_production_schema.sql` — production schema migration (defensive, idempotent)
- `supabase/reset_schema.sql` — full clean-slate schema script

## Test plan

- [ ] POST `Authorization: Bearer <CRON_SECRET>` to `/api/cron/correlations` — confirm `user_insights` rows written with `metric_a`, `metric_b`, `coefficient`
- [ ] Ask the coach "show me my HRV vs sleep chart" — confirm skeleton appears then resolves to a live line chart
- [ ] Click Pin — confirm POST to `/api/dashboard/pin-widget` and button transitions to Pinned
- [ ] Verify correlation insights appear in coach system prompt when `actionable = true` rows exist
- [ ] Run `supabase/reset_schema.sql` on a blank Supabase project — confirm all tables created without errors

> **Note:** The head branch (`feat/correlation-engine-generative-ui`) targets `base/before-session-work` to show the reviewable diff. The work is already live on the default branch.

Generated with [Claude Code](https://claude.com/claude-code)